### PR TITLE
fix: use cryptographically random nonce for TEE settlement

### DIFF
--- a/api/inference/internal/ctrl/settlement_tee.go
+++ b/api/inference/internal/ctrl/settlement_tee.go
@@ -2,6 +2,7 @@ package ctrl
 
 import (
 	"context"
+	"crypto/rand"
 	"math/big"
 	"time"
 
@@ -476,8 +477,10 @@ func (c *Ctrl) groupRequestsByUser(reqs []model.Request) map[string]*UserRequest
 
 func (c *Ctrl) createUserSettlement(userAddr string, userReqs *UserRequests) (contract.TEESettlementData, error) {
 	requestsHash := c.hashUserRequests(userReqs.Requests)
-	nonce := big.NewInt(time.Now().Unix())
-	nonce.Mul(nonce, big.NewInt(10000000))
+	nonce, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return contract.TEESettlementData{}, errors.Wrap(err, "failed to generate random nonce")
+	}
 
 	settlementData := contract.TEESettlementData{
 		User:         common.HexToAddress(userAddr),


### PR DESCRIPTION
## Summary

The settlement nonce in `createUserSettlement` is derived from the Unix timestamp:

```go
nonce := big.NewInt(time.Now().Unix())
nonce.Mul(nonce, big.NewInt(10000000))
```

This produces the same nonce for any two settlements that occur within the same second. The smart contract rejects duplicate nonces with `SettlementInvalidNonce` (status 4), so under load — multiple users settling in the same second — valid settlements fail.

The nonce is also predictable, since it's just a function of the current time.

**Fix:** Replace with a 128-bit cryptographically random nonce via `crypto/rand`. This is the standard approach for blockchain replay protection — collision probability is negligible (1 in 2^128), and the nonce is unpredictable.

## Changes

- Replaced `time.Now().Unix() * 10_000_000` with `rand.Int(rand.Reader, 2^128)`
- Added `crypto/rand` import
- Added error handling for the (extremely unlikely) RNG failure case

## Test plan

- [ ] Settlement transactions use unique nonces even when executed in rapid succession
- [ ] No `SettlementInvalidNonce` rejections under concurrent settlement load
- [ ] Existing settlement flow and EIP-712 signing unaffected