### PR TITLE
feat(inference): set provider reservation and minimum deposit to 5 tokens

### DIFF
--- a/api/inference/const/const.go
+++ b/api/inference/const/const.go
@@ -50,12 +50,6 @@ var (
 	// Should align with the topUpTriggerThreshold in the client sdk
 	SettleTriggerThreshold = int64(1000000)
 
-	// Response fee reservation factor for balance adequacy validation:  chatbot, speech-to-text,
-	ResponseFeeReservationFactor = int64(1000000)
-
-	// Response fee reservation factor for balance adequacy validation: text-to-image
-	ResponseFeeReservationFactorForImage = int64(100)
-
 	// MinimumLockedBalance is the fixed minimum locked balance required for all service types (5 0G in neuron).
 	// This replaces the dynamic per-service-type calculation in balance adequacy validation.
 	MinimumLockedBalance = "5000000000000000000"

--- a/api/inference/internal/ctrl/request.go
+++ b/api/inference/internal/ctrl/request.go
@@ -15,7 +15,6 @@ import (
 	"github.com/patrickmn/go-cache"
 
 	"github.com/0glabs/0g-serving-broker/common/errors"
-	"github.com/0glabs/0g-serving-broker/common/util"
 	constant "github.com/0glabs/0g-serving-broker/inference/const"
 	"github.com/0glabs/0g-serving-broker/inference/contract"
 	"github.com/0glabs/0g-serving-broker/inference/model"
@@ -363,27 +362,23 @@ func (c *Ctrl) validateBalanceAdequacy(ctx *gin.Context, account model.User, fee
 		return errors.New("invalid MinimumLockedBalance constant")
 	}
 
+	feeBI, ok := new(big.Int).SetString(fee, 10)
+	if !ok {
+		return errors.New("invalid fee value")
+	}
+
+	lockBalance, ok := new(big.Int).SetString(*account.LockBalance, 10)
+	if !ok {
+		return errors.New("invalid lock balance value")
+	}
+
 	// Use optimized calculation for unsettled fee using database aggregation
 	unsettledFee, err := c.db.CalculateUnsettledFee(account.User)
 	if err != nil {
 		return errors.Wrap(err, "calculate unsettled fee")
 	}
 
-	// Add input fee, unsettled fee, and response fee reservation
-	totalWithInput, err := util.Add(fee, unsettledFee.String())
-	if err != nil {
-		return err
-	}
-	total, err := util.Add(totalWithInput, responseFeeReservation)
-	if err != nil {
-		return err
-	}
-
-	cmp1, err := util.Compare(total, account.LockBalance)
-	if err != nil {
-		return err
-	}
-	if cmp1 <= 0 {
+	if balanceSufficient(lockBalance, feeBI, unsettledFee, responseFeeReservation) {
 		return nil
 	}
 
@@ -402,19 +397,16 @@ func (c *Ctrl) validateBalanceAdequacy(ctx *gin.Context, account model.User, fee
 		return errors.Wrap(err, "recalculate unsettled fee")
 	}
 
-	totalWithInputNew, err := util.Add(fee, unsettledFeeNew.String())
-	if err != nil {
-		return err
+	if newAccount.LockBalance == nil {
+		return errors.New("nil lockBalance after sync")
 	}
-	totalNew, err := util.Add(totalWithInputNew, responseFeeReservation)
-	if err != nil {
-		return err
+
+	newLockBalance, ok := new(big.Int).SetString(*newAccount.LockBalance, 10)
+	if !ok {
+		return errors.New("invalid lock balance after sync")
 	}
-	cmp2, err := util.Compare(totalNew, newAccount.LockBalance)
-	if err != nil {
-		return err
-	}
-	if cmp2 <= 0 {
+
+	if balanceSufficient(newLockBalance, feeBI, unsettledFeeNew, responseFeeReservation) {
 		return nil
 	}
 	ctx.Set("ignoreError", true)
@@ -427,6 +419,9 @@ func (c *Ctrl) validateBalanceAdequacy(ctx *gin.Context, account model.User, fee
 		return new(big.Float).Quo(new(big.Float).SetInt(v), new(big.Float).SetInt(divisor)).Text('f', 6)
 	}
 
+	totalNew := new(big.Int).Add(feeBI, unsettledFeeNew)
+	totalNew.Add(totalNew, responseFeeReservation)
+
 	balanceZG := toZG(*newAccount.LockBalance)
 	unsettledZG := toZG(unsettledFeeNew.String())
 	currentFeeZG := toZG(fee)
@@ -436,6 +431,15 @@ func (c *Ctrl) validateBalanceAdequacy(ctx *gin.Context, account model.User, fee
 		"(breakdown: minimum reserve %s 0G + unsettled fees %s 0G + current request fee %s 0G). "+
 		"Please add more funds with: 0g-compute-cli transfer-fund --provider %s --amount <amount>",
 		balanceZG, toZG(totalNew.String()), minLockedZG, unsettledZG, currentFeeZG, c.contract.ProviderAddress)
+}
+
+// balanceSufficient reports whether lockBalance is sufficient to cover
+// inputFee + unsettledFee + minReserve. All values are in neuron units.
+// Returns true when lockBalance >= inputFee + unsettledFee + minReserve.
+func balanceSufficient(lockBalance, inputFee, unsettledFee, minReserve *big.Int) bool {
+	total := new(big.Int).Add(inputFee, unsettledFee)
+	total.Add(total, minReserve)
+	return lockBalance.Cmp(total) >= 0
 }
 
 // GetUnsettledFee returns the total unsettled fee for a given user address.

--- a/api/inference/internal/ctrl/request_test.go
+++ b/api/inference/internal/ctrl/request_test.go
@@ -1,0 +1,113 @@
+package ctrl
+
+import (
+	"math/big"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	constant "github.com/0glabs/0g-serving-broker/inference/const"
+	"github.com/0glabs/0g-serving-broker/inference/model"
+)
+
+func TestBalanceSufficient(t *testing.T) {
+	min, _ := new(big.Int).SetString(constant.MinimumLockedBalance, 10)
+	zero := big.NewInt(0)
+	one := big.NewInt(1)
+
+	tests := []struct {
+		name         string
+		lockBalance  *big.Int
+		inputFee     *big.Int
+		unsettledFee *big.Int
+		minReserve   *big.Int
+		want         bool
+	}{
+		{
+			name:         "exact minimum, zero fees",
+			lockBalance:  new(big.Int).Set(min),
+			inputFee:     zero,
+			unsettledFee: zero,
+			minReserve:   min,
+			want:         true,
+		},
+		{
+			// T2: regression test — this case had no coverage when MinimumLockedBalance was raised
+			// from 1 to 5 0G. Any future change to the constant will fail this test.
+			name:         "one below minimum, zero fees",
+			lockBalance:  new(big.Int).Sub(min, one),
+			inputFee:     zero,
+			unsettledFee: zero,
+			minReserve:   min,
+			want:         false,
+		},
+		{
+			name:         "zero balance",
+			lockBalance:  zero,
+			inputFee:     zero,
+			unsettledFee: zero,
+			minReserve:   min,
+			want:         false,
+		},
+		{
+			name:         "one above minimum, zero fees",
+			lockBalance:  new(big.Int).Add(min, one),
+			inputFee:     zero,
+			unsettledFee: zero,
+			minReserve:   min,
+			want:         true,
+		},
+		{
+			name:         "unsettled fee eats into reserve",
+			lockBalance:  new(big.Int).Set(min),
+			inputFee:     zero,
+			unsettledFee: one,
+			minReserve:   min,
+			want:         false,
+		},
+		{
+			name:         "balance exactly covers combined total",
+			lockBalance:  new(big.Int).Add(min, big.NewInt(150)),
+			inputFee:     big.NewInt(100),
+			unsettledFee: big.NewInt(50),
+			minReserve:   min,
+			want:         true,
+		},
+		{
+			name:         "balance one below combined total",
+			lockBalance:  new(big.Int).Add(min, big.NewInt(149)),
+			inputFee:     big.NewInt(100),
+			unsettledFee: big.NewInt(50),
+			minReserve:   min,
+			want:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := balanceSufficient(tt.lockBalance, tt.inputFee, tt.unsettledFee, tt.minReserve)
+			if got != tt.want {
+				t.Errorf("balanceSufficient() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateBalanceAdequacyNilLockBalance(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+
+	c := &Ctrl{}
+	account := model.User{} // LockBalance is nil
+
+	err := c.validateBalanceAdequacy(ctx, account, "0")
+	if err == nil {
+		t.Fatal("expected error for nil LockBalance, got nil")
+	}
+	if !strings.Contains(err.Error(), "nil lockBalance") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Raise `MinimumLockedBalance` from 1 0G to 5 0G (`"5000000000000000000"` neuron) in `api/inference/const/const.go`
- Fix stale comment in `request.go` that referenced the old 3 0G value

## Changes

`MinimumLockedBalance` is the broker-enforced minimum balance each user must keep locked per provider account. Raising it to 5 0G:
1. Sets the **provider reservation requirement** to 5 tokens — users need ≥5 0G locked to make requests
2. Sets the effective **minimum deposit requirement** to 5 tokens — users must deposit at least 5 0G to open a usable account

Closes 0gfoundation/0g-serving-broker#384