### PR TITLE
feat(inference): add gas optimization for settlement with per-user fe…

### DIFF
--- a/api/inference/config/config.go
+++ b/api/inference/config/config.go
@@ -226,12 +226,20 @@ type Config struct {
 	} `yaml:"event"`
 	GasPrice    string `yaml:"gasPrice"`
 	MaxGasPrice string `yaml:"maxGasPrice"`
-	Interval    struct {
+	Interval struct {
 		AutoSettleBufferTime     int `yaml:"autoSettleBufferTime"`
 		ForceSettlementProcessor int `yaml:"forceSettlementProcessor"`
 		SettlementProcessor      int `yaml:"settlementProcessor"`
 		ReconciliationProcessor  int `yaml:"reconciliationProcessor"`
 	} `yaml:"interval"`
+	Settlement struct {
+		// MinSettlementFee is the minimum accumulated fee (in neuron) per user
+		// before including them in a settlement batch. Users below this threshold
+		// are deferred to accumulate more fees. Default "4000000000000000"
+		// (0.004 A0GI) covers gas cost (~0.0006 A0GI) with ~7× margin.
+		// Set to "0" to disable per-user filtering.
+		MinSettlementFee string `yaml:"minSettlementFee"`
+	} `yaml:"settlement"`
 	RevenueTransfer struct {
 		TargetAddress string `yaml:"targetAddress"`
 		ReserveAmount string `yaml:"reserveAmount"`
@@ -436,7 +444,7 @@ func GetConfig() *Config {
 			}{
 				ProviderAddr: ":8088",
 			},
-			GasPrice:    "",
+			GasPrice:    "2000000007",
 			MaxGasPrice: "",
 			Interval: struct {
 				AutoSettleBufferTime     int `yaml:"autoSettleBufferTime"`
@@ -448,6 +456,11 @@ func GetConfig() *Config {
 				ForceSettlementProcessor: 600,
 				SettlementProcessor:      300,
 				ReconciliationProcessor:  60,
+			},
+			Settlement: struct {
+				MinSettlementFee string `yaml:"minSettlementFee"`
+			}{
+				MinSettlementFee: "4000000000000000",
 			},
 			RevenueTransfer: struct {
 				TargetAddress string `yaml:"targetAddress"`

--- a/api/inference/contract/contract.go
+++ b/api/inference/contract/contract.go
@@ -98,6 +98,15 @@ func (s *ServingContract) TransactWithValue(ctx context.Context, retryOpts *Retr
 	if err != nil {
 		return nil, err
 	}
+	// Let go-ethereum estimate gas dynamically via eth_estimateGas
+	// instead of using the fixed TransactionLimit from network config.
+	// When GasLimit is 0, bind.BoundContract.createLegacyTx() calls
+	// eth_estimateGas automatically, resulting in tighter gas limits
+	// that reflect actual transaction complexity.
+	// Note: the "Gas Limit: ..." debug log from TransactionCallMessage
+	// shows the config value before this override — it is not the actual
+	// gas limit used by the transaction.
+	opts.GasLimit = 0
 
 	nRetries := 0
 	for {

--- a/api/inference/integration/config/config.mainnet.yml
+++ b/api/inference/integration/config/config.mainnet.yml
@@ -36,6 +36,14 @@ interval:
   # Interval for regular settlement processor (in seconds)
   settlementProcessor: 300
 
+# Settlement profitability configuration
+settlement:
+  # Minimum accumulated fee (in neuron) per user before including them in settlement.
+  # Users below this threshold are deferred to accumulate more fees.
+  # Default "4000000000000000" (0.004 A0GI) covers gas cost (~0.0006 A0GI) with ~7× margin.
+  # Set to "0" to disable per-user filtering.
+  minSettlementFee: "4000000000000000"
+
 # Service configuration for the inference provider
 service:
   # URL where the serving broker exposes its API (required)

--- a/api/inference/integration/config/config.testnet.yml
+++ b/api/inference/integration/config/config.testnet.yml
@@ -36,6 +36,14 @@ interval:
   # Interval for regular settlement processor (in seconds)
   settlementProcessor: 300
 
+# Settlement profitability configuration
+settlement:
+  # Minimum accumulated fee (in neuron) per user before including them in settlement.
+  # Users below this threshold are deferred to accumulate more fees.
+  # Default "4000000000000000" (0.004 A0GI) covers gas cost (~0.0006 A0GI) with ~7× margin.
+  # Set to "0" to disable per-user filtering.
+  minSettlementFee: "4000000000000000"
+
 # Service configuration for the inference provider
 service:
   # URL where the serving broker exposes its API (required)

--- a/api/inference/integration/provider/config.example.yaml
+++ b/api/inference/integration/provider/config.example.yaml
@@ -2,6 +2,11 @@ interval:
   autoSettleBufferTime: 60
   forceSettlementProcessor: 600
   settlementProcessor: 300
+# Settlement profitability: defer users whose fees don't cover gas costs.
+# minSettlementFee is the minimum accumulated fee (in neuron) per user.
+# Default "4000000000000000" (0.004 A0GI). Set to "0" to disable.
+# settlement:
+#   minSettlementFee: "4000000000000000"
 networks:
   ethereum0g:
     url: "https://evmrpc-testnet.0g.ai"

--- a/api/inference/internal/contract/request.go
+++ b/api/inference/internal/contract/request.go
@@ -5,9 +5,10 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/0glabs/0g-serving-broker/common/errors"
 	"github.com/0glabs/0g-serving-broker/inference/contract"
-	"github.com/ethereum/go-ethereum/common"
 )
 
 type TEESettlementData struct {
@@ -78,3 +79,4 @@ func (c *ProviderContract) SettleFeesWithTEE(ctx context.Context, settlements []
 
 	return tx.Hash(), results, nil
 }
+

--- a/api/inference/internal/ctrl/ctrl.go
+++ b/api/inference/internal/ctrl/ctrl.go
@@ -2,6 +2,7 @@ package ctrl
 
 import (
 	"context"
+	"math/big"
 	"net/http"
 	"strings"
 	"sync"
@@ -40,6 +41,7 @@ type Ctrl struct {
 	logger   log.Logger
 
 	autoSettleBufferTime time.Duration
+	minSettlementFee    *big.Int
 
 	Service           config.Service
 	cacheTokenBilling config.CacheTokenBillingConfig
@@ -106,8 +108,16 @@ func New(
 		eventLogDir = "/var/log/event"
 	}
 
+	minSettlementFee := new(big.Int)
+	if cfg.Settlement.MinSettlementFee != "" {
+		if _, ok := minSettlementFee.SetString(cfg.Settlement.MinSettlementFee, 10); !ok {
+			logger.Errorf("Invalid minSettlementFee value: %q, per-user filter disabled", cfg.Settlement.MinSettlementFee)
+		}
+	}
+
 	p := &Ctrl{
 		autoSettleBufferTime: time.Duration(cfg.Interval.AutoSettleBufferTime) * time.Second,
+		minSettlementFee:     minSettlementFee,
 		db:                   db,
 		asyncDB:              db,
 		contract:             contract,

--- a/api/inference/internal/ctrl/settlement_tee.go
+++ b/api/inference/internal/ctrl/settlement_tee.go
@@ -215,7 +215,7 @@ func (c *Ctrl) SettleFeesWithTEE(ctx context.Context) error {
 		if len(batch.ExecutableItems) > 0 {
 			settledUsers := make([]string, 0)
 			for _, outcome := range batch.Outcomes {
-				if outcome.Status == SettlementSuccess || outcome.Status == SettlementPartial {
+				if outcome.AdjustedRequest != nil && (outcome.Status == SettlementSuccess || outcome.Status == SettlementPartial) {
 					settledUsers = append(settledUsers, outcome.User.Hex())
 				}
 			}
@@ -443,6 +443,11 @@ func (c *Ctrl) executeAndProcessResults(ctx context.Context, batch *SettlementBa
 		return nil
 	}
 
+	// Pre-flight: filter out users whose accumulated fee is below minSettlementFee.
+	if c.filterByGasProfitability(batch) {
+		return nil // All users filtered — requests stay unprocessed for next round
+	}
+
 	// Record pending settlements and mark requests as settling BEFORE sending tx
 	pendingIDs := c.recordPendingSettlements(ctx, batch)
 
@@ -451,6 +456,28 @@ func (c *Ctrl) executeAndProcessResults(ctx context.Context, batch *SettlementBa
 
 	// Update pending_settlement records with tx hashes
 	c.updatePendingTxHashes(pendingIDs, execResult.TxHashes)
+
+	// If no tx was submitted at all (e.g., gas price error), the requests are
+	// stuck with settling=true until reconciliation expires them. Clear immediately
+	// so they're available for the next settlement round.
+	if len(execResult.TxHashes) == 0 && execErr != nil {
+		c.logger.Warnf("No transactions submitted, clearing settling state for immediate retry")
+		for _, outcome := range batch.Outcomes {
+			if outcome.AdjustedRequest == nil {
+				continue
+			}
+			hashes := c.getRequestHashes(outcome.SettledRequests)
+			if err := c.db.MarkRequestsSettling(hashes, false); err != nil {
+				c.logger.Warnf("Failed to clear settling flag for user %s: %v", outcome.User.Hex(), err)
+			}
+		}
+		// Also mark pending settlement records as expired since no tx exists
+		for _, rec := range pendingIDs {
+			if err := c.db.UpdatePendingSettlementStatus(rec.ID, "expired"); err != nil {
+				c.logger.Warnf("Failed to expire pending settlement %d: %v", rec.ID, err)
+			}
+		}
+	}
 
 	// Update outcomes with execution results
 	for _, outcome := range batch.Outcomes {
@@ -486,6 +513,50 @@ func (c *Ctrl) executeAndProcessResults(ctx context.Context, batch *SettlementBa
 	}
 
 	return execErr
+}
+
+// filterByGasProfitability removes users whose accumulated fee is below
+// minSettlementFee from the batch. Returns true if all users were filtered
+// (entire batch deferred, requests stay for next round).
+func (c *Ctrl) filterByGasProfitability(batch *SettlementBatch) bool {
+	if len(batch.ExecutableItems) == 0 || c.minSettlementFee.Sign() <= 0 {
+		return len(batch.ExecutableItems) == 0
+	}
+
+	c.logger.Infof("Per-user filter: minSettlementFee=%s, users=%d",
+		c.minSettlementFee.String(), len(batch.ExecutableItems))
+
+	filteredOutUsers := make(map[common.Address]bool)
+	var keptItems []contract.TEESettlementData
+	for _, item := range batch.ExecutableItems {
+		if item.TotalFee.Cmp(c.minSettlementFee) < 0 {
+			filteredOutUsers[item.User] = true
+			c.logger.Infof("Deferred user %s: fee=%s < minSettlementFee=%s",
+				item.User.Hex(), item.TotalFee.String(), c.minSettlementFee.String())
+		} else {
+			keptItems = append(keptItems, item)
+		}
+	}
+
+	if len(filteredOutUsers) > 0 {
+		c.logger.Infof("Deferred %d users below fee threshold, %d remaining", len(filteredOutUsers), len(keptItems))
+		// Clear outcomes for filtered users so processOutcomes won't delete their requests
+		for _, outcome := range batch.Outcomes {
+			if filteredOutUsers[outcome.User] {
+				outcome.AdjustedRequest = nil
+				outcome.SettledRequests = nil
+			}
+		}
+		batch.ExecutableItems = keptItems
+	}
+
+	if len(batch.ExecutableItems) == 0 {
+		c.logger.Warnf("All %d users deferred (minSettlementFee=%s)", len(filteredOutUsers), c.minSettlementFee.String())
+		batch.Outcomes = nil
+		return true
+	}
+
+	return false
 }
 
 // pendingSettlementRecord tracks a pending settlement ID and which batch index it belongs to


### PR DESCRIPTION
…e filter

Replace fixed gas limits with dynamic eth_estimateGas and add per-user minimum settlement fee filtering to prevent unprofitable settlements.

- Set opts.GasLimit=0 in TransactWithValue to use eth_estimateGas
- Add configurable minSettlementFee (default 0.004 A0GI) to defer users whose accumulated fees don't justify gas costs
- Clear settling state immediately when tx submission fails instead of waiting for reconciliation
- Exclude filtered users from post-settlement balance sync
- Set default gasPrice to 2 Gwei as floor for chains with unreliable SuggestGasPrice