### PR TITLE
fix: return explicit error for invalid signature length in recoverAddress

### DIFF
--- a/api/controller/internal/middleware/auth.go
+++ b/api/controller/internal/middleware/auth.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -116,7 +117,7 @@ func recoverAddress(message string, signature string) (string, error) {
 
 	// Ethereum signatures are 65 bytes: R (32) + S (32) + V (1)
 	if len(sigBytes) != 65 {
-		return "", err
+		return "", fmt.Errorf("invalid signature length: expected 65 bytes, got %d", len(sigBytes))
 	}
 
 	// Adjust V value for Ethereum signature recovery


### PR DESCRIPTION
## Summary

`recoverAddress()` in `api/controller/internal/middleware/auth.go` checks that the decoded signature is exactly 65 bytes. When the length is wrong, it returns `("", err)` — but `err` is `nil` at that point because `hexutil.Decode` succeeded on the previous line. This means the caller receives `("", nil)`, which violates Go error handling conventions: an empty result with a nil error signals success.

**The fix**: return `fmt.Errorf("invalid signature length: expected 65 bytes, got %d", len(sigBytes))` so the caller gets a proper error.

**Note**: The downstream `AuthMiddleware` has additional checks (address match and admin whitelist) that currently prevent this from being exploitable, but returning nil error for an invalid state is incorrect and fragile.

## Changes

- Added `"fmt"` import
- Replaced `return "", err` (nil) with `return "", fmt.Errorf(...)` in the signature length check

## Test plan

- [x] Verified the fix compiles
- [ ] Existing auth middleware tests should continue to pass
- [ ] Malformed signatures (wrong length) now return a descriptive error instead of nil