### PR TITLE
feat(inference): implement robust contract error parsing with ABI support

### DIFF
--- a/api/inference/integration/all-in-one/docker-compose.yml
+++ b/api/inference/integration/all-in-one/docker-compose.yml
@@ -49,7 +49,7 @@ services:
 
   # Main broker starts after nginx is ready
   0g-serving-provider-broker:
-    image: ghcr.io/0gfoundation/0g-serving-broker:dev1
+    image: ghcr.io/0gfoundation/0g-serving-broker@sha256:25ffd3c777773cc0688e23c44eb5ae4df8b0e0bf2c759ece1f95f09b62d580cd
     environment:
       - PORT=3080
       - CONFIG_FILE=/etc/config.yaml
@@ -81,7 +81,7 @@ services:
 
   # Event service starts after broker is ready
   0g-serving-provider-event:
-    image: ghcr.io/0gfoundation/0g-serving-broker:dev1
+    image: ghcr.io/0gfoundation/0g-serving-broker@sha256:25ffd3c777773cc0688e23c44eb5ae4df8b0e0bf2c759ece1f95f09b62d580cd
     environment:
       - CONFIG_FILE=/etc/config.yaml
       - NETWORK=hardhat
@@ -105,7 +105,7 @@ services:
 
   # Controller service for managing broker and event containers
   0g-controller:
-    image: ghcr.io/0gfoundation/0g-serving-broker:dev1
+    image: ghcr.io/0gfoundation/0g-serving-broker@sha256:25ffd3c777773cc0688e23c44eb5ae4df8b0e0bf2c759ece1f95f09b62d580cd
     ports:
       - "3090:3090"
     environment:

