### PR TITLE
fix(inference): ignore 4xx errors in monitoring for proxy requests

### DIFF
--- a/api/inference/internal/ctrl/proxy.go
+++ b/api/inference/internal/ctrl/proxy.go
@@ -74,6 +74,10 @@ func (c *Ctrl) ProcessHTTPRequest(ctx *gin.Context, svcType string, req *http.Re
 	c.addNoCacheHeaders(ctx)
 
 	if resp.StatusCode != http.StatusOK {
+		// Ignore 4xx errors in monitoring as they are client errors
+		if resp.StatusCode >= 400 && resp.StatusCode < 500 {
+			ctx.Set("ignoreError", true)
+		}
 		ctx.Writer.WriteHeader(resp.StatusCode)
 		c.handleServiceError(ctx, resp.Body)
 		return err


### PR DESCRIPTION
When proxying requests, 4xx errors are client errors and should not trigger monitoring alerts. This change sets ignoreError flag for 4xx status codes to exclude them from error monitoring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)