### PR TITLE
fix(fine-tuning): enhance upload/download security and prevent replay attacks

### DIFF
--- a/api/fine-tuning/config/config.go
+++ b/api/fine-tuning/config/config.go
@@ -236,8 +236,8 @@ func GetConfig() *Config {
 			DeliveredTaskAckTimeoutSecs: 60 * 60 * 6,
 			DataRetentionDays:           3,
 			MaxTaskQueueSize:            5,
-			RateLimitRPS:                10,  // Default: 10 requests per second
-			RateLimitBurst:              20,  // Default: burst of 20 requests
+			RateLimitRPS:                0.1, // Default: 0.1 requests per second (1 request per 10 seconds) - suitable for file upload/download operations
+			RateLimitBurst:              2,   // Default: burst of 2 requests - allows retry on failure
 		}
 
 		if err := loadConfig(instance); err != nil {

--- a/api/fine-tuning/internal/ctrl/task.go
+++ b/api/fine-tuning/internal/ctrl/task.go
@@ -2,12 +2,15 @@ package ctrl
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"mime/multipart"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
+	"time"
 
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
@@ -136,9 +139,15 @@ func (c *Ctrl) ListTask(ctx context.Context, userAddress string, latest, desc bo
 	return taskRes, nil
 }
 
-func (c *Ctrl) GetProgress(id *uuid.UUID) (string, error) {
-	if _, err := c.db.GetTask(id); err != nil {
+func (c *Ctrl) GetProgress(id *uuid.UUID, userAddress string) (string, error) {
+	task, err := c.db.GetTask(id)
+	if err != nil {
 		return "", err
+	}
+
+	// Verify user owns this task
+	if task.UserAddress != userAddress {
+		return "", errors.New("unauthorized: task does not belong to this user")
 	}
 
 	return filepath.Join(utils.GetDataDir(), id.String(), utils.TaskLogFileName), nil
@@ -210,20 +219,96 @@ func (c *Ctrl) GetPendingTrainingTaskCount(ctx context.Context) (int64, error) {
 }
 
 // VerifyDownloadSignature verifies that the signature is valid for the given task ID and user address
-// Uses the same message format as validateSignature: TextHash(keccak256(binaryTaskID))
-func (c *Ctrl) VerifyDownloadSignature(id *uuid.UUID, userAddress string, signature string) error {
+// Uses the message format: TextHash(keccak256(taskID + timestamp))
+// Validates that the timestamp is within an acceptable time window (5 minutes)
+func (c *Ctrl) VerifyDownloadSignature(id *uuid.UUID, userAddress string, signature string, timestamp int64) error {
 	if id == nil {
 		return errors.New("task ID cannot be nil")
 	}
 
-	// Get binary representation of UUID (same as task.ID.MarshalBinary())
+	// Validate timestamp is within acceptable window (5 minutes = 300 seconds)
+	currentTime := time.Now().Unix()
+	timeDiff := currentTime - timestamp
+
+	if timeDiff < -60 {
+		// Timestamp is more than 1 minute in the future (allow some clock skew)
+		return fmt.Errorf("timestamp is too far in the future: %d seconds ahead", -timeDiff)
+	}
+
+	if timeDiff > 300 {
+		// Timestamp is more than 5 minutes old
+		return fmt.Errorf("timestamp is too old: %d seconds ago (max 300 seconds)", timeDiff)
+	}
+
+	// Get binary representation of UUID
 	idBytes, err := id.MarshalBinary()
 	if err != nil {
 		return errors.Wrap(err, "marshal task ID")
 	}
 
-	// Create message hash using same format as validateSignature
-	hash := accounts.TextHash(crypto.Keccak256(idBytes)[:])
+	// Create message: keccak256(taskIDHex + timestamp)
+	// This ensures each signature is unique and time-bound
+	idHex := common.Bytes2Hex(idBytes)
+	message := fmt.Sprintf("%s%d", idHex, timestamp)
+	hash := accounts.TextHash(crypto.Keccak256([]byte(message)))
+
+	// Decode signature
+	sigBytes, err := hexutil.Decode(signature)
+	if err != nil {
+		return errors.Wrap(err, "decode signature")
+	}
+
+	// Validate signature length and recovery ID
+	if len(sigBytes) != 65 {
+		return fmt.Errorf("invalid signature length %d, expected 65", len(sigBytes))
+	}
+
+	if sigBytes[64] != 27 && sigBytes[64] != 28 {
+		return fmt.Errorf("invalid recovery ID (V): got %d", sigBytes[64])
+	}
+
+	sigBytes[64] -= 27
+	pubKey, err := crypto.SigToPub(hash, sigBytes)
+	if err != nil {
+		return errors.Wrap(err, "recover public key from signature")
+	}
+
+	recoveredAddr := crypto.PubkeyToAddress(*pubKey)
+	expectedAddr := common.HexToAddress(userAddress)
+
+	if recoveredAddr != expectedAddr {
+		return fmt.Errorf("signature verification failed: expected %s, got %s", expectedAddr.Hex(), recoveredAddr.Hex())
+	}
+
+	return nil
+}
+
+// VerifyUploadSignature verifies that the signature is valid for dataset upload
+// Uses the message format: TextHash(keccak256(userAddress + timestamp))
+// Validates that the timestamp is within an acceptable time window (5 minutes)
+func (c *Ctrl) VerifyUploadSignature(userAddress string, signature string, timestamp int64) error {
+	if !common.IsHexAddress(userAddress) {
+		return errors.New("invalid user address format")
+	}
+
+	// Validate timestamp is within acceptable window (5 minutes = 300 seconds)
+	currentTime := time.Now().Unix()
+	timeDiff := currentTime - timestamp
+
+	if timeDiff < -60 {
+		// Timestamp is more than 1 minute in the future (allow some clock skew)
+		return fmt.Errorf("timestamp is too far in the future: %d seconds ahead", -timeDiff)
+	}
+
+	if timeDiff > 300 {
+		// Timestamp is more than 5 minutes old
+		return fmt.Errorf("timestamp is too old: %d seconds ago (max 300 seconds)", timeDiff)
+	}
+
+	// Create message: keccak256(userAddress + timestamp)
+	// This ensures each signature is unique and time-bound
+	message := fmt.Sprintf("%s%d", userAddress, timestamp)
+	hash := accounts.TextHash(crypto.Keccak256([]byte(message)))
 
 	// Decode signature
 	sigBytes, err := hexutil.Decode(signature)
@@ -302,36 +387,100 @@ func (c *Ctrl) GetLoRAModel(id *uuid.UUID, userAddress string) (string, error) {
 // 2. Content hash ensures deduplication - same dataset uploaded twice won't create duplicate files
 // 3. Content hash guarantees data integrity - any modification creates a different hash
 func (c *Ctrl) SaveDataset(userAddress string, file *multipart.FileHeader) (string, error) {
-	// Create dataset directory for user
-	datasetDir := filepath.Join(utils.GetDataDir(), "datasets", userAddress)
+	// 1. Validate user address format
+	if !common.IsHexAddress(userAddress) {
+		return "", errors.New("invalid user address format")
+	}
+
+	// 2. Validate filename (check for path traversal)
+	filename := filepath.Base(file.Filename) // Get base filename only
+	if filename != file.Filename || filename == "." || filename == ".." {
+		return "", errors.New("invalid filename")
+	}
+
+	// 3. Clean and validate user address path component
+	userAddress = filepath.Clean(userAddress)
+	if filepath.IsAbs(userAddress) || filepath.Dir(userAddress) != "." {
+		return "", errors.New("invalid user address: path traversal detected")
+	}
+
+	// 4. Create dataset directory and validate path
+	baseDir := filepath.Join(utils.GetDataDir(), "datasets")
+	datasetDir := filepath.Join(baseDir, userAddress)
+
+	// Ensure datasetDir is within baseDir (prevent path traversal)
+	absDatasetDir, err := filepath.Abs(datasetDir)
+	if err != nil {
+		return "", errors.Wrap(err, "resolve dataset directory")
+	}
+	absBaseDir, err := filepath.Abs(baseDir)
+	if err != nil {
+		return "", errors.Wrap(err, "resolve base directory")
+	}
+	// Use strings.HasPrefix with proper path separator check
+	if !strings.HasPrefix(absDatasetDir, absBaseDir+string(filepath.Separator)) && absDatasetDir != absBaseDir {
+		return "", errors.New("path traversal detected")
+	}
+
 	if err := os.MkdirAll(datasetDir, 0755); err != nil {
 		return "", errors.Wrap(err, "create dataset directory")
 	}
 
-	// Open uploaded file
+	// 5. Open uploaded file
 	src, err := file.Open()
 	if err != nil {
 		return "", errors.Wrap(err, "open uploaded file")
 	}
 	defer src.Close()
 
-	// Read file content to calculate hash
-	content, err := io.ReadAll(src)
+	// 6. Stream file to temp location while computing hash
+	tempID := uuid.New().String()
+	tempPath := filepath.Join(datasetDir, "temp_"+tempID)
+	tempFile, err := os.Create(tempPath)
 	if err != nil {
-		return "", errors.Wrap(err, "read file content")
+		return "", errors.Wrap(err, "create temp file")
+	}
+	defer func() {
+		tempFile.Close()
+		os.Remove(tempPath) // Clean up temp file on any error
+	}()
+
+	// 7. Compute hash while writing (streaming to avoid memory issues)
+	hasher := crypto.NewKeccakState()
+	multiWriter := io.MultiWriter(tempFile, hasher)
+
+	bytesWritten, err := io.Copy(multiWriter, src)
+	if err != nil {
+		return "", errors.Wrap(err, "process file content")
 	}
 
-	// Calculate hash of the dataset
-	datasetHash := crypto.Keccak256Hash(content)
-	hashStr := datasetHash.Hex()
+	// 8. Finalize hash
+	var hashBytes []byte
+	hashBytes = hasher.Sum(hashBytes)
+	hashStr := "0x" + common.Bytes2Hex(hashBytes)
 
-	// Save JSONL file with hash as filename
+	// 9. Read content for validation
+	tempFile.Close() // Close before reading
+	content, err := os.ReadFile(tempPath)
+	if err != nil {
+		return "", errors.Wrap(err, "read temp file for validation")
+	}
+
+	// 10. Validate JSONL format
+	if err := validateJSONLFormat(content); err != nil {
+		return "", errors.Wrap(err, "invalid JSONL format")
+	}
+
+	// 11. Move to final location with hash as filename
 	jsonlPath := filepath.Join(datasetDir, hashStr)
-	if err := os.WriteFile(jsonlPath, content, 0644); err != nil {
-		return "", errors.Wrap(err, "write dataset file")
+	if err := os.Rename(tempPath, jsonlPath); err != nil {
+		// If rename fails, try copy and delete
+		if err := os.WriteFile(jsonlPath, content, 0644); err != nil {
+			return "", errors.Wrap(err, "write dataset file")
+		}
 	}
 
-	c.logger.Infof("Dataset saved: %s (hash: %s, size: %d bytes)", jsonlPath, hashStr, len(content))
+	c.logger.Infof("Dataset saved: %s (hash: %s, size: %d bytes)", jsonlPath, hashStr, bytesWritten)
 
 	// Convert JSONL to HF format is required by the fine-tuning executor's token counter
 	if err := c.convertJSONLToHF(jsonlPath); err != nil {
@@ -438,6 +587,45 @@ print(f"Converted {len(data['instruction'])} examples to {output_dir}")
 	}
 
 	c.logger.Infof("Converted dataset to HF format: %s (output: %s)", hfPath, string(output))
+	return nil
+}
+
+// validateJSONLFormat validates that the content is valid JSONL format
+// Each line must be valid JSON (empty lines are allowed)
+func validateJSONLFormat(content []byte) error {
+	lines := string(content)
+	lineNum := 0
+	start := 0
+
+	for i := 0; i <= len(lines); i++ {
+		if i == len(lines) || lines[i] == '\n' {
+			lineNum++
+			line := lines[start:i]
+			start = i + 1
+
+			// Skip empty lines and whitespace-only lines
+			trimmed := ""
+			for _, ch := range line {
+				if ch != ' ' && ch != '\t' && ch != '\r' {
+					trimmed += string(ch)
+				}
+			}
+			if trimmed == "" {
+				continue
+			}
+
+			// Validate JSON
+			var obj map[string]interface{}
+			if err := json.Unmarshal([]byte(line), &obj); err != nil {
+				return fmt.Errorf("line %d is not valid JSON: %w", lineNum, err)
+			}
+		}
+	}
+
+	if lineNum == 0 {
+		return errors.New("dataset file is empty")
+	}
+
 	return nil
 }
 

--- a/api/fine-tuning/internal/handler/handler.go
+++ b/api/fine-tuning/internal/handler/handler.go
@@ -34,8 +34,8 @@ func (h *Handler) Register(r *gin.Engine) {
 	group.GET("/user/:userAddress/task/:taskID", h.GetTask)
 
 	group.GET("/user/:userAddress/task/:taskID/log", h.GetTaskProgress)
-	group.POST("/user/:userAddress/task/:taskID/lora", h.DownloadLoRA)
-	group.POST("/user/:userAddress/dataset", h.UploadDataset) // Upload dataset to TEE
+	group.POST("/user/:userAddress/task/:taskID/lora", middleware.RateLimitMiddleware(h.rateLimiter), h.DownloadLoRA) // Download LoRA with rate limiting
+	group.POST("/user/:userAddress/dataset", middleware.RateLimitMiddleware(h.rateLimiter), h.UploadDataset) // Upload dataset to TEE with rate limiting
 	group.GET("/task/pending", h.GetPendingTrainingTaskCount)
 
 	group.GET("/quote", middleware.RateLimitMiddleware(h.rateLimiter), h.GetQuote)

--- a/api/fine-tuning/internal/handler/task.go
+++ b/api/fine-tuning/internal/handler/task.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"strconv"
@@ -146,25 +147,42 @@ func (h *Handler) ListTask(ctx *gin.Context) {
 //	@Param		taskID		path	string	true	"task ID"
 //	@Success	200	{file}	file	"progress.log"
 func (h *Handler) GetTaskProgress(ctx *gin.Context) {
+	userAddress := ctx.Param("userAddress")
 	id, err := uuid.Parse(ctx.Param("taskID"))
 	if err != nil {
 		handleBrokerError(ctx, err, "parse task id")
 		return
 	}
-	filePath, err := h.ctrl.GetProgress(&id)
+
+	// Verify task ownership
+	filePath, err := h.ctrl.GetProgress(&id, userAddress)
 	if err != nil {
 		handleBrokerError(ctx, err, "get task")
 		return
 	}
 
-	data, err := os.ReadFile(filePath)
+	// Stream file instead of loading to memory
+	file, err := os.Open(filePath)
 	if err != nil {
-		h.logger.Errorf("read file %v, err: %v", filePath, err)
-		ctx.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("Failed to read log file: %s, please ensure the task is running", err.Error())})
+		h.logger.Errorf("open log file %v, err: %v", filePath, err)
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to read log file. Please ensure the task is running"})
 		return
 	}
+	defer file.Close()
 
-	ctx.Data(http.StatusOK, "text/plain", data)
+	// Get file size for Content-Length header
+	fileInfo, err := file.Stat()
+	if err == nil {
+		ctx.Header("Content-Length", fmt.Sprintf("%d", fileInfo.Size()))
+	}
+
+	ctx.Header("Content-Type", "text/plain; charset=utf-8")
+	ctx.Status(http.StatusOK)
+
+	// Stream the file
+	if _, err := io.Copy(ctx.Writer, file); err != nil {
+		h.logger.Errorf("stream log file %v, err: %v", filePath, err)
+	}
 }
 
 // GetPendingTrainingTaskCount godoc
@@ -188,13 +206,14 @@ func (h *Handler) GetPendingTrainingTaskCount(ctx *gin.Context) {
 // @Description Download the encrypted LoRA adapter from TEE. The file is AES encrypted.
 // @Description User must call contract acknowledge() to settle and get the decryption key.
 // @Description Flow: Download encrypted file -> acknowledge on contract -> get encryptedSecret -> decrypt with user private key -> get AES key -> decrypt LoRA
-// @Description Authentication: Requires signature of keccak256(taskID) signed by user's private key
+// @Description Authentication: Requires signature of keccak256(taskIDHex + timestamp) signed by user's private key
+// @Description The timestamp must be within 5 minutes to prevent replay attacks
 // @Tags Task
 // @Produce application/octet-stream
 // @Router /user/{userAddress}/task/{taskID}/lora [post]
 // @Param userAddress path string true "user address"
 // @Param taskID path string true "task ID"
-// @Param body body object true "Request body with signature" example({"signature": "0x..."})
+// @Param body body object true "Request body with signature and timestamp" example({"signature": "0x...", "timestamp": 1234567890})
 // @Success 200 {file} file "lora_encrypted.data"
 func (h *Handler) DownloadLoRA(ctx *gin.Context) {
 	userAddress := ctx.Param("userAddress")
@@ -204,18 +223,18 @@ func (h *Handler) DownloadLoRA(ctx *gin.Context) {
 		return
 	}
 
-	// Verify signature - user must prove they own the userAddress
-	// Use POST body for signature (consistent with CancelTask)
+	// Verify signature with timestamp - prevents replay attacks
 	var jsonData struct {
 		Signature string `json:"signature" binding:"required"`
+		Timestamp int64  `json:"timestamp" binding:"required"`
 	}
 	if err := ctx.Bind(&jsonData); err != nil {
 		handleBrokerError(ctx, err, "bind request body")
 		return
 	}
-	signature := jsonData.Signature
 
-	if err := h.ctrl.VerifyDownloadSignature(&id, userAddress, signature); err != nil {
+	if err := h.ctrl.VerifyDownloadSignature(&id, userAddress, jsonData.Signature, jsonData.Timestamp); err != nil {
+		h.logger.Warnf("download signature verification failed for %s task %s: %v", userAddress, id.String(), err)
 		ctx.JSON(http.StatusUnauthorized, gin.H{"error": fmt.Sprintf("authentication failed: %v", err)})
 		return
 	}
@@ -241,26 +260,64 @@ func (h *Handler) DownloadLoRA(ctx *gin.Context) {
 // UploadDataset godoc
 // @Summary Upload dataset to TEE
 // @Description Upload a dataset file to TEE for fine-tuning. Returns a dataset hash for use in task creation.
+// @Description Authentication: Requires signature of keccak256(userAddress + timestamp) signed by user's private key
+// @Description The timestamp must be within 5 minutes to prevent replay attacks
 // @Tags Dataset
 // @Accept multipart/form-data
 // @Produce json
 // @Router /user/{userAddress}/dataset [post]
 // @Param userAddress path string true "user address"
-// @Param file formance formData file true "dataset file (JSONL format)"
+// @Param file formData file true "dataset file (JSONL format)"
+// @Param signature formData string true "signature of keccak256(userAddress + timestamp)"
+// @Param timestamp formData string true "unix timestamp in seconds"
 // @Success 200 {object} object{datasetHash=string} "Dataset uploaded successfully"
 func (h *Handler) UploadDataset(ctx *gin.Context) {
 	userAddress := ctx.Param("userAddress")
-	
+
+	// Get and validate signature
+	signature := ctx.PostForm("signature")
+	if signature == "" {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "Signature is required"})
+		return
+	}
+
+	// Get and validate timestamp
+	timestampStr := ctx.PostForm("timestamp")
+	if timestampStr == "" {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "Timestamp is required"})
+		return
+	}
+
+	timestamp, err := strconv.ParseInt(timestampStr, 10, 64)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "Invalid timestamp format"})
+		return
+	}
+
+	// Verify signature with timestamp (prevents replay attacks)
+	if err := h.ctrl.VerifyUploadSignature(userAddress, signature, timestamp); err != nil {
+		h.logger.Warnf("signature verification failed for %s: %v", userAddress, err)
+		ctx.JSON(http.StatusUnauthorized, gin.H{"error": fmt.Sprintf("Authentication failed: %v", err)})
+		return
+	}
+
 	file, err := ctx.FormFile("file")
 	if err != nil {
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": "No file provided"})
 		return
 	}
 
-	// Check file size (max 500MB)
-	maxSize := int64(500 * 1024 * 1024)
+	// Check file size (max 100MB)
+	maxSize := int64(100 * 1024 * 1024)
 	if file.Size > maxSize {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": "File too large. Maximum size is 500MB"})
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "File too large. Maximum size is 100MB"})
+		return
+	}
+
+	// Validate file extension
+	filename := strings.ToLower(file.Filename)
+	if !strings.HasSuffix(filename, ".jsonl") && !strings.HasSuffix(filename, ".json") {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "Invalid file type. Only JSONL/JSON files are allowed"})
 		return
 	}
 


### PR DESCRIPTION

This commit addresses multiple critical security vulnerabilities in the fine-tuning service's file upload and download endpoints.

Security Improvements:
- Add timestamp-based signature verification to prevent replay attacks on UploadDataset and DownloadLoRA endpoints (5-minute time window)
- Add task ownership verification to GetTaskProgress to prevent unauthorized access to training logs
- Implement path traversal protection in SaveDataset with address validation and safe path construction
- Add JSONL format validation for uploaded datasets
- Implement streaming for file operations to prevent memory exhaustion

Rate Limiting:
- Reduce default rate limit from 10 RPS to 0.1 RPS (1 request per 10 seconds) to better match realistic usage patterns for file operations
- Reduce burst limit from 20 to 2 to allow retry on failure while preventing abuse
- Apply rate limiting to UploadDataset and DownloadLoRA endpoints

Performance:
- Replace io.ReadAll with streaming in GetTaskProgress to handle large log files efficiently
- Use io.MultiWriter in SaveDataset for hash computation during upload

