### PR TITLE
fix: replace panic with error return in TdxQuote NVIDIA env check

### DIFF
--- a/api/common/tee/phala.go
+++ b/api/common/tee/phala.go
@@ -129,7 +129,7 @@ func (c *PhalaTappdClient) TdxQuote(ctx context.Context, reportData string, nvQu
 
 	if nvQuote {
 		if err := util.CheckPythonEnv(util.NvTrustPackages, nil); err != nil {
-			panic(err)
+			return "", errors.Wrap(err, "failed to check Python environment for NVIDIA trust packages")
 		}
 
 		nvidiaPayload, err := GpuPayload(hex.EncodeToString(crypto.Keccak256(reportDataBytes)), nil)


### PR DESCRIPTION
## Summary

In `api/common/tee/phala.go:132`, the `TdxQuote` function calls `panic(err)` when `CheckPythonEnv` fails for NVIDIA trust packages. This crashes the entire broker process instead of returning an error to the caller.

Every other error path in this function correctly returns `("", error)`. This one should too.

## Changes

- Replaced `panic(err)` with `return "", errors.Wrap(err, "failed to check Python environment for NVIDIA trust packages")`

## Test plan

- [ ] Verify that missing Python environment for NVIDIA packages returns a proper error response instead of crashing the broker
- [ ] Existing TEE attestation flows unaffected (non-NVIDIA paths unchanged)