--- a/api/inference/internal/contract/errors.go
+++ b/api/inference/internal/contract/errors.go
@@ -1,0 +1,332 @@
+package providercontract
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"math/big"
+	"strings"
+
+	"github.com/0glabs/0g-serving-broker/inference/contract"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+// Common contract error types for better error handling
+var (
+	// InferenceAccount.sol errors
+	ErrAccountNotExists    = errors.New("account not exists")
+	ErrAccountExists       = errors.New("account already exists")
+	ErrInsufficientBalance = errors.New("insufficient balance")
+	ErrRefundInvalid       = errors.New("refund invalid")
+	ErrRefundProcessed     = errors.New("refund processed")
+	ErrRefundLocked        = errors.New("refund locked")
+	ErrTooManyRefunds      = errors.New("too many refunds")
+
+	// InferenceService.sol errors
+	ErrServiceNotExist       = errors.New("service not exist")
+	ErrAdditionalInfoTooLong = errors.New("additional info too long")
+
+	// InferenceServing.sol errors
+	ErrInvalidTEESignature = errors.New("invalid TEE signature")
+
+	// LedgerManager.sol errors
+	ErrLedgerNotExists        = errors.New("ledger not exists")
+	ErrLedgerExists           = errors.New("ledger already exists")
+	ErrTooManyProviders       = errors.New("too many providers")
+	ErrInvalidServiceType     = errors.New("invalid service type")
+	ErrServiceNotRegistered   = errors.New("service not registered")
+	ErrServiceNameExists      = errors.New("service name already exists")
+	ErrInvalidServiceAddress  = errors.New("invalid service address")
+)
+
+// contractABI is the parsed ABI of the InferenceServing contract
+var contractABI *abi.ABI
+
+func init() {
+	// Parse the ABI once at initialization
+	parsed, err := abi.JSON(strings.NewReader(contract.InferenceServingABI))
+	if err != nil {
+		panic(fmt.Sprintf("failed to parse contract ABI: %v", err))
+	}
+	contractABI = &parsed
+}
+
+// WrapContractError extracts and wraps contract errors from RPC responses
+// It uses errors.As with rpc.DataError and abi.ABI.ErrorByID for robust error parsing
+func WrapContractError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	// Try to cast to rpc.DataError interface to get the error data
+	var dataErr rpc.DataError
+	if errors.As(err, &dataErr) {
+		// Get the error data (hex string like "0x08ca03ac...")
+		errorData := dataErr.ErrorData()
+		if errorData != nil {
+			// Try to convert to string
+			if dataStr, ok := errorData.(string); ok && dataStr != "" {
+				// Decode hex data
+				dataStr = strings.TrimPrefix(dataStr, "0x")
+				data, decodeErr := hex.DecodeString(dataStr)
+				if decodeErr == nil && len(data) >= 4 {
+					// Extract error selector (first 4 bytes)
+					selector := [4]byte(data[:4])
+
+					// Use ABI to find the error definition
+					abiErr, abiErrLookup := contractABI.ErrorByID(selector)
+					if abiErrLookup == nil && abiErr != nil {
+						// Unpack the error arguments
+						unpacked, unpackErr := abiErr.Unpack(data)
+						if unpackErr == nil {
+							// Convert unpacked interface to []interface{}
+							if unpackedSlice, ok := unpacked.([]interface{}); ok {
+								return formatContractError(abiErr.Name, unpackedSlice)
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Fallback: check error message for keywords
+	errMsg := strings.ToLower(err.Error())
+	if strings.Contains(errMsg, "accountnotexists") ||
+		(strings.Contains(errMsg, "account") && strings.Contains(errMsg, "not") && strings.Contains(errMsg, "exist")) {
+		return errors.Join(ErrAccountNotExists, err)
+	}
+
+	if strings.Contains(errMsg, "servicenotexist") ||
+		(strings.Contains(errMsg, "service") && strings.Contains(errMsg, "not") && strings.Contains(errMsg, "exist")) {
+		return errors.Join(ErrServiceNotExist, err)
+	}
+
+	// Return original error if no match
+	return err
+}
+
+// formatContractError formats the unpacked error arguments into a readable error message
+func formatContractError(errName string, args []interface{}) error {
+	switch errName {
+	// InferenceAccount.sol errors
+	case "AccountNotExists":
+		if len(args) >= 2 {
+			user, _ := args[0].(common.Address)
+			provider, _ := args[1].(common.Address)
+			return fmt.Errorf("%w: user=%s, provider=%s", ErrAccountNotExists, user.Hex(), provider.Hex())
+		}
+		return ErrAccountNotExists
+
+	case "AccountExists":
+		if len(args) >= 2 {
+			user, _ := args[0].(common.Address)
+			provider, _ := args[1].(common.Address)
+			return fmt.Errorf("%w: user=%s, provider=%s", ErrAccountExists, user.Hex(), provider.Hex())
+		}
+		return ErrAccountExists
+
+	case "InsufficientBalance":
+		if len(args) >= 2 {
+			user, _ := args[0].(common.Address)
+			provider, _ := args[1].(common.Address)
+			return fmt.Errorf("%w: user=%s, provider=%s", ErrInsufficientBalance, user.Hex(), provider.Hex())
+		}
+		return ErrInsufficientBalance
+
+	case "RefundInvalid":
+		if len(args) >= 3 {
+			user, _ := args[0].(common.Address)
+			provider, _ := args[1].(common.Address)
+			index, _ := args[2].(*big.Int)
+			return fmt.Errorf("%w: user=%s, provider=%s, index=%s", ErrRefundInvalid, user.Hex(), provider.Hex(), index.String())
+		}
+		return ErrRefundInvalid
+
+	case "RefundProcessed":
+		if len(args) >= 3 {
+			user, _ := args[0].(common.Address)
+			provider, _ := args[1].(common.Address)
+			index, _ := args[2].(*big.Int)
+			return fmt.Errorf("%w: user=%s, provider=%s, index=%s", ErrRefundProcessed, user.Hex(), provider.Hex(), index.String())
+		}
+		return ErrRefundProcessed
+
+	case "RefundLocked":
+		if len(args) >= 3 {
+			user, _ := args[0].(common.Address)
+			provider, _ := args[1].(common.Address)
+			index, _ := args[2].(*big.Int)
+			return fmt.Errorf("%w: user=%s, provider=%s, index=%s", ErrRefundLocked, user.Hex(), provider.Hex(), index.String())
+		}
+		return ErrRefundLocked
+
+	case "TooManyRefunds":
+		if len(args) >= 2 {
+			user, _ := args[0].(common.Address)
+			provider, _ := args[1].(common.Address)
+			return fmt.Errorf("%w: user=%s, provider=%s", ErrTooManyRefunds, user.Hex(), provider.Hex())
+		}
+		return ErrTooManyRefunds
+
+	// InferenceService.sol errors
+	case "ServiceNotExist":
+		if len(args) >= 1 {
+			provider, _ := args[0].(common.Address)
+			return fmt.Errorf("%w: provider=%s", ErrServiceNotExist, provider.Hex())
+		}
+		return ErrServiceNotExist
+
+	case "AdditionalInfoTooLong":
+		return ErrAdditionalInfoTooLong
+
+	// InferenceServing.sol errors
+	case "InvalidTEESignature":
+		if len(args) >= 1 {
+			reason, _ := args[0].(string)
+			return fmt.Errorf("%w: %s", ErrInvalidTEESignature, reason)
+		}
+		return ErrInvalidTEESignature
+
+	// LedgerManager.sol errors
+	case "LedgerNotExists":
+		if len(args) >= 1 {
+			user, _ := args[0].(common.Address)
+			return fmt.Errorf("%w: user=%s", ErrLedgerNotExists, user.Hex())
+		}
+		return ErrLedgerNotExists
+
+	case "LedgerExists":
+		if len(args) >= 1 {
+			user, _ := args[0].(common.Address)
+			return fmt.Errorf("%w: user=%s", ErrLedgerExists, user.Hex())
+		}
+		return ErrLedgerExists
+
+	case "TooManyProviders":
+		if len(args) >= 2 {
+			requested, _ := args[0].(*big.Int)
+			maximum, _ := args[1].(*big.Int)
+			return fmt.Errorf("%w: requested=%s, maximum=%s", ErrTooManyProviders, requested.String(), maximum.String())
+		}
+		return ErrTooManyProviders
+
+	case "InvalidServiceType":
+		if len(args) >= 1 {
+			serviceType, _ := args[0].(string)
+			return fmt.Errorf("%w: %s", ErrInvalidServiceType, serviceType)
+		}
+		return ErrInvalidServiceType
+
+	case "ServiceNotRegistered":
+		if len(args) >= 1 {
+			serviceAddress, _ := args[0].(common.Address)
+			return fmt.Errorf("%w: address=%s", ErrServiceNotRegistered, serviceAddress.Hex())
+		}
+		return ErrServiceNotRegistered
+
+	case "ServiceNameExists":
+		if len(args) >= 1 {
+			serviceName, _ := args[0].(string)
+			return fmt.Errorf("%w: %s", ErrServiceNameExists, serviceName)
+		}
+		return ErrServiceNameExists
+
+	case "InvalidServiceAddress":
+		if len(args) >= 1 {
+			serviceAddress, _ := args[0].(common.Address)
+			return fmt.Errorf("%w: address=%s", ErrInvalidServiceAddress, serviceAddress.Hex())
+		}
+		return ErrInvalidServiceAddress
+
+	default:
+		return fmt.Errorf("contract error: %s", errName)
+	}
+}
+
+// IsAccountNotExists checks if the error is AccountNotExists
+func IsAccountNotExists(err error) bool {
+	return errors.Is(err, ErrAccountNotExists)
+}
+
+// IsAccountExists checks if the error is AccountExists
+func IsAccountExists(err error) bool {
+	return errors.Is(err, ErrAccountExists)
+}
+
+// IsInsufficientBalance checks if the error is InsufficientBalance
+func IsInsufficientBalance(err error) bool {
+	return errors.Is(err, ErrInsufficientBalance)
+}
+
+// IsRefundInvalid checks if the error is RefundInvalid
+func IsRefundInvalid(err error) bool {
+	return errors.Is(err, ErrRefundInvalid)
+}
+
+// IsRefundProcessed checks if the error is RefundProcessed
+func IsRefundProcessed(err error) bool {
+	return errors.Is(err, ErrRefundProcessed)
+}
+
+// IsRefundLocked checks if the error is RefundLocked
+func IsRefundLocked(err error) bool {
+	return errors.Is(err, ErrRefundLocked)
+}
+
+// IsTooManyRefunds checks if the error is TooManyRefunds
+func IsTooManyRefunds(err error) bool {
+	return errors.Is(err, ErrTooManyRefunds)
+}
+
+// IsServiceNotExist checks if the error is ServiceNotExist
+func IsServiceNotExist(err error) bool {
+	return errors.Is(err, ErrServiceNotExist)
+}
+
+// IsAdditionalInfoTooLong checks if the error is AdditionalInfoTooLong
+func IsAdditionalInfoTooLong(err error) bool {
+	return errors.Is(err, ErrAdditionalInfoTooLong)
+}
+
+// IsInvalidTEESignature checks if the error is InvalidTEESignature
+func IsInvalidTEESignature(err error) bool {
+	return errors.Is(err, ErrInvalidTEESignature)
+}
+
+// IsLedgerNotExists checks if the error is LedgerNotExists
+func IsLedgerNotExists(err error) bool {
+	return errors.Is(err, ErrLedgerNotExists)
+}
+
+// IsLedgerExists checks if the error is LedgerExists
+func IsLedgerExists(err error) bool {
+	return errors.Is(err, ErrLedgerExists)
+}
+
+// IsTooManyProviders checks if the error is TooManyProviders
+func IsTooManyProviders(err error) bool {
+	return errors.Is(err, ErrTooManyProviders)
+}
+
+// IsInvalidServiceType checks if the error is InvalidServiceType
+func IsInvalidServiceType(err error) bool {
+	return errors.Is(err, ErrInvalidServiceType)
+}
+
+// IsServiceNotRegistered checks if the error is ServiceNotRegistered
+func IsServiceNotRegistered(err error) bool {
+	return errors.Is(err, ErrServiceNotRegistered)
+}
+
+// IsServiceNameExists checks if the error is ServiceNameExists
+func IsServiceNameExists(err error) bool {
+	return errors.Is(err, ErrServiceNameExists)
+}
+
+// IsInvalidServiceAddress checks if the error is InvalidServiceAddress
+func IsInvalidServiceAddress(err error) bool {
+	return errors.Is(err, ErrInvalidServiceAddress)
+}

--- a/api/inference/internal/contract/request.go
+++ b/api/inference/internal/contract/request.go
@@ -22,14 +22,18 @@ func (c *ProviderContract) SettleFeesWithTEE(ctx context.Context, settlements []
 	// Execute the actual transaction
 	tx, err := c.Contract.Transact(ctx, nil, "settleFeesWithTEE", settlements)
 	if err != nil {
-		return nil, errors.Wrap(err, "call settleFeesWithTEE")
+		wrappedErr := WrapContractError(err)
+		c.logger.Errorf("[SettleFeesWithTEE] Contract error calling settleFeesWithTEE: %v", wrappedErr)
+		return nil, errors.Wrap(wrappedErr, "call settleFeesWithTEE")
 	}
-	
+
 	// Wait for transaction receipt
 	c.logger.Infof("Settlement transaction submitted with hash: %s", tx.Hash().Hex())
 	receipt, err := c.Contract.WaitForReceipt(ctx, tx.Hash())
 	if err != nil {
-		return nil, errors.Wrap(err, "wait for receipt")
+		wrappedErr := WrapContractError(err)
+		c.logger.Errorf("[SettleFeesWithTEE] Contract error waiting for receipt: %v", wrappedErr)
+		return nil, errors.Wrap(wrappedErr, "wait for receipt")
 	}
 	
 	// Parse TEESettlementResult events from logs to determine failed users

--- a/api/inference/internal/contract/service.go
+++ b/api/inference/internal/contract/service.go
@@ -102,8 +102,9 @@ func (c *ProviderContract) addOrUpdateService(ctx context.Context, service confi
 	)
 
 	if err != nil {
-		c.logger.Errorf("[addOrUpdateService] Failed to send transaction - error=%v", err)
-		return err
+		wrappedErr := WrapContractError(err)
+		c.logger.Errorf("[addOrUpdateService] Failed to send transaction - error=%v", wrappedErr)
+		return wrappedErr
 	}
 
 	c.logger.Infof("[addOrUpdateService] Transaction sent - txHash=%s", tx.Hash().String())
@@ -111,8 +112,9 @@ func (c *ProviderContract) addOrUpdateService(ctx context.Context, service confi
 
 	receipt, err := c.Contract.WaitForReceipt(ctx, tx.Hash())
 	if err != nil {
-		c.logger.Errorf("[addOrUpdateService] Failed to wait for transaction receipt - txHash=%s, error=%v", tx.Hash().String(), err)
-		return errors.Wrapf(err, "wait for receipt of tx %s", tx.Hash().String())
+		wrappedErr := WrapContractError(err)
+		c.logger.Errorf("[addOrUpdateService] Failed to wait for transaction receipt - txHash=%s, error=%v", tx.Hash().String(), wrappedErr)
+		return errors.Wrapf(wrappedErr, "wait for receipt of tx %s", tx.Hash().String())
 	}
 
 	c.logger.Infof("[addOrUpdateService] Transaction successful - txHash=%s, blockNumber=%d, gasUsed=%d",
@@ -127,10 +129,17 @@ func (c *ProviderContract) DeleteService(ctx context.Context) error {
 		"removeService",
 	)
 	if err != nil {
-		return err
+		wrappedErr := WrapContractError(err)
+		c.logger.Errorf("[DeleteService] Failed to send transaction - error=%v", wrappedErr)
+		return wrappedErr
 	}
 	_, err = c.Contract.WaitForReceipt(ctx, tx.Hash())
-	return err
+	if err != nil {
+		wrappedErr := WrapContractError(err)
+		c.logger.Errorf("[DeleteService] Failed to wait for receipt - txHash=%s, error=%v", tx.Hash().String(), wrappedErr)
+		return wrappedErr
+	}
+	return nil
 }
 
 func (c *ProviderContract) GetService(ctx context.Context) (*contract.Service, error) {
@@ -142,8 +151,10 @@ func (c *ProviderContract) GetService(ctx context.Context) (*contract.Service, e
 
 	service, err := c.Contract.GetService(callOpts, common.HexToAddress(c.ProviderAddress))
 	if err != nil {
-		c.logger.Errorf("[GetService] Failed to get service - error=%v", err)
-		return nil, err
+		// Wrap error to extract details from rpc.jsonError Data field
+		wrappedErr := WrapContractError(err)
+		c.logger.Errorf("[GetService] Contract error - provider=%s: %v", c.ProviderAddress, wrappedErr)
+		return nil, wrappedErr
 	}
 
 	c.logger.Infof("[GetService] Retrieved service from contract - url=%s, model=%s, type=%s",

--- a/api/inference/internal/contract/user.go
+++ b/api/inference/internal/contract/user.go
@@ -13,7 +13,20 @@ func (c *ProviderContract) GetUserAccount(ctx context.Context, user common.Addre
 	callOpts := &bind.CallOpts{
 		Context: ctx,
 	}
-	return c.Contract.GetAccount(callOpts, user, common.HexToAddress(c.ProviderAddress))
+	account, err := c.Contract.GetAccount(callOpts, user, common.HexToAddress(c.ProviderAddress))
+
+	if err != nil {
+		// Wrap error to extract details from rpc.jsonError Data field
+		wrappedErr := WrapContractError(err)
+
+		// Log the parsed error
+		c.logger.Errorf("[GetUserAccount] Contract error - user=%s, provider=%s: %v",
+			user.Hex(), c.ProviderAddress, wrappedErr)
+
+		return account, wrappedErr
+	}
+
+	return account, nil
 }
 
 func (c *ProviderContract) ListUserAccount(ctx context.Context) ([]contract.Account, error) {
@@ -31,11 +44,14 @@ func (c *ProviderContract) ListUserAccount(ctx context.Context) ([]contract.Acco
 	for {
 		result, err := c.Contract.GetAccountsByProvider(callOpts, common.HexToAddress(c.ProviderAddress), offset, limit)
 		if err != nil {
-			return nil, err
+			wrappedErr := WrapContractError(err)
+			c.logger.Errorf("[ListUserAccount] Contract error - provider=%s, offset=%s, limit=%s: %v",
+				c.ProviderAddress, offset.String(), limit.String(), wrappedErr)
+			return nil, wrappedErr
 		}
-		
+
 		allAccounts = append(allAccounts, result.Accounts...)
-		
+
 		if offset.Add(offset, limit).Cmp(result.Total) >= 0 {
 			break
 		}


### PR DESCRIPTION

- Add comprehensive error parsing using go-ethereum ABI package
- Implement WrapContractError using errors.As with rpc.DataError interface
- Support all contract errors from InferenceAccount, InferenceService, InferenceServing, and LedgerManager
- Apply error wrapping to all contract interaction points (GetUserAccount, ListUserAccount, GetService, addOrUpdateService, DeleteService, SettleFeesWithTEE)
- Replace reflection-based parsing with idiomatic ABI.ErrorByID and Unpack methods
- Add helper functions for error type checking (IsAccountNotExists, IsServiceNotExist, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)