### PR TITLE
fix: pass reportData to GetQuote and fix nil error wrap in GCP TDX

### DIFF
--- a/api/common/tee/gcp.go
+++ b/api/common/tee/gcp.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 
 	"github.com/google/go-tdx-guest/client"
 	pb "github.com/google/go-tdx-guest/proto/tdx"
@@ -17,18 +18,26 @@ import (
 type GcpTappdClient struct{}
 
 func (c *GcpTappdClient) TdxQuote(ctx context.Context, reportData string, nvQuote bool) (string, error) {
+	reportDataBytes := []byte(reportData)
+	if len(reportDataBytes) > 64 {
+		return "", errors.New("report data is too large, it should be at most 64 bytes")
+	}
+
+	var reportDataArray [64]byte
+	copy(reportDataArray[:], reportDataBytes)
+
 	quoteProvider, err := client.GetQuoteProvider()
 	if err != nil {
 		return "", errors.Wrap(err, "Failed to get quote provider")
 	}
 
-	quote, err := client.GetQuote(quoteProvider, [64]byte{})
+	quote, err := client.GetQuote(quoteProvider, reportDataArray)
 	if err != nil {
 		return "", errors.Wrap(err, "Failed to get quote")
 	}
 	quoteV4, ok := quote.(*pb.QuoteV4)
 	if !ok {
-		return "", errors.Wrap(err, "Failed to assert quote to *client.QuoteV4")
+		return "", fmt.Errorf("failed to assert quote to *pb.QuoteV4, got %T", quote)
 	}
 
 	// Create GCP response structure


### PR DESCRIPTION
## Summary

Two bugs in `GcpTappdClient.TdxQuote` (`api/common/tee/gcp.go`):

**1. reportData parameter ignored**
`client.GetQuote` was called with `[64]byte{}` (all zeros) instead of the actual `reportData`. This means the TDX quote is not bound to any caller-specified data, which undermines attestation verification. The Phala implementation correctly converts and passes `reportData` — this change makes the GCP implementation consistent.

**2. Nil error in type assertion failure path**
Line 31 used `errors.Wrap(err, "Failed to assert quote...")` but `err` is nil at that point (from the successful `GetQuote` call on line 25). Replaced with `fmt.Errorf` that includes the actual type received for debugging.

## Changes

- Convert `reportData` string to `[64]byte` and pass to `client.GetQuote` (with length validation matching Phala)
- Replace `errors.Wrap(err, ...)` with `fmt.Errorf(...)` on type assertion failure

## Test plan

- [ ] GCP TDX quotes now contain the actual report data instead of zeros
- [ ] Type assertion failures return a descriptive error instead of wrapping nil
- [ ] Report data exceeding 64 bytes is rejected with a clear error (consistent with Phala)