### PR TITLE
fix: add settlement resilience for event service restart and TEE sign…

### DIFF
--- a/api/inference/const/const.go
+++ b/api/inference/const/const.go
@@ -63,7 +63,7 @@ var (
 	// TEE settlement batch size to avoid gas limit issues
 	TEESettlementBatchSize = 50
 
-	SkipUntilDuration = 8 * time.Hour
+	SkipUntilDuration = 1 * time.Hour
 
 	// EIP-712 constants matching the contract
 	// DOMAIN_TYPEHASH = keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)")

--- a/api/inference/internal/ctrl/request.go
+++ b/api/inference/internal/ctrl/request.go
@@ -331,6 +331,19 @@ func (c *Ctrl) ValidateRequestWithEstimatedFee(ctx *gin.Context, req model.Reque
 		return err
 	}
 
+	// Cross-check DB lockBalance against the contract account balance we already fetched.
+	// The DB lockBalance can become stale (e.g., after settlement deducts fees on-chain
+	// but DB isn't synced yet). Use the lesser of the two to prevent over-spending.
+	contractLockBalance := new(big.Int).Sub(contractAccount.Balance, contractAccount.PendingRefund)
+	if account.LockBalance != nil {
+		dbBalance, ok := new(big.Int).SetString(*account.LockBalance, 10)
+		if ok && dbBalance.Cmp(contractLockBalance) > 0 {
+			// DB balance is higher than contract balance — DB is stale, use contract value
+			corrected := contractLockBalance.String()
+			account.LockBalance = &corrected
+		}
+	}
+
 	// Use estimated fee for validation
 	err = c.validateBalanceAdequacy(ctx, account, estimatedFee)
 	if err != nil {

--- a/api/inference/internal/ctrl/settlement_tee.go
+++ b/api/inference/internal/ctrl/settlement_tee.go
@@ -134,7 +134,25 @@ func (c *Ctrl) ProcessSettlement(ctx context.Context) error {
 	return errors.Wrap(c.SettleFeesWithTEE(ctx), "settle fees with TEE")
 }
 
-// SettleFeesWithTEE implements the optimized settlement logic
+// ResetSettlementState clears settling flags and skip_until for all
+// pending requests and users. Call this on startup to allow all
+// pending requests to be retried immediately.
+func (c *Ctrl) ResetSettlementState() error {
+	return c.db.ResetSettlementState()
+}
+
+// IsTeeSignerAcknowledged checks whether the TEE signer is acknowledged
+// on-chain for this provider's service.
+func (c *Ctrl) IsTeeSignerAcknowledged(ctx context.Context) bool {
+	svc, err := c.contract.GetService(ctx)
+	if err != nil {
+		c.logger.Warnf("Failed to check TEE signer status: %v", err)
+		return false
+	}
+	return svc.TeeSignerAcknowledged
+}
+
+// SettleFeesWithTEE implements the optimized settlement logic.
 func (c *Ctrl) SettleFeesWithTEE(ctx context.Context) error {
 	// Clear expired skipUntil flags for both requests and users
 	if err := c.db.ClearExpiredSkipUntil(); err != nil {
@@ -188,6 +206,27 @@ func (c *Ctrl) SettleFeesWithTEE(ctx context.Context) error {
 
 		// Process outcomes (delete/skip requests) — runs even if execution had partial errors
 		c.processOutcomes(batch.Outcomes)
+
+		// Sync user balances from contract AFTER settlement execution.
+		// Settlement deducts fees on-chain, so the DB lockBalance is now stale
+		// (it was synced before settlement). Without this sync, the balance check
+		// in ValidateRequestWithEstimatedFee uses the pre-settlement balance,
+		// allowing users to accumulate more unsettled fees than their actual balance.
+		if len(batch.ExecutableItems) > 0 {
+			settledUsers := make([]string, 0)
+			for _, outcome := range batch.Outcomes {
+				if outcome.Status == SettlementSuccess || outcome.Status == SettlementPartial {
+					settledUsers = append(settledUsers, outcome.User.Hex())
+				}
+			}
+			if len(settledUsers) > 0 {
+				if err := c.SyncUserAccountsByAddresses(ctx, settledUsers); err != nil {
+					c.logger.Warnf("Failed to sync user balances after settlement: %v", err)
+				} else {
+					c.logger.Infof("Synced %d user balances after settlement", len(settledUsers))
+				}
+			}
+		}
 
 		if execErr != nil {
 			return errors.Wrap(execErr, "execute settlement batch")

--- a/api/inference/internal/db/reconciliation.go
+++ b/api/inference/internal/db/reconciliation.go
@@ -60,6 +60,26 @@ func (d *DB) UpdatePendingSettlementStatus(id uint64, status string) error {
 		}).Error
 }
 
+// ResetSettlementState clears settling flags and skip_until for all unprocessed requests
+// and all user-level skip_until flags.
+// This should be called on startup to recover from incomplete settlements
+// and allow all pending requests to be retried immediately.
+func (d *DB) ResetSettlementState() error {
+	if err := d.db.Model(&model.Request{}).
+		Where("processed = ?", false).
+		Where("settling = ? OR skip_until IS NOT NULL", true).
+		Updates(map[string]interface{}{
+			"settling":   false,
+			"skip_until": nil,
+		}).Error; err != nil {
+		return err
+	}
+
+	return d.db.Model(&model.User{}).
+		Where("skip_until IS NOT NULL").
+		Update("skip_until", nil).Error
+}
+
 // MarkRequestsSettling sets or clears the settling flag for requests
 func (d *DB) MarkRequestsSettling(requestHashes []string, settling bool) error {
 	if len(requestHashes) == 0 {

--- a/api/inference/internal/event/settlement_processor.go
+++ b/api/inference/internal/event/settlement_processor.go
@@ -2,6 +2,7 @@ package event
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -18,7 +19,10 @@ type SettlementProcessor struct {
 	checkSettleInterval int
 	forceSettleInterval int
 
-	enableMonitor bool
+	enableMonitor      bool
+	settleMu           sync.Mutex
+	teeSignerReady     bool
+	teeSignerReadyOnce sync.Once
 }
 
 func NewSettlementProcessor(ctrl *ctrl.Ctrl, checkSettleInterval, forceSettleInterval int, enableMonitor bool, logger log.Logger) *SettlementProcessor {
@@ -33,7 +37,13 @@ func NewSettlementProcessor(ctrl *ctrl.Ctrl, checkSettleInterval, forceSettleInt
 }
 
 // Start implements controller-runtime/pkg/manager.Runnable interface
-func (s SettlementProcessor) Start(ctx context.Context) error {
+func (s *SettlementProcessor) Start(ctx context.Context) error {
+	// Reset settlement state (settling flags + skip_until) so all pending
+	// requests are eligible for immediate settlement after restart
+	if err := s.ctrl.ResetSettlementState(); err != nil {
+		s.logger.Errorf("Failed to reset settlement state on startup: %s", err.Error())
+	}
+
 	checkSettleTicker := time.NewTicker(time.Duration(s.checkSettleInterval) * time.Second)
 	forceSettleTicker := time.NewTicker(time.Duration(s.forceSettleInterval) * time.Second)
 	defer checkSettleTicker.Stop()
@@ -51,7 +61,31 @@ func (s SettlementProcessor) Start(ctx context.Context) error {
 	}
 }
 
+// ensureTeeSignerReady checks if the TEE signer is acknowledged on-chain.
+// Returns false if not ready, skipping settlement to prevent NO_TEE_SIGNER
+// permanent failures that would delete all pending requests.
+func (s *SettlementProcessor) ensureTeeSignerReady(ctx context.Context) bool {
+	if s.teeSignerReady {
+		return true
+	}
+	if s.ctrl.IsTeeSignerAcknowledged(ctx) {
+		s.teeSignerReadyOnce.Do(func() {
+			s.logger.Info("TEE signer acknowledged, settlement enabled")
+		})
+		s.teeSignerReady = true
+		return true
+	}
+	s.logger.Debug("TEE signer not yet acknowledged, skipping settlement")
+	return false
+}
+
 func (s *SettlementProcessor) handleCheckSettle(ctx context.Context) {
+	s.settleMu.Lock()
+	defer s.settleMu.Unlock()
+
+	if !s.ensureTeeSignerReady(ctx) {
+		return
+	}
 	if err := s.ctrl.ProcessSettlement(ctx); err != nil {
 		s.incrementMonitorCounter(monitor.EventSettleErrorCount, "Process settlement: %s", err)
 	} else {
@@ -60,6 +94,12 @@ func (s *SettlementProcessor) handleCheckSettle(ctx context.Context) {
 }
 
 func (s *SettlementProcessor) handleForceSettle(ctx context.Context) {
+	s.settleMu.Lock()
+	defer s.settleMu.Unlock()
+
+	if !s.ensureTeeSignerReady(ctx) {
+		return
+	}
 	s.logger.Info("Force Settlement")
 	if err := s.ctrl.SettleFeesWithTEE(ctx); err != nil {
 		s.incrementMonitorCounter(monitor.EventForceSettleErrorCount, "Process settlement: %s", err)


### PR DESCRIPTION
…er readiness

- Reset settling/skip_until flags on event startup to recover stuck requests
- Gate all settlement paths on TEE signer acknowledgement to prevent NO_TEE_SIGNER permanent failures that delete pending requests
- Add mutex to prevent concurrent settlement execution
- Sync user balances from contract after settlement to prevent stale DB
- Cross-check DB lockBalance against contract balance to prevent over-spending
- Reduce SkipUntilDuration from 8h to 1h for faster retry
- Fix value receiver on Start() to pointer receiver for correct mutex sharing