### PR TITLE
feat: add per-user RPM rate limiting and billing resilience for clien…

### DIFF
--- a/api/common/middleware/concurrency.go
+++ b/api/common/middleware/concurrency.go
@@ -56,6 +56,8 @@ func (cl *ConcurrencyLimiter) GetActive() int64 {
 func ConcurrencyLimitMiddleware(limiter *ConcurrencyLimiter) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if !limiter.Acquire() {
+			// Mark as expected so metrics don't count capacity limiting as a service error
+			c.Set("ignoreError", true)
 			c.JSON(http.StatusServiceUnavailable, gin.H{
 				"error": "Server is currently processing too many requests. Please try again later.",
 			})

--- a/api/common/middleware/per_user_concurrency.go
+++ b/api/common/middleware/per_user_concurrency.go
@@ -70,6 +70,8 @@ func CheckPerUserConcurrency(limiter *PerUserConcurrencyLimiter, c *gin.Context,
 
 	if !limiter.Acquire(userAddress) {
 		active := limiter.GetActiveForUser(userAddress)
+		// Mark as expected so metrics don't count concurrency limiting as a service error
+		c.Set("ignoreError", true)
 		c.JSON(http.StatusTooManyRequests, gin.H{
 			"error": fmt.Sprintf(
 				"Too many concurrent requests. You have %d active requests (limit: %d). Please wait for some to complete.",

--- a/api/common/middleware/per_user_ratelimit.go
+++ b/api/common/middleware/per_user_ratelimit.go
@@ -1,0 +1,91 @@
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"golang.org/x/time/rate"
+)
+
+// PerUserRateLimiter enforces a requests-per-minute limit for each user address.
+// This is the primary defense against cancel-retry abuse, where an attacker
+// sends requests and immediately cancels them to waste GPU resources.
+// Unlike concurrency limits (which only cap simultaneous in-flight requests),
+// rate limits cap the total request throughput per user over time.
+type PerUserRateLimiter struct {
+	limiters map[string]*rate.Limiter
+	mu       sync.Mutex
+	rate     rate.Limit // tokens per second
+	burst    int        // max burst size
+}
+
+// NewPerUserRateLimiter creates a per-user rate limiter.
+// rpm: maximum requests per minute per user.
+// burst: maximum burst size (requests allowed in a short spike).
+func NewPerUserRateLimiter(rpm int, burst int) *PerUserRateLimiter {
+	rl := &PerUserRateLimiter{
+		limiters: make(map[string]*rate.Limiter),
+		rate:     rate.Limit(float64(rpm) / 60.0), // convert RPM to per-second
+		burst:    burst,
+	}
+
+	go rl.cleanup()
+
+	return rl
+}
+
+// cleanup periodically removes idle user entries to prevent memory growth.
+func (rl *PerUserRateLimiter) cleanup() {
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		rl.mu.Lock()
+		for userID, limiter := range rl.limiters {
+			// Remove users whose bucket is full (idle)
+			if limiter.Tokens() >= float64(rl.burst) {
+				delete(rl.limiters, userID)
+			}
+		}
+		rl.mu.Unlock()
+	}
+}
+
+// Allow checks whether the user is within their rate limit.
+// Returns true if the request is allowed, false if rate limited.
+func (rl *PerUserRateLimiter) Allow(userID string) bool {
+	rl.mu.Lock()
+	limiter, exists := rl.limiters[userID]
+	if !exists {
+		limiter = rate.NewLimiter(rl.rate, rl.burst)
+		rl.limiters[userID] = limiter
+	}
+	rl.mu.Unlock()
+
+	return limiter.Allow()
+}
+
+// CheckPerUserRateLimit checks per-user rate limit after user address is known.
+// Returns true if allowed, false if rate limited (response already written).
+func CheckPerUserRateLimit(limiter *PerUserRateLimiter, c *gin.Context, userAddress string) bool {
+	if limiter == nil {
+		return true
+	}
+
+	if !limiter.Allow(userAddress) {
+		// Mark as expected so metrics don't count rate limiting as a service error
+		c.Set("ignoreError", true)
+		c.JSON(http.StatusTooManyRequests, gin.H{
+			"error": fmt.Sprintf(
+				"Rate limit exceeded. Please slow down your request rate (limit: %.0f requests/min).",
+				float64(limiter.rate)*60,
+			),
+		})
+		c.Abort()
+		return false
+	}
+	return true
+}

--- a/api/inference/config/config.go
+++ b/api/inference/config/config.go
@@ -159,6 +159,8 @@ type Config struct {
 type ConcurrencyLimitConfig struct {
 	MaxGlobalConcurrent  int `yaml:"maxGlobalConcurrent"`  // Max total concurrent requests to backend (default: 20)
 	MaxPerUserConcurrent int `yaml:"maxPerUserConcurrent"` // Max concurrent requests per user (default: 5, whitelisted users are exempt)
+	PerUserRPM           int `yaml:"perUserRPM"`           // Max requests per minute per user (default: 40, 0 = disabled)
+	PerUserBurst         int `yaml:"perUserBurst"`          // Max burst size for per-user rate limit (default: 10)
 }
 
 // AsyncConfig defines configuration for async job processing.
@@ -348,6 +350,8 @@ func GetConfig() *Config {
 				ConcurrencyLimit: ConcurrencyLimitConfig{
 				MaxGlobalConcurrent:  20,
 				MaxPerUserConcurrent: 5,
+				PerUserRPM:           30,
+				PerUserBurst:         5,
 			},
 			Async: AsyncConfig{
 				Enabled:                true,

--- a/api/inference/internal/ctrl/chatbot.go
+++ b/api/inference/internal/ctrl/chatbot.go
@@ -109,16 +109,29 @@ func (c *Ctrl) handleChargingResponse(ctx *gin.Context, resp *http.Response, acc
 		ctx.Writer.Header().Set("ZG-Res-Key", chatKey)
 	}
 
-	var rawBody bytes.Buffer
-	reader := bufio.NewReader(io.TeeReader(resp.Body, &rawBody))
-
-	_, err := reader.WriteTo(ctx.Writer)
+	// Read the full response body first to ensure complete data for billing,
+	// regardless of whether the client is still connected.
+	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		c.handleBrokerError(ctx, err, "read from body")
 		return err
 	}
 
-	if err := c.decodeAndProcess(ctx, rawBody.Bytes(), resp.Header.Get("Content-Encoding"), account, outputPrice, false, reqBody, reqModel, rawBody.Bytes(), chatKey); err != nil {
+	// Attempt to write the response to the client. If the client has already
+	// disconnected (broken pipe, connection reset), log a warning but continue
+	// to billing so GPU work is not wasted without payment.
+	if _, writeErr := ctx.Writer.Write(respBody); writeErr != nil {
+		if c.isClientDisconnectError(writeErr) {
+			ctx.Set("ignoreError", true)
+			c.logger.Warnf("Client disconnected during non-streaming response, billing for completed response (%d bytes)", len(respBody))
+		} else {
+			c.handleBrokerError(ctx, writeErr, "write response body")
+			// Still proceed to billing below
+		}
+	}
+
+	// Always process billing regardless of client connection state
+	if err := c.decodeAndProcess(ctx, respBody, resp.Header.Get("Content-Encoding"), account, outputPrice, false, reqBody, reqModel, respBody, chatKey); err != nil {
 		c.logger.Errorf("decode and process failed: %v", err)
 		return err
 	}

--- a/api/inference/internal/ctrl/proxy.go
+++ b/api/inference/internal/ctrl/proxy.go
@@ -2,6 +2,7 @@ package ctrl
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -62,9 +63,13 @@ func (c *Ctrl) PrepareHTTPRequest(ctx *gin.Context, targetURL string, reqBody []
 	if len(reqBody) > 0 {
 		body = bytes.NewBuffer(reqBody)
 	}
-	// Use request context to support client cancellation
-	// This ensures that if the client disconnects, the backend request is also cancelled
-	req, err := http.NewRequestWithContext(ctx.Request.Context(), ctx.Request.Method, targetURL, body)
+	// Use a server-side context decoupled from the client connection.
+	// This prevents client disconnection from canceling backend GPU computation,
+	// ensuring we always receive the response for accurate billing.
+	// The HTTP client's own Timeout (10min) and ResponseHeaderTimeout (5min)
+	// still apply as safety bounds. Rate limiting (RPM/TPM) is the primary
+	// defense against cancel-retry abuse.
+	req, err := http.NewRequestWithContext(context.Background(), ctx.Request.Method, targetURL, body)
 	if err != nil {
 		return nil, err
 	}
@@ -110,8 +115,8 @@ func (c *Ctrl) ProcessHTTPRequest(ctx *gin.Context, svcType string, req *http.Re
 		if strings.Contains(ctx.Request.RequestURI, "/api/event_logging/batch") {
 			ctx.Set("ignoreError", true)
 		}
-		// Skip error logging for context canceled errors (client-side cancellations)
-		// These are normal when users close browser, refresh page, or lose connection
+		// With server-side context, context canceled errors should only occur
+		// on HTTP client timeout, not client disconnection.
 		if strings.Contains(err.Error(), "context canceled") {
 			ctx.Set("ignoreError", true)
 		}
@@ -410,3 +415,4 @@ func (c *Ctrl) EnforceConfiguredModel(body []byte, userAddr string) ([]byte, err
 
 	return modifiedBody, nil
 }
+

--- a/api/inference/internal/ctrl/speech_to_text.go
+++ b/api/inference/internal/ctrl/speech_to_text.go
@@ -78,10 +78,15 @@ func (c *Ctrl) handleNonStreamingSpeechToText(ctx *gin.Context, resp *http.Respo
 		return err
 	}
 
-	// Write raw response to client first
-	if _, err := ctx.Writer.Write(body); err != nil {
-		c.handleBrokerError(ctx, err, "write transcription response")
-		return err
+	// Attempt to write raw response to client. If client disconnected, continue to billing.
+	if _, writeErr := ctx.Writer.Write(body); writeErr != nil {
+		if c.isClientDisconnectError(writeErr) {
+			ctx.Set("ignoreError", true)
+			c.logger.Warnf("Client disconnected during speech-to-text response, billing for completed response (%d bytes)", len(body))
+		} else {
+			c.handleBrokerError(ctx, writeErr, "write transcription response")
+			// Still proceed to billing below
+		}
 	}
 
 	// Decompress body if needed for parsing
@@ -147,6 +152,9 @@ func (c *Ctrl) handleStreamingSpeechToText(ctx *gin.Context, resp *http.Response
 	var rawBody bytes.Buffer
 	var usage *SpeechToTextUsage
 	var streamErr error
+	var clientDisconnected bool
+	var silentReadBytes int64
+	const maxSilentReadBytes int64 = 10 * 1024 * 1024 // 10MB limit to prevent abuse
 
 	ctx.Stream(func(w io.Writer) bool {
 		// Apply decompression if needed
@@ -174,14 +182,31 @@ func (c *Ctrl) handleStreamingSpeechToText(ctx *gin.Context, resp *http.Response
 				}
 			}
 
-			// Write line to client
-			_, streamErr = w.Write(line)
-			if streamErr != nil {
-				c.handleBrokerError(ctx, streamErr, "write to stream")
-				return false
+			// Only write to client if still connected
+			if !clientDisconnected {
+				_, streamErr = w.Write(line)
+				if streamErr != nil {
+					if c.isClientDisconnectError(streamErr) {
+						ctx.Set("ignoreError", true)
+						clientDisconnected = true
+						c.logger.Warnf("Client disconnected during speech-to-text stream, continuing to read for billing")
+					} else {
+						c.handleBrokerError(ctx, streamErr, "write to stream")
+						return false
+					}
+				} else {
+					ctx.Writer.Flush()
+				}
 			}
 
-			ctx.Writer.Flush()
+			// If client disconnected, count silent read bytes and check limit
+			if clientDisconnected {
+				silentReadBytes += int64(len(line))
+				if silentReadBytes > maxSilentReadBytes {
+					c.logger.Warnf("Reached max silent read limit (%d bytes), stopping", maxSilentReadBytes)
+					return false
+				}
+			}
 
 			// Check if stream is done
 			if chunk.Type == "transcript.text.done" {
@@ -189,10 +214,6 @@ func (c *Ctrl) handleStreamingSpeechToText(ctx *gin.Context, resp *http.Response
 			}
 		}
 	})
-
-	if streamErr != nil {
-		return streamErr
-	}
 
 	// Sign response if needed
 	if !c.Service.TargetSeparated {

--- a/api/inference/internal/ctrl/text_to_image.go
+++ b/api/inference/internal/ctrl/text_to_image.go
@@ -48,10 +48,15 @@ func (c *Ctrl) handleTextToImageResponse(ctx *gin.Context, resp *http.Response, 
 		return err
 	}
 
-	// Return image to client
-	if _, err := ctx.Writer.Write(body); err != nil {
-		c.handleBrokerError(ctx, err, "write image response")
-		return err
+	// Attempt to return image to client. If client disconnected, continue to billing.
+	if _, writeErr := ctx.Writer.Write(body); writeErr != nil {
+		if c.isClientDisconnectError(writeErr) {
+			ctx.Set("ignoreError", true)
+			c.logger.Warnf("Client disconnected during text-to-image response, billing for completed response (%d bytes)", len(body))
+		} else {
+			c.handleBrokerError(ctx, writeErr, "write image response")
+			// Still proceed to billing below
+		}
 	}
 
 	if !c.Service.TargetSeparated {

--- a/api/inference/internal/proxy/proxy.go
+++ b/api/inference/internal/proxy/proxy.go
@@ -36,6 +36,7 @@ type Proxy struct {
 	rateLimiter               *middleware.RateLimiter
 	concurrencyLimiter        *middleware.ConcurrencyLimiter
 	perUserConcurrencyLimiter *middleware.PerUserConcurrencyLimiter
+	perUserRateLimiter        *middleware.PerUserRateLimiter
 }
 
 func New(ctrl *ctrl.Ctrl, engine *gin.Engine, allowOrigins []string, enableMonitor bool, concurrencyConfig config.ConcurrencyLimitConfig, logger log.Logger) *Proxy {
@@ -62,6 +63,16 @@ func New(ctrl *ctrl.Ctrl, engine *gin.Engine, allowOrigins []string, enableMonit
 		// Configure concurrency limiter to match backend GPU capacity
 		concurrencyLimiter:        middleware.NewConcurrencyLimiter(concurrencyConfig.MaxGlobalConcurrent),
 		perUserConcurrencyLimiter: middleware.NewPerUserConcurrencyLimiter(concurrencyConfig.MaxPerUserConcurrent),
+	}
+
+	// Initialize per-user rate limiter if configured
+	if concurrencyConfig.PerUserRPM > 0 {
+		burst := concurrencyConfig.PerUserBurst
+		if burst <= 0 {
+			burst = 10
+		}
+		p.perUserRateLimiter = middleware.NewPerUserRateLimiter(concurrencyConfig.PerUserRPM, burst)
+		logger.Infof("Per-user rate limit: %d RPM, burst=%d", concurrencyConfig.PerUserRPM, burst)
 	}
 
 	logger.Infof("Concurrency limits: global=%d, per-user=%d",
@@ -238,10 +249,15 @@ func (p *Proxy) proxyHTTPRequest(ctx *gin.Context) {
 	// Check if user is whitelisted (checked early to skip per-user concurrency limit)
 	isWhitelisted := p.ctrl.IsWhitelistedUser(userAddress)
 
-	// Apply per-user concurrency limit only for non-whitelisted users.
+	// Apply per-user rate limit and concurrency limit for non-whitelisted users.
 	// Whitelisted users (internal services, monitoring) are exempt to avoid
 	// blocking critical operations, but still subject to the global limit.
+	// Rate limit is checked first (cheap, no slot to release) before concurrency.
 	if !isWhitelisted {
+		if !middleware.CheckPerUserRateLimit(p.perUserRateLimiter, ctx, userAddress) {
+			p.logger.Warnf("Per-user rate limit exceeded: user=%s", userAddress)
+			return
+		}
 		if !middleware.CheckPerUserConcurrency(p.perUserConcurrencyLimiter, ctx, userAddress) {
 			p.logger.Warnf("Per-user concurrency limit reached: user=%s, active=%d",
 				userAddress, p.perUserConcurrencyLimiter.GetActiveForUser(userAddress))


### PR DESCRIPTION
…t disconnection

- Add per-user RPM rate limiter (default 30 RPM, burst 5) to prevent cancel-retry abuse where attackers waste GPU without paying
- Use server-side context (context.Background) for backend HTTP requests so client disconnection doesn't cancel GPU computation, ensuring accurate billing from completed responses
- Make all response handlers (chatbot, text-to-image, speech-to-text) resilient to client disconnect: continue reading and billing even if client is gone
- Exclude rate limit and concurrency limit rejections from error metrics (ignoreError) since they are expected flow control, not service errors