### PR TITLE
fix: resolve settlement signing bug and add reconciliation safety net

### DIFF
--- a/api/inference/cmd/event/main.go
+++ b/api/inference/cmd/event/main.go
@@ -90,6 +90,15 @@ func Main() {
 		panic(err)
 	}
 
+	// Add reconciliation processor for event-based settlement verification
+	if conf.Interval.ReconciliationProcessor > 0 {
+		reconciliationProcessor := event.NewReconciliationProcessor(db, contract, conf.Interval.ReconciliationProcessor, logger)
+		if err := mgr.Add(reconciliationProcessor); err != nil {
+			panic(err)
+		}
+		logger.Infof("Starting reconciliation processor: interval=%ds", conf.Interval.ReconciliationProcessor)
+	}
+
 	// Add revenue transfer processor if configured
 	if conf.RevenueTransfer.Interval > 0 && conf.RevenueTransfer.TargetAddress != "" {
 		revenueTransferProcessor, err := event.NewRevenueTransferProcessor(

--- a/api/inference/config/config.go
+++ b/api/inference/config/config.go
@@ -122,9 +122,10 @@ type Config struct {
 	GasPrice    string `yaml:"gasPrice"`
 	MaxGasPrice string `yaml:"maxGasPrice"`
 	Interval    struct {
-		AutoSettleBufferTime     int `yaml:"autoSettleBufferTime"`
-		ForceSettlementProcessor int `yaml:"forceSettlementProcessor"`
-		SettlementProcessor      int `yaml:"settlementProcessor"`
+		AutoSettleBufferTime         int `yaml:"autoSettleBufferTime"`
+		ForceSettlementProcessor     int `yaml:"forceSettlementProcessor"`
+		SettlementProcessor          int `yaml:"settlementProcessor"`
+		ReconciliationProcessor      int `yaml:"reconciliationProcessor"`
 	} `yaml:"interval"`
 	RevenueTransfer struct {
 		TargetAddress string `yaml:"targetAddress"` // Target address to transfer revenue to
@@ -267,13 +268,15 @@ func GetConfig() *Config {
 			GasPrice:    "",
 			MaxGasPrice: "",
 			Interval: struct {
-				AutoSettleBufferTime     int `yaml:"autoSettleBufferTime"`
-				ForceSettlementProcessor int `yaml:"forceSettlementProcessor"`
-				SettlementProcessor      int `yaml:"settlementProcessor"`
+				AutoSettleBufferTime         int `yaml:"autoSettleBufferTime"`
+				ForceSettlementProcessor     int `yaml:"forceSettlementProcessor"`
+				SettlementProcessor          int `yaml:"settlementProcessor"`
+				ReconciliationProcessor      int `yaml:"reconciliationProcessor"`
 			}{
-				AutoSettleBufferTime:     60,
-				ForceSettlementProcessor: 600,
-				SettlementProcessor:      300,
+				AutoSettleBufferTime:         60,
+				ForceSettlementProcessor:     600,
+				SettlementProcessor:          300,
+				ReconciliationProcessor:      60,
 			},
 			RevenueTransfer: struct {
 				TargetAddress string `yaml:"targetAddress"`

--- a/api/inference/internal/contract/request.go
+++ b/api/inference/internal/contract/request.go
@@ -3,6 +3,7 @@ package providercontract
 import (
 	"context"
 	"math/big"
+	"time"
 
 	"github.com/0glabs/0g-serving-broker/common/errors"
 	"github.com/0glabs/0g-serving-broker/inference/contract"
@@ -18,26 +19,44 @@ type TEESettlementData struct {
 	Signature    []byte
 }
 
-func (c *ProviderContract) SettleFeesWithTEE(ctx context.Context, settlements []contract.TEESettlementData) ([]common.Address, error) {
+// SettlementResult represents the on-chain result for a single user settlement
+type SettlementResult struct {
+	User            common.Address
+	Status          uint8
+	UnsettledAmount *big.Int
+}
+
+func (c *ProviderContract) SettleFeesWithTEE(ctx context.Context, settlements []contract.TEESettlementData) (common.Hash, []SettlementResult, error) {
 	// Execute the actual transaction
 	tx, err := c.Contract.Transact(ctx, nil, "settleFeesWithTEE", settlements)
 	if err != nil {
 		wrappedErr := WrapContractError(err)
 		c.logger.Errorf("[SettleFeesWithTEE] Contract error calling settleFeesWithTEE: %v", wrappedErr)
-		return nil, errors.Wrap(wrappedErr, "call settleFeesWithTEE")
+		return common.Hash{}, nil, errors.Wrap(wrappedErr, "call settleFeesWithTEE")
 	}
 
 	// Wait for transaction receipt
 	c.logger.Infof("Settlement transaction submitted with hash: %s", tx.Hash().Hex())
 	receipt, err := c.Contract.WaitForReceipt(ctx, tx.Hash())
 	if err != nil {
-		wrappedErr := WrapContractError(err)
-		c.logger.Errorf("[SettleFeesWithTEE] Contract error waiting for receipt: %v", wrappedErr)
-		return nil, errors.Wrap(wrappedErr, "wait for receipt")
+		// WaitForReceipt timed out — but the tx may have been mined.
+		// Do one final check with a fresh context.
+		freshCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		finalReceipt, finalErr := c.Contract.Client.Client.TransactionReceipt(freshCtx, tx.Hash())
+		if finalErr != nil || finalReceipt == nil {
+			wrappedErr := WrapContractError(err)
+			c.logger.Errorf("[SettleFeesWithTEE] Contract error waiting for receipt: %v", wrappedErr)
+			return tx.Hash(), nil, errors.Wrapf(wrappedErr, "wait for receipt (txHash=%s, may still be pending)", tx.Hash().Hex())
+		}
+		// Tx was actually mined! Use this receipt.
+		receipt = finalReceipt
+		c.logger.Warnf("Transaction %s was mined despite WaitForReceipt timeout (block %d)",
+			tx.Hash().Hex(), receipt.BlockNumber.Uint64())
 	}
 	
-	// Parse TEESettlementResult events from logs to determine failed users
-	var failedUsers []common.Address
+	// Parse TEESettlementResult events from logs to determine per-user results
+	var results []SettlementResult
 	for _, vLog := range receipt.Logs {
 		// Try to parse the log as a TEESettlementResult event
 		event, err := c.Contract.InferenceServing.ParseTEESettlementResult(*vLog)
@@ -45,15 +64,17 @@ func (c *ProviderContract) SettleFeesWithTEE(ctx context.Context, settlements []
 			// Not a TEESettlementResult event, skip
 			continue
 		}
-		
-		// Status 0 means SUCCESS, anything else is a failure or partial settlement
-		// For backward compatibility, we treat both failures and partial settlements as "failed"
+
 		if event.Status != 0 {
-			failedUsers = append(failedUsers, event.User)
-			c.logger.Infof("Settlement for user %s: status=%d (0=SUCCESS, 1=PARTIAL, 2=PROVIDER_MISMATCH, 3=NO_TEE_SIGNER, 4=INVALID_NONCE, 5=INVALID_SIG), unsettledAmount=%s", 
+			results = append(results, SettlementResult{
+				User:            event.User,
+				Status:          event.Status,
+				UnsettledAmount: event.UnsettledAmount,
+			})
+			c.logger.Infof("Settlement for user %s: status=%d, unsettledAmount=%s",
 				event.User.Hex(), event.Status, event.UnsettledAmount.String())
 		}
 	}
-	
-	return failedUsers, nil
+
+	return tx.Hash(), results, nil
 }

--- a/api/inference/internal/ctrl/settlement_tee.go
+++ b/api/inference/internal/ctrl/settlement_tee.go
@@ -2,6 +2,7 @@ package ctrl
 
 import (
 	"context"
+	"encoding/json"
 	"math/big"
 	"time"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/0glabs/0g-serving-broker/common/util"
 	constant "github.com/0glabs/0g-serving-broker/inference/const"
 	"github.com/0glabs/0g-serving-broker/inference/contract"
+	providercontract "github.com/0glabs/0g-serving-broker/inference/internal/contract"
 	"github.com/0glabs/0g-serving-broker/inference/model"
 )
 
@@ -136,16 +138,16 @@ func (c *Ctrl) ProcessSettlement(ctx context.Context) error {
 func (c *Ctrl) SettleFeesWithTEE(ctx context.Context) error {
 	// Clear expired skipUntil flags for both requests and users
 	if err := c.db.ClearExpiredSkipUntil(); err != nil {
-		c.logger.Infof("Warning: failed to clear expired skipUntil for requests: %v", err)
+		c.logger.Warnf("Failed to clear expired skipUntil for requests: %v", err)
 	}
 	if err := c.db.ClearExpiredUserSkipUntil(); err != nil {
-		c.logger.Infof("Warning: failed to clear expired skipUntil for users: %v", err)
+		c.logger.Warnf("Failed to clear expired skipUntil for users: %v", err)
 	}
 
 	// Prune old requests with zero output
 	pruneThreshold := 1 * time.Hour // Prune requests older than 1 hours with zero output
 	if err := c.db.PruneRequest(pruneThreshold); err != nil {
-		c.logger.Infof("Warning: failed to prune old zero-output requests: %v", err)
+		c.logger.Warnf("Failed to prune old zero-output requests: %v", err)
 	}
 
 	// Main settlement loop with limited iterations
@@ -178,15 +180,18 @@ func (c *Ctrl) SettleFeesWithTEE(ctx context.Context) error {
 		}
 
 		// Execute settlements if we have any
+		var execErr error
 		if len(batch.ExecutableItems) > 0 {
-			err = c.executeAndProcessResults(ctx, batch)
-			if err != nil {
-				return errors.Wrap(err, "execute settlement batch")
-			}
+			execErr = c.executeAndProcessResults(ctx, batch)
+			// Don't return immediately — always process outcomes for completed batches
 		}
 
-		// Process outcomes (delete/skip requests)
+		// Process outcomes (delete/skip requests) — runs even if execution had partial errors
 		c.processOutcomes(batch.Outcomes)
+
+		if execErr != nil {
+			return errors.Wrap(execErr, "execute settlement batch")
+		}
 
 		// If no executable items, we're done
 		if len(batch.ExecutableItems) == 0 {
@@ -379,10 +384,16 @@ func (c *Ctrl) adjustForPartialSettlement(settlement contract.TEESettlementData,
 		return nil, nil
 	}
 
-	// Create adjusted settlement
-	adjustedSettlement := settlement
-	adjustedSettlement.TotalFee = actualTotalFee
-	adjustedSettlement.RequestsHash = c.hashUserRequests(settledRequests)
+	// Re-create settlement with fresh nonce and signature for the adjusted subset
+	adjustedUserReqs := &UserRequests{
+		Requests: settledRequests,
+		TotalFee: actualTotalFee,
+	}
+	adjustedSettlement, err := c.createUserSettlement(settlement.User.Hex(), adjustedUserReqs)
+	if err != nil {
+		c.logger.Errorf("Error re-signing adjusted settlement for user %s: %v", settlement.User.Hex(), err)
+		return nil, nil
+	}
 
 	return &adjustedSettlement, settledRequests
 }
@@ -393,11 +404,14 @@ func (c *Ctrl) executeAndProcessResults(ctx context.Context, batch *SettlementBa
 		return nil
 	}
 
+	// Record pending settlements and mark requests as settling BEFORE sending tx
+	pendingIDs := c.recordPendingSettlements(ctx, batch)
+
 	// Execute settlements in contract batches
-	actualFailures, err := c.executeBatches(ctx, batch.ExecutableItems)
-	if err != nil {
-		return errors.Wrap(err, "execute contract batches")
-	}
+	execResult, execErr := c.executeBatches(ctx, batch.ExecutableItems)
+
+	// Update pending_settlement records with tx hashes
+	c.updatePendingTxHashes(pendingIDs, execResult.TxHashes)
 
 	// Update outcomes with execution results
 	for _, outcome := range batch.Outcomes {
@@ -405,15 +419,107 @@ func (c *Ctrl) executeAndProcessResults(ctx context.Context, batch *SettlementBa
 			continue // Already marked as failed
 		}
 
-		if _, failed := actualFailures[outcome.User]; failed {
-			// Execution failed - revert to failed status
-			outcome.Status = SettlementPartial // insufficient balance or other failure
+		result, hasResult := execResult.Results[outcome.User]
+		if !hasResult {
+			continue // No failure event — settlement fully succeeded
+		}
+
+		switch result.Status {
+		case uint8(SettlementPartial):
+			// PARTIAL: some funds were deducted on-chain
+			settledAmount := new(big.Int).Sub(outcome.AdjustedRequest.TotalFee, result.UnsettledAmount)
+			if settledAmount.Cmp(big.NewInt(0)) > 0 && len(outcome.SettledRequests) > 0 {
+				settledReqs, _ := c.getRequestsWithinBudget(outcome.SettledRequests, settledAmount)
+				outcome.SettledRequests = settledReqs
+				outcome.Status = SettlementPartial
+				outcome.UnsettledAmount = result.UnsettledAmount
+			} else {
+				outcome.AdjustedRequest = nil
+				outcome.SettledRequests = nil
+				outcome.Status = SettlementPartial
+			}
+		default:
+			// Complete failure
+			outcome.Status = SettlementStatus(result.Status)
 			outcome.AdjustedRequest = nil
 			outcome.SettledRequests = nil
 		}
 	}
 
-	return nil
+	return execErr
+}
+
+// pendingSettlementRecord tracks a pending settlement ID and which batch index it belongs to
+type pendingSettlementRecord struct {
+	ID         uint64
+	BatchIndex int // which TEESettlementBatchSize chunk this belongs to
+}
+
+// recordPendingSettlements creates pending_settlement records and marks requests as settling
+func (c *Ctrl) recordPendingSettlements(ctx context.Context, batch *SettlementBatch) []pendingSettlementRecord {
+	currentBlock, err := c.contract.Contract.Client.Client.BlockNumber(ctx)
+	if err != nil {
+		c.logger.Warnf("Failed to get block number for pending settlement, using 1 as fallback: %v", err)
+		currentBlock = 1 // Use 1 instead of 0 so expiry logic still works
+	}
+
+	// Map each executable item to its batch index
+	executableUserBatch := make(map[common.Address]int)
+	for i, item := range batch.ExecutableItems {
+		batchIdx := i / constant.TEESettlementBatchSize
+		executableUserBatch[item.User] = batchIdx
+	}
+
+	var records []pendingSettlementRecord
+	for _, outcome := range batch.Outcomes {
+		if outcome.AdjustedRequest == nil {
+			continue
+		}
+
+		requestHashes := c.getRequestHashes(outcome.SettledRequests)
+		hashesJSON, err := json.Marshal(requestHashes)
+		if err != nil {
+			c.logger.Errorf("Failed to marshal request hashes for user %s: %v", outcome.User.Hex(), err)
+			continue
+		}
+
+		ps := &model.PendingSettlement{
+			UserAddress:    outcome.User.Hex(),
+			TotalFee:       outcome.AdjustedRequest.TotalFee.String(),
+			Nonce:          outcome.AdjustedRequest.Nonce.String(),
+			RequestHashes:  string(hashesJSON),
+			Status:         "pending",
+			SubmittedBlock: currentBlock,
+		}
+		if err := c.db.CreatePendingSettlement(ps); err != nil {
+			c.logger.Warnf("Failed to record pending settlement for user %s: %v", outcome.User.Hex(), err)
+			continue
+		}
+
+		batchIdx := executableUserBatch[outcome.User]
+		records = append(records, pendingSettlementRecord{ID: ps.ID, BatchIndex: batchIdx})
+
+		// Mark requests as settling so they won't be picked up by the next settlement cycle
+		if err := c.db.MarkRequestsSettling(requestHashes, true); err != nil {
+			c.logger.Warnf("Failed to mark requests as settling for user %s: %v", outcome.User.Hex(), err)
+		}
+	}
+	return records
+}
+
+// updatePendingTxHashes updates pending_settlement records with the correct tx hash per batch
+func (c *Ctrl) updatePendingTxHashes(records []pendingSettlementRecord, txHashes []common.Hash) {
+	if len(records) == 0 || len(txHashes) == 0 {
+		return
+	}
+	for _, rec := range records {
+		if rec.BatchIndex < len(txHashes) {
+			txHash := txHashes[rec.BatchIndex].Hex()
+			if err := c.db.UpdatePendingSettlementTxHash(rec.ID, txHash); err != nil {
+				c.logger.Warnf("Failed to update tx hash for pending settlement %d: %v", rec.ID, err)
+			}
+		}
+	}
 }
 
 // processOutcomes handles the final outcome processing
@@ -422,22 +528,28 @@ func (c *Ctrl) processOutcomes(outcomes []*SettlementOutcome) {
 		switch outcome.Status {
 		case SettlementSuccess, SettlementPartial:
 			if len(outcome.SettledRequests) > 0 {
-				// Delete successfully settled requests
-				c.deleteRequests(outcome.SettledRequests)
+				if err := c.deleteRequests(outcome.SettledRequests); err != nil {
+					c.logger.Errorf("User %s: failed to delete %d settled requests: %v",
+						outcome.User.Hex(), len(outcome.SettledRequests), err)
+					continue
+				}
 				c.logger.Infof("User %s: deleted %d settled requests",
 					outcome.User.Hex(), len(outcome.SettledRequests))
 			}
 
 		case SettlementNoSigner:
 			// Permanent failure - delete all requests for this user
-			// For permanent failures, we should delete all user's requests (not just settled ones)
 			userReqs, err := c.getUserRequestsForAddress(outcome.User.Hex())
 			if err != nil {
 				c.logger.Infof("Error getting requests for permanent failure user %s: %v", outcome.User.Hex(), err)
 			} else if userReqs != nil {
-				c.deleteRequests(userReqs.Requests)
-				c.logger.Infof("User %s: deleted %d requests due to permanent failure",
-					outcome.User.Hex(), len(userReqs.Requests))
+				if err := c.deleteRequests(userReqs.Requests); err != nil {
+					c.logger.Errorf("User %s: failed to delete requests for permanent failure: %v",
+						outcome.User.Hex(), err)
+				} else {
+					c.logger.Infof("User %s: deleted %d requests due to permanent failure",
+						outcome.User.Hex(), len(userReqs.Requests))
+				}
 			}
 
 		default:
@@ -550,42 +662,64 @@ func (c *Ctrl) getRequestHashes(requests []*model.Request) []string {
 	return hashes
 }
 
-func (c *Ctrl) deleteRequests(requests []*model.Request) {
+func (c *Ctrl) deleteRequests(requests []*model.Request) error {
 	if len(requests) == 0 {
-		return
+		return nil
 	}
-	
+
 	requestHashes := c.getRequestHashes(requests)
-	err := c.db.DeleteRequestsByHashes(requestHashes)
-	if err != nil {
-		c.logger.Infof("Error deleting requests: %v", err)
+	if err := c.db.DeleteRequestsByHashes(requestHashes); err != nil {
+		c.logger.Errorf("CRITICAL: failed to delete settled requests: %v, hashes: %v", err, requestHashes)
+		return err
 	}
+	return nil
 }
 
-func (c *Ctrl) executeBatches(ctx context.Context, settlements []contract.TEESettlementData) (map[common.Address]SettlementStatus, error) {
-	failures := make(map[common.Address]SettlementStatus)
-	
-	// Process in batches
+// executeBatchesResult holds the results of executing settlement batches
+type executeBatchesResult struct {
+	Results  map[common.Address]*providercontract.SettlementResult
+	TxHashes []common.Hash
+}
+
+func (c *Ctrl) executeBatches(ctx context.Context, settlements []contract.TEESettlementData) (*executeBatchesResult, error) {
+	result := &executeBatchesResult{
+		Results: make(map[common.Address]*providercontract.SettlementResult),
+	}
+	var batchErr error
+
 	for i := 0; i < len(settlements); i += constant.TEESettlementBatchSize {
 		end := i + constant.TEESettlementBatchSize
 		if end > len(settlements) {
 			end = len(settlements)
 		}
-		
+
 		batch := settlements[i:end]
 		c.logger.Infof("Executing settlement batch %d-%d", i+1, end)
-		
-		failedUsers, err := c.contract.SettleFeesWithTEE(ctx, batch)
-		if err != nil {
-			return failures, errors.Wrapf(err, "settlement batch %d-%d failed", i, end-1)
+
+		txHash, batchResults, err := c.contract.SettleFeesWithTEE(ctx, batch)
+		if txHash != (common.Hash{}) {
+			result.TxHashes = append(result.TxHashes, txHash)
 		}
-		
-		for _, user := range failedUsers {
-			failures[user] = SettlementPartial
+		if err != nil {
+			// Mark all users in this and remaining batches as failed
+			for j := i; j < len(settlements); j++ {
+				result.Results[settlements[j].User] = &providercontract.SettlementResult{
+					User:            settlements[j].User,
+					Status:          uint8(SettlementPartial),
+					UnsettledAmount: settlements[j].TotalFee,
+				}
+			}
+			batchErr = errors.Wrapf(err, "settlement batch %d-%d failed", i, end-1)
+			break // Stop sending more batches, but return results so far
+		}
+
+		for _, r := range batchResults {
+			rCopy := r
+			result.Results[r.User] = &rCopy
 		}
 	}
-	
-	return failures, nil
+
+	return result, batchErr
 }
 
 // getUserRequestsForAddress gets all unprocessed requests for a specific user

--- a/api/inference/internal/db/migrate.go
+++ b/api/inference/internal/db/migrate.go
@@ -159,6 +159,44 @@ func (d *DB) Migrate() error {
 				return tx.AutoMigrate(&AsyncJob{})
 			},
 		},
+		{
+			ID: "add-settling-to-request",
+			Migrate: func(tx *gorm.DB) error {
+				type Request struct {
+					Settling bool `gorm:"type:tinyint(1);not null;default:0"`
+				}
+				return tx.AutoMigrate(&Request{})
+			},
+		},
+		{
+			ID: "create-pending-settlement",
+			Migrate: func(tx *gorm.DB) error {
+				type PendingSettlement struct {
+					model.Model
+					ID             uint64     `gorm:"primaryKey;autoIncrement"`
+					TxHash         string     `gorm:"type:varchar(66);index"`
+					UserAddress    string     `gorm:"type:varchar(255);not null;index"`
+					TotalFee       string     `gorm:"type:varchar(255);not null"`
+					Nonce          string     `gorm:"type:varchar(255);not null"`
+					RequestHashes  string     `gorm:"type:text;not null"`
+					Status         string     `gorm:"type:varchar(32);not null;default:'pending';index"`
+					SubmittedBlock uint64     `gorm:"type:bigint unsigned;not null;default:0"`
+					ResolvedAt     *time.Time `gorm:"type:datetime"`
+				}
+				return tx.AutoMigrate(&PendingSettlement{})
+			},
+		},
+		{
+			ID: "create-reconciliation-cursor",
+			Migrate: func(tx *gorm.DB) error {
+				type ReconciliationCursor struct {
+					ID              uint64     `gorm:"primaryKey;autoIncrement"`
+					LastBlockNumber uint64     `gorm:"type:bigint unsigned;not null;default:0"`
+					UpdatedAt       *time.Time
+				}
+				return tx.AutoMigrate(&ReconciliationCursor{})
+			},
+		},
 	})
 
 	return errors.Wrap(m.Migrate(), "migrate database")

--- a/api/inference/internal/db/reconciliation.go
+++ b/api/inference/internal/db/reconciliation.go
@@ -1,0 +1,120 @@
+package db
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/0glabs/0g-serving-broker/inference/model"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// CreatePendingSettlement creates a new pending settlement record
+func (d *DB) CreatePendingSettlement(ps *model.PendingSettlement) error {
+	return d.db.Create(ps).Error
+}
+
+// UpdatePendingSettlementTxHash sets the tx hash after the transaction is submitted
+func (d *DB) UpdatePendingSettlementTxHash(id uint64, txHash string) error {
+	return d.db.Model(&model.PendingSettlement{}).
+		Where("id = ?", id).
+		Update("tx_hash", txHash).Error
+}
+
+// FindPendingSettlementByTxHash finds a pending settlement by tx hash and user.
+// Returns (nil, nil) if no matching record is found — this is expected for events
+// already handled by the primary (Layer 1) settlement flow.
+func (d *DB) FindPendingSettlementByTxHash(txHash string, userAddress string) (*model.PendingSettlement, error) {
+	var ps model.PendingSettlement
+	err := d.db.Session(&gorm.Session{Logger: d.db.Logger.LogMode(logger.Silent)}).
+		Where("tx_hash = ? AND user_address = ? AND status = ?", txHash, userAddress, "pending").
+		First(&ps).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("find pending settlement by tx hash %s user %s: %w", txHash, userAddress, err)
+	}
+	return &ps, nil
+}
+
+// FindStalePendingSettlements finds pending settlements submitted before the given block
+func (d *DB) FindStalePendingSettlements(beforeBlock uint64) ([]model.PendingSettlement, error) {
+	var results []model.PendingSettlement
+	err := d.db.Where("status = ? AND submitted_block <= ?", "pending", beforeBlock).
+		Find(&results).Error
+	if err != nil {
+		return nil, fmt.Errorf("find stale pending settlements before block %d: %w", beforeBlock, err)
+	}
+	return results, nil
+}
+
+// UpdatePendingSettlementStatus updates the status of a pending settlement
+func (d *DB) UpdatePendingSettlementStatus(id uint64, status string) error {
+	now := time.Now()
+	return d.db.Model(&model.PendingSettlement{}).
+		Where("id = ?", id).
+		Updates(map[string]interface{}{
+			"status":      status,
+			"resolved_at": &now,
+		}).Error
+}
+
+// MarkRequestsSettling sets or clears the settling flag for requests
+func (d *DB) MarkRequestsSettling(requestHashes []string, settling bool) error {
+	if len(requestHashes) == 0 {
+		return nil
+	}
+	return d.db.Model(&model.Request{}).
+		Where("request_hash IN ?", requestHashes).
+		Update("settling", settling).Error
+}
+
+// DeleteRequestsByHashesIfExist deletes requests by hashes, ignoring already-deleted ones (idempotent)
+func (d *DB) DeleteRequestsByHashesIfExist(requestHashes []string) error {
+	if len(requestHashes) == 0 {
+		return nil
+	}
+	return d.db.Where("request_hash IN ?", requestHashes).Delete(&model.Request{}).Error
+}
+
+// GetReconciliationCursor returns the current reconciliation cursor
+func (d *DB) GetReconciliationCursor() (*model.ReconciliationCursor, error) {
+	var cursor model.ReconciliationCursor
+	err := d.db.First(&cursor).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			// Create initial cursor
+			cursor = model.ReconciliationCursor{LastBlockNumber: 0}
+			if createErr := d.db.Create(&cursor).Error; createErr != nil {
+				return nil, fmt.Errorf("create initial reconciliation cursor: %w", createErr)
+			}
+			return &cursor, nil
+		}
+		return nil, fmt.Errorf("get reconciliation cursor: %w", err)
+	}
+	return &cursor, nil
+}
+
+// UpdateReconciliationCursor updates the cursor to the given block number
+func (d *DB) UpdateReconciliationCursor(blockNumber uint64) error {
+	now := time.Now()
+	return d.db.Model(&model.ReconciliationCursor{}).
+		Where("1 = 1").
+		Updates(map[string]interface{}{
+			"last_block_number": blockNumber,
+			"updated_at":        &now,
+		}).Error
+}
+
+// GetRequestsByHashes returns requests matching the given hashes
+func (d *DB) GetRequestsByHashes(requestHashes []string) ([]model.Request, error) {
+	if len(requestHashes) == 0 {
+		return nil, nil
+	}
+	var requests []model.Request
+	if err := d.db.Where("request_hash IN ?", requestHashes).Find(&requests).Error; err != nil {
+		return nil, fmt.Errorf("get requests by hashes: %w", err)
+	}
+	return requests, nil
+}

--- a/api/inference/internal/db/request.go
+++ b/api/inference/internal/db/request.go
@@ -27,6 +27,9 @@ func (d *DB) ListRequest(q model.RequestListOptions) ([]model.Request, *big.Int,
 			ret = ret.Where("output_count != ?", 0)
 		}
 
+		// Exclude requests currently being settled on-chain
+		ret = ret.Where("settling = ?", false)
+
 		// Exclude temporarily skipped requests unless explicitly included
 		if !q.IncludeSkipped {
 			now := time.Now()

--- a/api/inference/internal/event/reconciliation_processor.go
+++ b/api/inference/internal/event/reconciliation_processor.go
@@ -1,0 +1,291 @@
+package event
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/0glabs/0g-serving-broker/common/log"
+	"github.com/0glabs/0g-serving-broker/common/util"
+	providercontract "github.com/0glabs/0g-serving-broker/inference/internal/contract"
+	"github.com/0glabs/0g-serving-broker/inference/internal/db"
+	"github.com/0glabs/0g-serving-broker/inference/model"
+)
+
+const (
+	// DefaultConfirmationBlocks is the number of blocks to wait before considering a block finalized.
+	DefaultConfirmationBlocks = uint64(12)
+	// DefaultExpiryBlocks is the number of blocks after which a pending settlement without a matching
+	// on-chain event is considered expired and its requests are released.
+	DefaultExpiryBlocks = uint64(200)
+)
+
+// ReconciliationProcessor scans on-chain TEESettlementResult events and reconciles
+// them against pending_settlement records. This acts as a safety net behind the
+// primary receipt-based settlement flow.
+type ReconciliationProcessor struct {
+	db       *db.DB
+	contract *providercontract.ProviderContract
+	logger   log.Logger
+
+	interval           int    // seconds between scans
+	confirmationBlocks uint64 // blocks to wait for finality
+	expiryBlocks       uint64 // blocks after which a pending settlement is expired
+}
+
+// NewReconciliationProcessor creates a processor that periodically scans on-chain settlement
+// events and reconciles them against local pending_settlement records.
+func NewReconciliationProcessor(
+	db *db.DB,
+	contract *providercontract.ProviderContract,
+	interval int,
+	logger log.Logger,
+) *ReconciliationProcessor {
+	if interval <= 0 {
+		interval = 60
+	}
+	return &ReconciliationProcessor{
+		db:                 db,
+		contract:           contract,
+		logger:             logger,
+		interval:           interval,
+		confirmationBlocks: DefaultConfirmationBlocks,
+		expiryBlocks:       DefaultExpiryBlocks,
+	}
+}
+
+// Start implements the controller-runtime Runnable interface
+func (r *ReconciliationProcessor) Start(ctx context.Context) error {
+	ticker := time.NewTicker(time.Duration(r.interval) * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			r.reconcile(ctx)
+		}
+	}
+}
+
+func (r *ReconciliationProcessor) reconcile(ctx context.Context) {
+	// 1. Get cursor
+	cursor, err := r.db.GetReconciliationCursor()
+	if err != nil {
+		r.logger.Errorf("Reconciliation: failed to get cursor: %v", err)
+		return
+	}
+
+	// 2. Get current block
+	currentBlock, err := r.contract.Contract.Client.Client.BlockNumber(ctx)
+	if err != nil {
+		r.logger.Errorf("Reconciliation: failed to get current block: %v", err)
+		return
+	}
+
+	// 3. Calculate safe block (with confirmation buffer)
+	if currentBlock <= r.confirmationBlocks {
+		return
+	}
+	safeBlock := currentBlock - r.confirmationBlocks
+	if safeBlock <= cursor.LastBlockNumber {
+		return // Nothing new to process
+	}
+
+	fromBlock := cursor.LastBlockNumber + 1
+
+	// 4. Scan events
+	events, err := r.scanEvents(ctx, fromBlock, safeBlock)
+	if err != nil {
+		r.logger.Errorf("Reconciliation: failed to scan events from block %d to %d: %v", fromBlock, safeBlock, err)
+		return
+	}
+
+	if len(events) > 0 {
+		r.logger.Infof("Reconciliation: processing %d events from block %d to %d", len(events), fromBlock, safeBlock)
+	}
+
+	// 5. Process each event
+	for _, evt := range events {
+		r.processEvent(evt)
+	}
+
+	// 6. Expire stale pending settlements
+	if safeBlock > r.expiryBlocks {
+		r.expireStaleSettlements(safeBlock - r.expiryBlocks)
+	}
+
+	// 7. Update cursor
+	if err := r.db.UpdateReconciliationCursor(safeBlock); err != nil {
+		r.logger.Errorf("Reconciliation: failed to update cursor to block %d: %v", safeBlock, err)
+	}
+}
+
+func (r *ReconciliationProcessor) scanEvents(ctx context.Context, fromBlock, toBlock uint64) ([]settlementEvent, error) {
+	filterOpts := &bind.FilterOpts{
+		Start:   fromBlock,
+		End:     &toBlock,
+		Context: ctx,
+	}
+
+	iter, err := r.contract.Contract.FilterTEESettlementResult(filterOpts, nil)
+	if err != nil {
+		return nil, fmt.Errorf("filter TEESettlementResult events from block %d to %d: %w", fromBlock, toBlock, err)
+	}
+	defer iter.Close()
+
+	var events []settlementEvent
+	for iter.Next() {
+		events = append(events, settlementEvent{
+			User:            iter.Event.User,
+			Status:          iter.Event.Status,
+			UnsettledAmount: iter.Event.UnsettledAmount,
+			TxHash:          iter.Event.Raw.TxHash,
+		})
+	}
+	return events, iter.Error()
+}
+
+type settlementEvent struct {
+	User            common.Address
+	Status          uint8
+	UnsettledAmount *big.Int
+	TxHash          common.Hash
+}
+
+func (r *ReconciliationProcessor) processEvent(evt settlementEvent) {
+	txHash := evt.TxHash.Hex()
+	userAddr := evt.User.Hex()
+
+	// Find matching pending settlement
+	pending, err := r.db.FindPendingSettlementByTxHash(txHash, userAddr)
+	if err != nil {
+		r.logger.Errorf("Reconciliation: error finding pending settlement for tx %s user %s: %v", txHash, userAddr, err)
+		return
+	}
+	if pending == nil {
+		return // No matching record -- already handled by Layer 1 or not our tx
+	}
+
+	var requestHashes []string
+	if err := json.Unmarshal([]byte(pending.RequestHashes), &requestHashes); err != nil {
+		r.logger.Errorf("Reconciliation: failed to unmarshal request hashes for pending %d: %v", pending.ID, err)
+		return
+	}
+
+	switch evt.Status {
+	case 0: // SUCCESS
+		// Delete requests (idempotent -- Layer 1 may have already done this)
+		if err := r.db.DeleteRequestsByHashesIfExist(requestHashes); err != nil {
+			r.logger.Errorf("Reconciliation: failed to delete requests for tx %s: %v", txHash, err)
+			return
+		}
+		if err := r.db.UpdatePendingSettlementStatus(pending.ID, "confirmed"); err != nil {
+			r.logger.Errorf("Reconciliation: failed to update status for pending %d: %v", pending.ID, err)
+		}
+		r.logger.Infof("Reconciliation: confirmed settlement for user %s (tx %s), %d requests",
+			userAddr, txHash, len(requestHashes))
+
+	case 1: // PARTIAL
+		r.handlePartialEvent(pending, requestHashes, evt.UnsettledAmount)
+		if err := r.db.UpdatePendingSettlementStatus(pending.ID, "confirmed"); err != nil {
+			r.logger.Errorf("Reconciliation: failed to update status for pending %d: %v", pending.ID, err)
+		}
+		r.logger.Infof("Reconciliation: confirmed partial settlement for user %s (tx %s)", userAddr, txHash)
+
+	default: // FAILURE (status 2-5)
+		// Clear settling state so requests become available again
+		if err := r.db.MarkRequestsSettling(requestHashes, false); err != nil {
+			r.logger.Errorf("Reconciliation: failed to clear settling state for tx %s: %v", txHash, err)
+			return
+		}
+		if err := r.db.UpdatePendingSettlementStatus(pending.ID, "failed"); err != nil {
+			r.logger.Errorf("Reconciliation: failed to update status for pending %d: %v", pending.ID, err)
+		}
+		r.logger.Infof("Reconciliation: settlement failed for user %s (tx %s, status %d)",
+			userAddr, txHash, evt.Status)
+	}
+}
+
+func (r *ReconciliationProcessor) handlePartialEvent(
+	pending *model.PendingSettlement,
+	requestHashes []string,
+	unsettledAmount *big.Int,
+) {
+	totalFee, ok := new(big.Int).SetString(pending.TotalFee, 10)
+	if !ok {
+		r.logger.Errorf("Reconciliation: invalid totalFee %s for pending %d", pending.TotalFee, pending.ID)
+		return
+	}
+	settledAmount := new(big.Int).Sub(totalFee, unsettledAmount)
+
+	// Load requests that still exist in DB
+	requests, err := r.db.GetRequestsByHashes(requestHashes)
+	if err != nil || len(requests) == 0 {
+		return // Already handled
+	}
+
+	// Determine which requests fit within the settled amount
+	accumulated := big.NewInt(0)
+	var settledHashes, unsettledHashes []string
+
+	for _, req := range requests {
+		fee, feeErr := util.ConvertToBigInt(req.Fee)
+		if feeErr != nil {
+			unsettledHashes = append(unsettledHashes, req.RequestHash)
+			continue
+		}
+		if new(big.Int).Add(accumulated, fee).Cmp(settledAmount) <= 0 {
+			accumulated.Add(accumulated, fee)
+			settledHashes = append(settledHashes, req.RequestHash)
+		} else {
+			unsettledHashes = append(unsettledHashes, req.RequestHash)
+		}
+	}
+
+	// Delete settled requests, clear settling flag for unsettled ones
+	if len(settledHashes) > 0 {
+		if err := r.db.DeleteRequestsByHashesIfExist(settledHashes); err != nil {
+			r.logger.Errorf("Reconciliation: failed to delete settled requests for pending %d: %v", pending.ID, err)
+		}
+	}
+	if len(unsettledHashes) > 0 {
+		if err := r.db.MarkRequestsSettling(unsettledHashes, false); err != nil {
+			r.logger.Errorf("Reconciliation: failed to clear settling for unsettled requests for pending %d: %v", pending.ID, err)
+		}
+	}
+}
+
+func (r *ReconciliationProcessor) expireStaleSettlements(beforeBlock uint64) {
+	stale, err := r.db.FindStalePendingSettlements(beforeBlock)
+	if err != nil {
+		r.logger.Errorf("Reconciliation: failed to find stale settlements: %v", err)
+		return
+	}
+
+	for _, ps := range stale {
+		var requestHashes []string
+		if err := json.Unmarshal([]byte(ps.RequestHashes), &requestHashes); err != nil {
+			r.logger.Errorf("Reconciliation: failed to unmarshal hashes for stale pending %d: %v", ps.ID, err)
+			continue
+		}
+
+		if err := r.db.MarkRequestsSettling(requestHashes, false); err != nil {
+			r.logger.Errorf("Reconciliation: failed to clear settling for stale pending %d: %v", ps.ID, err)
+			continue
+		}
+
+		if err := r.db.UpdatePendingSettlementStatus(ps.ID, "expired"); err != nil {
+			r.logger.Errorf("Reconciliation: failed to update status for stale pending %d: %v", ps.ID, err)
+			continue
+		}
+		r.logger.Warnf("Reconciliation: expired stale settlement for user %s (submitted block %d, threshold %d)",
+			ps.UserAddress, ps.SubmittedBlock, beforeBlock)
+	}
+}

--- a/api/inference/model/pending_settlement.go
+++ b/api/inference/model/pending_settlement.go
@@ -1,0 +1,25 @@
+package model
+
+import "time"
+
+// PendingSettlement tracks settlement transactions sent to the blockchain.
+// Used by the reconciliation system to verify on-chain results against local state.
+type PendingSettlement struct {
+	Model
+	ID             uint64     `gorm:"primaryKey;autoIncrement" json:"id"`
+	TxHash         string     `gorm:"type:varchar(66);index" json:"txHash"`
+	UserAddress    string     `gorm:"type:varchar(255);not null;index" json:"userAddress"`
+	TotalFee       string     `gorm:"type:varchar(255);not null" json:"totalFee"`
+	Nonce          string     `gorm:"type:varchar(255);not null" json:"nonce"`
+	RequestHashes  string     `gorm:"type:text;not null" json:"requestHashes"`
+	Status         string     `gorm:"type:varchar(32);not null;default:'pending';index" json:"status"`
+	SubmittedBlock uint64     `gorm:"type:bigint unsigned;not null;default:0" json:"submittedBlock"`
+	ResolvedAt     *time.Time `gorm:"type:datetime" json:"resolvedAt,omitempty"`
+}
+
+// ReconciliationCursor tracks the last processed block for event scanning.
+type ReconciliationCursor struct {
+	ID              uint64     `gorm:"primaryKey;autoIncrement" json:"id"`
+	LastBlockNumber uint64     `gorm:"type:bigint unsigned;not null;default:0" json:"lastBlockNumber"`
+	UpdatedAt       *time.Time `json:"updatedAt,omitempty"`
+}

--- a/api/inference/model/request.go
+++ b/api/inference/model/request.go
@@ -20,6 +20,9 @@ type Request struct {
 	OutputCount  int64      `gorm:"type:bigint;not null;default:0" json:"outputCount"`
 	// Skip this request in settlement until this time
 	SkipUntil    *time.Time `gorm:"type:datetime;index" json:"skipUntil,omitempty"`
+	// Settling indicates the request is currently being settled on-chain
+	// and should not be included in another settlement batch
+	Settling bool `gorm:"type:tinyint(1);not null;default:0" json:"settling"`
 	// IsWhitelisted indicates if this request is from a whitelisted user.
 	// Whitelisted users receive full response processing (stream handling, TEE signing)
 	// but bypass billing/settlement operations.


### PR DESCRIPTION
- Fix adjustForPartialSettlement to re-sign with TEE after modifying RequestsHash/TotalFee, preventing INVALID_SIGNATURE failures
- Add receipt recovery when WaitForReceipt times out but tx was mined
- Propagate deleteRequests errors instead of silently swallowing them
- Ensure processOutcomes always runs even if executeBatches partially fails
- Handle on-chain PARTIAL (status=1) by settling the correct request subset instead of treating it as complete failure
- Add Layer 2 event-based reconciliation processor as safety net: pending_settlement tracking, settling flag, on-chain event scanning
- Return tx hash from contract SettleFeesWithTEE for reconciliation matching