### PR TITLE
feat: add SupportedFormats field to ModelInfo for API format advertis…

### DIFF
--- a/api/inference/config/config.go
+++ b/api/inference/config/config.go
@@ -43,6 +43,7 @@ type ModelInfo struct {
 	MaxCompletionTokens int                    `yaml:"maxCompletionTokens"` // Optional. Max output tokens
 	Architecture        *ModelArchitecture     `yaml:"architecture"`        // Required. Model architecture details
 	SupportedParameters []string               `yaml:"supportedParameters"` // Required. e.g., ["temperature", "top_p", "max_tokens"]
+	SupportedFormats    []string               `yaml:"supportedFormats"`    // Optional. API formats this model supports, e.g., ["openai", "anthropic"]. Defaults to ["openai"] if omitted.
 	DefaultParameters   map[string]interface{} `yaml:"defaultParameters"`   // Optional. Default values for parameters, e.g., {"temperature": 0.7, "top_p": 0.9}
 	TeeType             string                 `yaml:"teeType"`             // Optional. TEE hardware type, e.g., "TDX", "SEV", "SGX", "H100"
 	ExpirationDate      string                 `yaml:"expirationDate"`      // Optional. Model availability expiration in RFC3339 format, e.g., "2026-12-31T00:00:00Z"

--- a/api/inference/integration/provider/config.example.yaml
+++ b/api/inference/integration/provider/config.example.yaml
@@ -45,3 +45,8 @@ service:
   #     - frequency_penalty
   #     - presence_penalty
   #     - stop
+  #   # Optional: API formats supported by this model. Defaults to ["openai"] if omitted.
+  #   # Add "anthropic" if the target service supports /v1/messages (Anthropic Messages API).
+  #   supportedFormats:
+  #     - openai
+  #     - anthropic

--- a/api/inference/internal/handler/models.go
+++ b/api/inference/internal/handler/models.go
@@ -23,6 +23,7 @@ type ModelObject struct {
 	MaxCompletionTokens int                       `json:"max_completion_tokens,omitempty"`
 	Architecture        *config.ModelArchitecture `json:"architecture,omitempty"`
 	SupportedParameters []string                  `json:"supported_parameters,omitempty"`
+	SupportedFormats    []string                  `json:"supported_formats,omitempty"`
 	DefaultParameters   map[string]interface{}    `json:"default_parameters,omitempty"`
 	Pricing             *ModelPricing             `json:"pricing,omitempty"`
 	Verifiability       string                    `json:"verifiability,omitempty"`
@@ -87,6 +88,7 @@ func (h *Handler) GetModels(ctx *gin.Context) {
 		obj.MaxCompletionTokens = cfg.ModelInfo.MaxCompletionTokens
 		obj.Architecture = cfg.ModelInfo.Architecture
 		obj.SupportedParameters = cfg.ModelInfo.SupportedParameters
+		obj.SupportedFormats = cfg.ModelInfo.SupportedFormats
 		obj.DefaultParameters = cfg.ModelInfo.DefaultParameters
 		obj.TeeType = cfg.ModelInfo.TeeType
 		obj.ExpirationDate = cfg.ModelInfo.ExpirationDate

--- a/api/inference/internal/handler/models_test.go
+++ b/api/inference/internal/handler/models_test.go
@@ -66,6 +66,7 @@ func TestGetModels_FullResponse(t *testing.T) {
 					Tokenizer:        "llama3",
 				},
 				SupportedParameters: []string{"temperature", "top_p", "max_tokens"},
+				SupportedFormats:    []string{"openai", "anthropic"},
 				DefaultParameters:   map[string]interface{}{"temperature": 0.7, "top_p": 0.9},
 				TeeType:             "TDX",
 				ExpirationDate:      "2026-12-31T00:00:00Z",
@@ -190,6 +191,17 @@ func TestGetModels_FullResponse(t *testing.T) {
 		}
 	}
 
+	// Supported formats
+	expectedFormats := []string{"openai", "anthropic"}
+	if len(m.SupportedFormats) != len(expectedFormats) {
+		t.Fatalf("expected %d supported_formats, got %d", len(expectedFormats), len(m.SupportedFormats))
+	}
+	for i, f := range expectedFormats {
+		if m.SupportedFormats[i] != f {
+			t.Errorf("expected supported_formats[%d]=%s, got %s", i, f, m.SupportedFormats[i])
+		}
+	}
+
 	// Expiration date
 	if m.ExpirationDate != "2026-12-31T00:00:00Z" {
 		t.Errorf("expected expiration_date=2026-12-31T00:00:00Z, got %s", m.ExpirationDate)
@@ -241,6 +253,9 @@ func TestGetModels_WithoutModelInfo(t *testing.T) {
 	}
 	if m.SupportedParameters != nil {
 		t.Errorf("expected supported_parameters to be nil, got %v", m.SupportedParameters)
+	}
+	if m.SupportedFormats != nil {
+		t.Errorf("expected supported_formats to be nil, got %v", m.SupportedFormats)
 	}
 	if m.TeeAttested {
 		t.Error("expected tee_attested=false")


### PR DESCRIPTION
…ement

Add optional SupportedFormats field (e.g., ["openai", "anthropic"]) to ModelInfo config and /v1/models response. This allows providers to explicitly declare which API formats they support, separate from SupportedParameters which describes request parameters.

Defaults to ["openai"] when omitted for backward compatibility.