### PR TITLE
Update Claude Code action to v1.0.90

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -65,7 +65,7 @@ jobs:
           submodules: recursive
 
       - name: Run Claude Code
-        uses: anthropics/claude-code-action@01f76518c3572f43543331de06b56cb042f3236f # v1.17.1
+        uses: anthropics/claude-code-action@26ddc358fe3befff50c5ec2f80304c90c763f6f8 # v1.0.90
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}        
         with:


### PR DESCRIPTION
## Summary
Updates the Claude Code action dependency to a newer version.

## Changes
- Updated `anthropics/claude-code-action` from v1.17.1 to v1.0.90
  - Commit hash: `01f76518c3572f43543331de06b56cb042f3236f` → `26ddc358fe3befff50c5ec2f80304c90c763f6f8`

## Notes
This updates the GitHub Actions workflow to use the specified version of the Claude Code action for code review automation.

https://claude.ai/code/session_013WYWTH4ZwxJaK91aHcpwgV