### PR TITLE
feat: add global and per-user concurrency limits for backend protection

### DIFF
--- a/api/common/middleware/per_user_concurrency.go
+++ b/api/common/middleware/per_user_concurrency.go
@@ -1,0 +1,83 @@
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+
+	"github.com/gin-gonic/gin"
+)
+
+// PerUserConcurrencyLimiter limits the number of concurrent requests per user.
+// This prevents a single user from monopolizing backend resources.
+type PerUserConcurrencyLimiter struct {
+	maxPerUser int
+	active     map[string]int
+	mu         sync.Mutex
+}
+
+// NewPerUserConcurrencyLimiter creates a per-user concurrency limiter.
+// maxPerUser: maximum concurrent requests allowed per user address.
+func NewPerUserConcurrencyLimiter(maxPerUser int) *PerUserConcurrencyLimiter {
+	return &PerUserConcurrencyLimiter{
+		maxPerUser: maxPerUser,
+		active:     make(map[string]int),
+	}
+}
+
+// Acquire attempts to acquire a slot for the given user.
+// Returns true if acquired, false if the user has reached their limit.
+func (l *PerUserConcurrencyLimiter) Acquire(userID string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.active[userID] >= l.maxPerUser {
+		return false
+	}
+	l.active[userID]++
+	return true
+}
+
+// Release releases a slot for the given user.
+func (l *PerUserConcurrencyLimiter) Release(userID string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.active[userID]--
+	if l.active[userID] <= 0 {
+		delete(l.active, userID)
+	}
+}
+
+// GetActiveForUser returns the current concurrent request count for a user.
+func (l *PerUserConcurrencyLimiter) GetActiveForUser(userID string) int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.active[userID]
+}
+
+// PerUserConcurrencyKey is the gin context key used to signal that a per-user
+// concurrency slot was acquired and must be released.
+const PerUserConcurrencyKey = "perUserConcurrencyAcquired"
+
+// CheckPerUserConcurrency checks per-user concurrency after user address is known.
+// It expects "userAddress" to be set in the gin context.
+// The caller must call Release when the request completes.
+func CheckPerUserConcurrency(limiter *PerUserConcurrencyLimiter, c *gin.Context, userAddress string) bool {
+	if limiter == nil {
+		return true
+	}
+
+	if !limiter.Acquire(userAddress) {
+		active := limiter.GetActiveForUser(userAddress)
+		c.JSON(http.StatusTooManyRequests, gin.H{
+			"error": fmt.Sprintf(
+				"Too many concurrent requests. You have %d active requests (limit: %d). Please wait for some to complete.",
+				active, limiter.maxPerUser,
+			),
+		})
+		c.Abort()
+		return false
+	}
+	return true
+}

