### PR TITLE
fix: increase async timeout and make provider HTTP timeouts configurable

### DIFF
--- a/api/inference/config/config.go
+++ b/api/inference/config/config.go
@@ -166,10 +166,10 @@ type Config struct {
 	GasPrice    string `yaml:"gasPrice"`
 	MaxGasPrice string `yaml:"maxGasPrice"`
 	Interval    struct {
-		AutoSettleBufferTime         int `yaml:"autoSettleBufferTime"`
-		ForceSettlementProcessor     int `yaml:"forceSettlementProcessor"`
-		SettlementProcessor          int `yaml:"settlementProcessor"`
-		ReconciliationProcessor      int `yaml:"reconciliationProcessor"`
+		AutoSettleBufferTime     int `yaml:"autoSettleBufferTime"`
+		ForceSettlementProcessor int `yaml:"forceSettlementProcessor"`
+		SettlementProcessor      int `yaml:"settlementProcessor"`
+		ReconciliationProcessor  int `yaml:"reconciliationProcessor"`
 	} `yaml:"interval"`
 	RevenueTransfer struct {
 		TargetAddress string `yaml:"targetAddress"` // Target address to transfer revenue to
@@ -194,6 +194,7 @@ type Config struct {
 	CacheTokenBilling   CacheTokenBillingConfig `yaml:"cacheTokenBilling"`
 	Whitelist           WhitelistConfig         `yaml:"whitelist"`
 	Async               AsyncConfig             `yaml:"async"`
+	ProviderHttp        ProviderHttpConfig      `yaml:"providerHttp"`
 	ConcurrencyLimit    ConcurrencyLimitConfig  `yaml:"concurrencyLimit"`
 }
 
@@ -204,7 +205,7 @@ type ConcurrencyLimitConfig struct {
 	MaxGlobalConcurrent  int `yaml:"maxGlobalConcurrent"`  // Max total concurrent requests to backend (default: 20)
 	MaxPerUserConcurrent int `yaml:"maxPerUserConcurrent"` // Max concurrent requests per user (default: 5, whitelisted users are exempt)
 	PerUserRPM           int `yaml:"perUserRPM"`           // Max requests per minute per user (default: 40, 0 = disabled)
-	PerUserBurst         int `yaml:"perUserBurst"`          // Max burst size for per-user rate limit (default: 10)
+	PerUserBurst         int `yaml:"perUserBurst"`         // Max burst size for per-user rate limit (default: 10)
 }
 
 // AsyncConfig defines configuration for async job processing.
@@ -214,7 +215,14 @@ type AsyncConfig struct {
 	MaxQueueSize           int  `yaml:"maxQueueSize"`           // Max pending jobs waiting for a worker (default: 100)
 	ResultTTLMinutes       int  `yaml:"resultTTLMinutes"`       // How long to keep completed results (default: 30)
 	CleanupIntervalSeconds int  `yaml:"cleanupIntervalSeconds"` // Interval for expired job cleanup (default: 60)
-	JobTimeoutMinutes      int  `yaml:"jobTimeoutMinutes"`      // Per-job HTTP request timeout (default: 10)
+	JobTimeoutMinutes      int  `yaml:"jobTimeoutMinutes"`      // Per-job HTTP request timeout (default: 15)
+}
+
+// ProviderHttpConfig defines HTTP client timeouts for broker→provider communication.
+// Providers can tune these values based on their GPU capacity and model complexity.
+type ProviderHttpConfig struct {
+	TotalTimeoutMinutes          int `yaml:"totalTimeoutMinutes"`          // Overall HTTP request timeout (default: 15)
+	ResponseHeaderTimeoutMinutes int `yaml:"responseHeaderTimeoutMinutes"` // Max time to wait for provider to start responding (default: 15)
 }
 
 type LogPathsConfig struct {
@@ -314,15 +322,15 @@ func GetConfig() *Config {
 			GasPrice:    "",
 			MaxGasPrice: "",
 			Interval: struct {
-				AutoSettleBufferTime         int `yaml:"autoSettleBufferTime"`
-				ForceSettlementProcessor     int `yaml:"forceSettlementProcessor"`
-				SettlementProcessor          int `yaml:"settlementProcessor"`
-				ReconciliationProcessor      int `yaml:"reconciliationProcessor"`
+				AutoSettleBufferTime     int `yaml:"autoSettleBufferTime"`
+				ForceSettlementProcessor int `yaml:"forceSettlementProcessor"`
+				SettlementProcessor      int `yaml:"settlementProcessor"`
+				ReconciliationProcessor  int `yaml:"reconciliationProcessor"`
 			}{
-				AutoSettleBufferTime:         60,
-				ForceSettlementProcessor:     600,
-				SettlementProcessor:          300,
-				ReconciliationProcessor:      60,
+				AutoSettleBufferTime:     60,
+				ForceSettlementProcessor: 600,
+				SettlementProcessor:      300,
+				ReconciliationProcessor:  60,
 			},
 			RevenueTransfer: struct {
 				TargetAddress string `yaml:"targetAddress"`
@@ -403,7 +411,11 @@ func GetConfig() *Config {
 				MaxQueueSize:           100,
 				ResultTTLMinutes:       30,
 				CleanupIntervalSeconds: 60,
-				JobTimeoutMinutes:      10,
+				JobTimeoutMinutes:      15,
+			},
+			ProviderHttp: ProviderHttpConfig{
+				TotalTimeoutMinutes:          15,
+				ResponseHeaderTimeoutMinutes: 15,
 			},
 		}
 

--- a/api/inference/integration/provider/config.example.yaml
+++ b/api/inference/integration/provider/config.example.yaml
@@ -50,3 +50,8 @@ service:
   #   supportedFormats:
   #     - openai
   #     - anthropic
+# Optional: HTTP client timeouts for broker→provider communication.
+# Tune based on GPU speed and model complexity (e.g., image generation may need longer timeouts).
+# providerHttp:
+#   totalTimeoutMinutes: 15          # Overall HTTP request timeout (default: 15)
+#   responseHeaderTimeoutMinutes: 15 # Max time to wait for provider to start responding (default: 15)

--- a/api/inference/internal/ctrl/ctrl.go
+++ b/api/inference/internal/ctrl/ctrl.go
@@ -40,8 +40,8 @@ type Ctrl struct {
 
 	autoSettleBufferTime time.Duration
 
-	Service            config.Service
-	cacheTokenBilling  config.CacheTokenBillingConfig
+	Service           config.Service
+	cacheTokenBilling config.CacheTokenBillingConfig
 
 	teeService          *tee.TeeService
 	chatCacheExpiration time.Duration
@@ -50,8 +50,8 @@ type Ctrl struct {
 	sessionCache *cache.Cache
 
 	// Contract data caches to avoid frequent contract calls
-	contractAccountCache *cache.Cache  // Cache for user account data from contract
-	serviceCache         *cache.Cache  // Cache for service data from contract
+	contractAccountCache *cache.Cache // Cache for user account data from contract
+	serviceCache         *cache.Cache // Cache for service data from contract
 
 	// Service sync flag to ensure SyncService is only called once
 	serviceSynced bool
@@ -68,7 +68,7 @@ type Ctrl struct {
 	whitelistUsers map[string]struct{}
 
 	// Async processing
-	asyncMu         sync.RWMutex       // protects asyncEnabled + asyncJobQueue against send-on-closed-channel during shutdown
+	asyncMu         sync.RWMutex // protects asyncEnabled + asyncJobQueue against send-on-closed-channel during shutdown
 	asyncJobQueue   chan asyncJobParams
 	asyncResultTTL  time.Duration
 	asyncJobTimeout time.Duration
@@ -113,29 +113,30 @@ func New(
 		chatCacheExpiration:  cfg.ChatCacheExpiration,
 		logger:               logger,
 		// Initialize session cache with 5 minute expiration and cleanup every 10 minutes
-		sessionCache:         cache.New(5*time.Minute, 10*time.Minute),
+		sessionCache: cache.New(5*time.Minute, 10*time.Minute),
 		// Initialize contract data caches with appropriate expiration times
-		contractAccountCache: cache.New(10*time.Minute, 20*time.Minute),  // Cache user accounts for 10 minutes
+		contractAccountCache: cache.New(10*time.Minute, 20*time.Minute), // Cache user accounts for 10 minutes
 		serviceCache:         cache.New(15*time.Minute, 20*time.Minute), // Cache service data for 15 minutes
 		logPath:              logPath,
 		brokerLogDir:         brokerLogDir,
 		eventLogDir:          eventLogDir,
 		// Initialize shared HTTP client with connection pooling
 		// Optimized for single backend container with many concurrent users
+		// Timeouts are configurable via providerHttp config for different GPU/model requirements
 		httpClient: &http.Client{
-			Timeout: 10 * time.Minute, // Increased for long-running image generation tasks
+			Timeout: time.Duration(cfg.ProviderHttp.TotalTimeoutMinutes) * time.Minute, // Overall request timeout
 			Transport: &http.Transport{
 				// Connection pool settings for high concurrency scenarios
-				MaxIdleConns:          200,               // Increased total idle connections to handle more concurrent users
-				MaxIdleConnsPerHost:   200,               // Idle connections per host (critical for single backend)
-				MaxConnsPerHost:       500,               // Limit max active connections to prevent resource exhaustion
-				IdleConnTimeout:       90 * time.Second,  // How long idle connections stay open
-				TLSHandshakeTimeout:   10 * time.Second,  // TLS handshake timeout
-				ResponseHeaderTimeout: 5 * time.Minute,   // Increased for complex LLM processing before response starts
-				ExpectContinueTimeout: 1 * time.Second,   // Time to wait for 100-continue response
-				DisableKeepAlives:     false,             // Enable connection reuse (critical)
-				DisableCompression:    false,             // Allow gzip compression
-				ForceAttemptHTTP2:     false,             // Use HTTP/1.1 for stability
+				MaxIdleConns:          200,                                                                        // Increased total idle connections to handle more concurrent users
+				MaxIdleConnsPerHost:   200,                                                                        // Idle connections per host (critical for single backend)
+				MaxConnsPerHost:       500,                                                                        // Limit max active connections to prevent resource exhaustion
+				IdleConnTimeout:       90 * time.Second,                                                           // How long idle connections stay open
+				TLSHandshakeTimeout:   10 * time.Second,                                                           // TLS handshake timeout
+				ResponseHeaderTimeout: time.Duration(cfg.ProviderHttp.ResponseHeaderTimeoutMinutes) * time.Minute, // Time to wait for response headers
+				ExpectContinueTimeout: 1 * time.Second,                                                            // Time to wait for 100-continue response
+				DisableKeepAlives:     false,                                                                      // Enable connection reuse (critical)
+				DisableCompression:    false,                                                                      // Allow gzip compression
+				ForceAttemptHTTP2:     false,                                                                      // Use HTTP/1.1 for stability
 			},
 		},
 		// Initialize whitelist users map


### PR DESCRIPTION
## Summary
- Increase default `ResponseHeaderTimeout` and overall HTTP client timeout from 5/10 min to 15 min
- Increase default async `JobTimeoutMinutes` from 10 to 15 min
- Add `ProviderHttpConfig` to make broker→provider HTTP timeouts configurable per deployment
- Add `providerHttp` section to example config YAML

## Changed Files
- `api/inference/config/config.go` — new `ProviderHttpConfig` struct, updated defaults
- `api/inference/internal/ctrl/ctrl.go` — use config values instead of hardcoded timeouts
- `api/inference/integration/provider/config.example.yaml` — document new config section

## How to Verify
- Deploy with default config → confirm HTTP client uses 15-min timeouts
- Set custom `providerHttp.totalTimeoutMinutes` / `responseHeaderTimeoutMinutes` in config → confirm values are applied
- Run concurrent async image edit requests → confirm no premature timeout failures

Closes #422