### PR TITLE
refactor(inference): correct Message types to reflect multimodal request content

### DIFF
--- a/api/inference/internal/ctrl/chatbot.go
+++ b/api/inference/internal/ctrl/chatbot.go
@@ -82,7 +82,7 @@ type ImageURL struct {
 }
 
 func (mc MessageContent) MarshalJSON() ([]byte, error) {
-	if mc.Parts != nil {
+	if len(mc.Parts) > 0 {
 		return json.Marshal(mc.Parts)
 	}
 	return json.Marshal(mc.Text)

--- a/api/inference/internal/ctrl/chatbot.go
+++ b/api/inference/internal/ctrl/chatbot.go
@@ -56,8 +56,71 @@ type ChatSignature struct {
 	TLSCertFingerprint string `json:"tls_cert_fingerprint,omitempty"`
 }
 
+// MessageContent can hold either a plain string or an array of content parts
+// (OpenAI multimodal/vision format). This enables support for requests like:
+//
+//	{"role": "user", "content": "Hello"}
+//	{"role": "user", "content": [{"type":"text","text":"Describe this"},{"type":"image_url","image_url":{"url":"data:image/png;base64,..."}}]}
+type MessageContent struct {
+	// Text holds the content when it is a plain string.
+	Text string
+	// Parts holds the content when it is a multimodal array.
+	Parts []ContentPart
+}
+
+// ContentPart represents one element of a multimodal content array.
+type ContentPart struct {
+	Type     string    `json:"type"`
+	Text     string    `json:"text,omitempty"`
+	ImageURL *ImageURL `json:"image_url,omitempty"`
+}
+
+// ImageURL holds an image reference in an OpenAI-compatible content part.
+type ImageURL struct {
+	URL    string `json:"url"`
+	Detail string `json:"detail,omitempty"`
+}
+
+func (mc MessageContent) MarshalJSON() ([]byte, error) {
+	if mc.Parts != nil {
+		return json.Marshal(mc.Parts)
+	}
+	return json.Marshal(mc.Text)
+}
+
+func (mc *MessageContent) UnmarshalJSON(data []byte) error {
+	// Try string first (most common case and all LLM responses).
+	if len(data) > 0 && data[0] == '"' {
+		return json.Unmarshal(data, &mc.Text)
+	}
+	// Try array (multimodal input).
+	if len(data) > 0 && data[0] == '[' {
+		if err := json.Unmarshal(data, &mc.Parts); err != nil {
+			return err
+		}
+		// Also populate Text with concatenated text parts for convenience.
+		var sb strings.Builder
+		for _, p := range mc.Parts {
+			if p.Type == "text" {
+				sb.WriteString(p.Text)
+			}
+		}
+		mc.Text = sb.String()
+		return nil
+	}
+	// null or other — treat as empty.
+	return nil
+}
+
+// RequestMessage represents a message in an OpenAI chat completion request.
+// Content supports both plain string and multimodal array formats.
+type RequestMessage struct {
+	Role    string         `json:"role"`
+	Content MessageContent `json:"content"`
+}
+
 type RequestBody struct {
-	Messages []Message `json:"messages"`
+	Messages []RequestMessage `json:"messages"`
 }
 
 type CompletionChunk struct {
@@ -81,14 +144,16 @@ type Usage struct {
 }
 
 type Choice struct {
-	Message Message `json:"message"`
+	Message ResponseMessage `json:"message"`
 	Delta   struct {
 		Content string `json:"content"`
 	} `json:"delta"`
 	FinishReason string `json:"finish_reason"`
 }
 
-type Message struct {
+// ResponseMessage represents a message in an LLM response.
+// Content is always a plain string in responses.
+type ResponseMessage struct {
 	Role    string `json:"role"`
 	Content string `json:"content"`
 }

--- a/api/inference/internal/ctrl/chatbot_test.go
+++ b/api/inference/internal/ctrl/chatbot_test.go
@@ -9,6 +9,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/hex"
+	"encoding/json"
 	"math/big"
 	"strings"
 	"testing"
@@ -430,5 +431,185 @@ func TestTeeServiceSigningRoundTrip(t *testing.T) {
 
 	if _, ok := interface{}(ts.ProviderSigner).(*ecdsa.PrivateKey); !ok {
 		t.Error("ProviderSigner is not *ecdsa.PrivateKey")
+	}
+}
+
+// ==========================================================================
+// MessageContent JSON marshaling/unmarshaling
+// ==========================================================================
+
+func TestMessageContent_UnmarshalString(t *testing.T) {
+	input := `"Hello, world!"`
+	var mc MessageContent
+	if err := json.Unmarshal([]byte(input), &mc); err != nil {
+		t.Fatalf("UnmarshalJSON error: %v", err)
+	}
+	if mc.Text != "Hello, world!" {
+		t.Errorf("Text = %q, want %q", mc.Text, "Hello, world!")
+	}
+	if mc.Parts != nil {
+		t.Error("Parts should be nil for string content")
+	}
+}
+
+func TestMessageContent_UnmarshalMultimodal(t *testing.T) {
+	input := `[{"type":"text","text":"Describe this image"},{"type":"image_url","image_url":{"url":"data:image/png;base64,iVBOR","detail":"high"}}]`
+	var mc MessageContent
+	if err := json.Unmarshal([]byte(input), &mc); err != nil {
+		t.Fatalf("UnmarshalJSON error: %v", err)
+	}
+	if len(mc.Parts) != 2 {
+		t.Fatalf("Parts length = %d, want 2", len(mc.Parts))
+	}
+	if mc.Parts[0].Type != "text" || mc.Parts[0].Text != "Describe this image" {
+		t.Errorf("Parts[0] = %+v, want text part", mc.Parts[0])
+	}
+	if mc.Parts[1].Type != "image_url" {
+		t.Errorf("Parts[1].Type = %q, want %q", mc.Parts[1].Type, "image_url")
+	}
+	if mc.Parts[1].ImageURL == nil {
+		t.Fatal("Parts[1].ImageURL is nil")
+	}
+	if mc.Parts[1].ImageURL.URL != "data:image/png;base64,iVBOR" {
+		t.Errorf("ImageURL.URL = %q, want data URI", mc.Parts[1].ImageURL.URL)
+	}
+	if mc.Parts[1].ImageURL.Detail != "high" {
+		t.Errorf("ImageURL.Detail = %q, want %q", mc.Parts[1].ImageURL.Detail, "high")
+	}
+	// Text should be populated from text parts
+	if mc.Text != "Describe this image" {
+		t.Errorf("Text = %q, want %q", mc.Text, "Describe this image")
+	}
+}
+
+func TestMessageContent_UnmarshalNull(t *testing.T) {
+	input := `null`
+	var mc MessageContent
+	if err := json.Unmarshal([]byte(input), &mc); err != nil {
+		t.Fatalf("UnmarshalJSON error: %v", err)
+	}
+	if mc.Text != "" {
+		t.Errorf("Text = %q, want empty", mc.Text)
+	}
+	if mc.Parts != nil {
+		t.Error("Parts should be nil")
+	}
+}
+
+func TestMessageContent_MarshalString(t *testing.T) {
+	mc := MessageContent{Text: "Hello"}
+	data, err := mc.MarshalJSON()
+	if err != nil {
+		t.Fatalf("MarshalJSON error: %v", err)
+	}
+	if string(data) != `"Hello"` {
+		t.Errorf("MarshalJSON = %s, want %q", data, `"Hello"`)
+	}
+}
+
+func TestMessageContent_MarshalMultimodal(t *testing.T) {
+	mc := MessageContent{
+		Parts: []ContentPart{
+			{Type: "text", Text: "Describe"},
+			{Type: "image_url", ImageURL: &ImageURL{URL: "data:image/png;base64,abc"}},
+		},
+	}
+	data, err := mc.MarshalJSON()
+	if err != nil {
+		t.Fatalf("MarshalJSON error: %v", err)
+	}
+	// Should marshal as array, not string
+	if data[0] != '[' {
+		t.Errorf("expected array JSON, got: %s", data)
+	}
+
+	// Round-trip: unmarshal back
+	var mc2 MessageContent
+	if err := json.Unmarshal(data, &mc2); err != nil {
+		t.Fatalf("round-trip unmarshal error: %v", err)
+	}
+	if len(mc2.Parts) != 2 {
+		t.Errorf("round-trip Parts length = %d, want 2", len(mc2.Parts))
+	}
+}
+
+func TestRequestBody_MultimodalRoundTrip(t *testing.T) {
+	// Simulate a full OpenAI vision request body
+	input := `{
+		"messages": [
+			{"role": "system", "content": "You are a helpful assistant."},
+			{"role": "user", "content": [
+				{"type": "text", "text": "What is in this image?"},
+				{"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,/9j/4AAQ"}}
+			]}
+		]
+	}`
+
+	var body RequestBody
+	if err := json.Unmarshal([]byte(input), &body); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	if len(body.Messages) != 2 {
+		t.Fatalf("Messages length = %d, want 2", len(body.Messages))
+	}
+
+	// First message: plain string content
+	if body.Messages[0].Role != "system" {
+		t.Errorf("Messages[0].Role = %q, want %q", body.Messages[0].Role, "system")
+	}
+	if body.Messages[0].Content.Text != "You are a helpful assistant." {
+		t.Errorf("Messages[0].Content.Text = %q", body.Messages[0].Content.Text)
+	}
+	if body.Messages[0].Content.Parts != nil {
+		t.Error("Messages[0].Content.Parts should be nil for string content")
+	}
+
+	// Second message: multimodal content
+	if body.Messages[1].Role != "user" {
+		t.Errorf("Messages[1].Role = %q, want %q", body.Messages[1].Role, "user")
+	}
+	if len(body.Messages[1].Content.Parts) != 2 {
+		t.Fatalf("Messages[1].Content.Parts length = %d, want 2", len(body.Messages[1].Content.Parts))
+	}
+	if body.Messages[1].Content.Parts[1].ImageURL == nil {
+		t.Fatal("image_url part should have ImageURL")
+	}
+	if body.Messages[1].Content.Parts[1].ImageURL.URL != "data:image/jpeg;base64,/9j/4AAQ" {
+		t.Errorf("ImageURL.URL = %q", body.Messages[1].Content.Parts[1].ImageURL.URL)
+	}
+	// Text should be populated from text parts only
+	if body.Messages[1].Content.Text != "What is in this image?" {
+		t.Errorf("Messages[1].Content.Text = %q, want %q", body.Messages[1].Content.Text, "What is in this image?")
+	}
+
+	// Round-trip: marshal back and ensure it can be re-parsed
+	data, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+	var body2 RequestBody
+	if err := json.Unmarshal(data, &body2); err != nil {
+		t.Fatalf("round-trip unmarshal error: %v", err)
+	}
+	if len(body2.Messages) != 2 {
+		t.Errorf("round-trip Messages length = %d, want 2", len(body2.Messages))
+	}
+	if len(body2.Messages[1].Content.Parts) != 2 {
+		t.Errorf("round-trip Parts length = %d, want 2", len(body2.Messages[1].Content.Parts))
+	}
+}
+
+func TestResponseMessage_UnmarshalStringContent(t *testing.T) {
+	// LLM responses always have string content — ensure ResponseMessage still works
+	input := `{"id":"chatcmpl-123","choices":[{"message":{"role":"assistant","content":"The image shows a cat."},"delta":{"content":""},"finish_reason":"stop"}]}`
+	var chunk CompletionChunk
+	if err := json.Unmarshal([]byte(input), &chunk); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	if len(chunk.Choices) != 1 {
+		t.Fatalf("Choices length = %d, want 1", len(chunk.Choices))
+	}
+	if chunk.Choices[0].Message.Content != "The image shows a cat." {
+		t.Errorf("Message.Content = %q", chunk.Choices[0].Message.Content)
 	}
 }


### PR DESCRIPTION
## Summary

This is a **type-correctness refactor**, not a feature enablement. Multimodal (vision) input already flows through the broker end-to-end today, because the inference path reads the request as raw bytes (`io.ReadAll` in `proxy/proxy.go`), hashes those bytes directly for signing, and forwards them unchanged to the provider. The `RequestBody`/`Message` structs in `chatbot.go` are not unmarshaled anywhere in the request path — they are effectively documentation.

The problem: the existing `Message.Content string` is an **incorrect type** for request messages. OpenAI-compatible clients may send `content` as either a plain string or an array of content parts (text + image_url). Any future code that does `json.Unmarshal` into the old `RequestBody` would silently drop multimodal content or fail outright. This PR fixes the type definitions so that future inspection/billing/logging code built on top of them won't break multimodal requests.

## Changes

- Introduce `MessageContent` with custom `MarshalJSON`/`UnmarshalJSON` that accepts both a plain string and an OpenAI multimodal array (text + image_url parts).
- Split `Message` into:
  - `RequestMessage` — `Content` is `MessageContent` (string or multimodal array).
  - `ResponseMessage` — `Content` remains `string`, since LLM responses are always plain text.
- Update `RequestBody.Messages` and `Choice.Message` to use the correct variant.
- Add unit tests covering string, multimodal, null, and round-trip (un)marshaling.

## Scope / non-goals

- **No runtime behavior change.** The proxy path still forwards raw bytes; signing still hashes raw bytes. Text-only and multimodal requests behave exactly as before this PR.
- No changes to proxy, signing, billing, or response handling.

## How to verify

- `go test ./api/inference/internal/ctrl/...` — unit tests for the new (un)marshaling.
- Text-only chat requests continue to work unchanged (no path reads these structs).
- Multimodal vision requests continue to work unchanged (already did pre-PR).

## Test plan

- [ ] Unit tests pass (`go test ./api/inference/internal/ctrl/...`)
- [ ] Text-only chat requests still work end-to-end
- [ ] Multimodal requests with base64 `image_url` are forwarded correctly (same as before)
- [ ] Response parsing (always plain string) is unaffected

Refs #421

Generated with [Claude Code](https://claude.com/claude-code)