--- a/api/inference/cmd/server/main.go
+++ b/api/inference/cmd/server/main.go
@@ -97,7 +97,7 @@ func Main() {
 	if err := ctrl.SyncService(ctx); err != nil {
 		panic(err)
 	}
-	proxy := proxy.New(ctrl, engine, config.AllowOrigins, config.Monitor.Enable, logger)
+	proxy := proxy.New(ctrl, engine, config.AllowOrigins, config.Monitor.Enable, config.ConcurrencyLimit, logger)
 	if err := proxy.Start(); err != nil {
 		panic(err)
 	}

--- a/api/inference/config/config.go
+++ b/api/inference/config/config.go
@@ -149,6 +149,15 @@ type Config struct {
 	CacheTokenBilling   CacheTokenBillingConfig `yaml:"cacheTokenBilling"`
 	Whitelist           WhitelistConfig         `yaml:"whitelist"`
 	Async               AsyncConfig          `yaml:"async"`
+	ConcurrencyLimit    ConcurrencyLimitConfig  `yaml:"concurrencyLimit"`
+}
+
+// ConcurrencyLimitConfig defines concurrency limiting for backend protection.
+// Global limit caps total in-flight requests to the backend (should match GPU capacity).
+// Per-user limit prevents a single user from monopolizing all slots.
+type ConcurrencyLimitConfig struct {
+	MaxGlobalConcurrent  int `yaml:"maxGlobalConcurrent"`  // Max total concurrent requests to backend (default: 20)
+	MaxPerUserConcurrent int `yaml:"maxPerUserConcurrent"` // Max concurrent requests per user (default: 5, whitelisted users are exempt)
 }
 
 // AsyncConfig defines configuration for async job processing.
@@ -332,6 +341,10 @@ func GetConfig() *Config {
 			Whitelist: WhitelistConfig{
 				Enabled:       false,
 				UserAddresses: []string{},
+			},
+				ConcurrencyLimit: ConcurrencyLimitConfig{
+				MaxGlobalConcurrent:  20,
+				MaxPerUserConcurrent: 5,
 			},
 			Async: AsyncConfig{
 				Enabled:                true,

--- a/api/inference/internal/proxy/proxy.go
+++ b/api/inference/internal/proxy/proxy.go
@@ -17,6 +17,7 @@ import (
 	"github.com/0glabs/0g-serving-broker/common/errors"
 	"github.com/0glabs/0g-serving-broker/common/log"
 	"github.com/0glabs/0g-serving-broker/common/middleware"
+	"github.com/0glabs/0g-serving-broker/inference/config"
 	constant "github.com/0glabs/0g-serving-broker/inference/const"
 	"github.com/0glabs/0g-serving-broker/inference/internal/ctrl"
 	"github.com/0glabs/0g-serving-broker/inference/model"
@@ -27,19 +28,28 @@ type Proxy struct {
 	ctrl   *ctrl.Ctrl
 	logger log.Logger
 
-	allowOrigins       []string
-	serviceRoutesLock  sync.RWMutex
-	serviceTarget      string
-	serviceType        string
-	serviceGroup       *gin.RouterGroup
-	rateLimiter        *middleware.RateLimiter
-	concurrencyLimiter *middleware.ConcurrencyLimiter
+	allowOrigins              []string
+	serviceRoutesLock         sync.RWMutex
+	serviceTarget             string
+	serviceType               string
+	serviceGroup              *gin.RouterGroup
+	rateLimiter               *middleware.RateLimiter
+	concurrencyLimiter        *middleware.ConcurrencyLimiter
+	perUserConcurrencyLimiter *middleware.PerUserConcurrencyLimiter
 }
 
-func New(ctrl *ctrl.Ctrl, engine *gin.Engine, allowOrigins []string, enableMonitor bool, logger log.Logger) *Proxy {
+func New(ctrl *ctrl.Ctrl, engine *gin.Engine, allowOrigins []string, enableMonitor bool, concurrencyConfig config.ConcurrencyLimitConfig, logger log.Logger) *Proxy {
 	// Ensure allowOrigins is not empty
 	if len(allowOrigins) == 0 {
 		allowOrigins = []string{"*"}
+	}
+
+	// Apply defaults if not configured
+	if concurrencyConfig.MaxGlobalConcurrent <= 0 {
+		concurrencyConfig.MaxGlobalConcurrent = 20
+	}
+	if concurrencyConfig.MaxPerUserConcurrent <= 0 {
+		concurrencyConfig.MaxPerUserConcurrent = 5
 	}
 
 	p := &Proxy{
@@ -49,10 +59,13 @@ func New(ctrl *ctrl.Ctrl, engine *gin.Engine, allowOrigins []string, enableMonit
 		serviceGroup: engine.Group(constant.ServicePrefix),
 		// Configure rate limiter: 15 requests per second with burst of 20
 		rateLimiter: middleware.NewRateLimiter(rate.Limit(15), 20),
-		// Configure concurrency limiter: max 50 concurrent requests
-		// For 2-minute requests: 50 concurrent × 2min = manageable load
-		concurrencyLimiter: middleware.NewConcurrencyLimiter(50),
+		// Configure concurrency limiter to match backend GPU capacity
+		concurrencyLimiter:        middleware.NewConcurrencyLimiter(concurrencyConfig.MaxGlobalConcurrent),
+		perUserConcurrencyLimiter: middleware.NewPerUserConcurrencyLimiter(concurrencyConfig.MaxPerUserConcurrent),
 	}
+
+	logger.Infof("Concurrency limits: global=%d, per-user=%d",
+		concurrencyConfig.MaxGlobalConcurrent, concurrencyConfig.MaxPerUserConcurrent)
 
 	// Configure CORS middleware
 	// IMPORTANT: This must handle OPTIONS preflight requests before they reach the proxy handler
@@ -90,12 +103,10 @@ func New(ctrl *ctrl.Ctrl, engine *gin.Engine, allowOrigins []string, enableMonit
 	// Apply rate limiting middleware
 	p.serviceGroup.Use(middleware.RateLimitMiddleware(p.rateLimiter))
 
-	// Apply concurrency limiting middleware only for long-running services
-	// text-to-image: 10-30s, image-editing: 1-2min
-	// chatbot and speech-to-text are fast enough and don't need this limit
-	if ctrl.Service.Type == "text-to-image" || ctrl.Service.Type == "image-editing" {
-		p.serviceGroup.Use(middleware.ConcurrencyLimitMiddleware(p.concurrencyLimiter))
-	}
+	// Apply global concurrency limiting to all service types.
+	// This caps total in-flight requests to match backend GPU capacity,
+	// preventing queue buildup that degrades throughput.
+	p.serviceGroup.Use(middleware.ConcurrencyLimitMiddleware(p.concurrencyLimiter))
 
 	// Apply request size limit middleware (32MB)
 	p.serviceGroup.Use(middleware.RequestSizeLimitMiddleware(middleware.MaxRequestSize))
@@ -224,6 +235,21 @@ func (p *Proxy) proxyHTTPRequest(ctx *gin.Context) {
 	// Store user address in context for rate limiting
 	ctx.Set("userAddress", userAddress)
 
+	// Check if user is whitelisted (checked early to skip per-user concurrency limit)
+	isWhitelisted := p.ctrl.IsWhitelistedUser(userAddress)
+
+	// Apply per-user concurrency limit only for non-whitelisted users.
+	// Whitelisted users (internal services, monitoring) are exempt to avoid
+	// blocking critical operations, but still subject to the global limit.
+	if !isWhitelisted {
+		if !middleware.CheckPerUserConcurrency(p.perUserConcurrencyLimiter, ctx, userAddress) {
+			p.logger.Warnf("Per-user concurrency limit reached: user=%s, active=%d",
+				userAddress, p.perUserConcurrencyLimiter.GetActiveForUser(userAddress))
+			return
+		}
+		defer p.perUserConcurrencyLimiter.Release(userAddress)
+	}
+
 	// Check if user is rate-limited due to excessive model mismatch attempts
 	rateLimiter := ctrl.GetRateLimiter()
 	if blocked, blockedUntil := rateLimiter.IsBlocked(userAddress); blocked {
@@ -242,8 +268,7 @@ func (p *Proxy) proxyHTTPRequest(ctx *gin.Context) {
 	// Record unique user for DAU tracking
 	monitor.RecordUniqueUser(userAddress)
 
-	// Check if user is whitelisted - whitelist users bypass billing but still need normal response processing
-	isWhitelisted := p.ctrl.IsWhitelistedUser(userAddress)
+	// Whitelisted users bypass billing but still need normal response processing
 	if isWhitelisted {
 		// Sanitize path for logging - never log query parameters that may contain sensitive data
 		// Note: targetPath may already be sanitized at L149-152, but we ensure it here for clarity


### PR DESCRIPTION
Prevent backend LLM overload by adding two-layer concurrency control:
- Global limit (default 20) caps total in-flight requests to match GPU capacity
- Per-user limit (default 5) prevents a single user from monopolizing all slots
- Whitelisted users are exempt from per-user limits but still subject to global limit
- Both limits are configurable via config.yaml concurrencyLimit section
- Concurrency limiting now applies to all service types (previously only image services)