### PR TITLE
feat(inference): add DB-backed DAU tracking and all-time cumulative s…

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -72,7 +72,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
           claude_args: |
-            --model claude-sonnet-4-5-20250929
+            --model claude-sonnet-4-6
             --max-turns 40
             --allowedTools "Bash(*)"
             --system-prompt "You are a code review expert for the 0G Serving Broker project.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,39 @@
 
 This document defines code review standards and architectural guidelines for the 0G Serving Broker project. Claude will follow these standards when reviewing code.
 
+## Quick Reference (Must Read)
+
+### Build & Test Commands
+- Build: `cd api && go build ./...`
+- Unit tests: `cd api && go test ./...`
+- Integration tests: `cd api && go test -tags integration ./inference/... -timeout 600s`
+- Lint: `cd api && make lint`
+- Format: `cd api && go fmt ./...`
+
+### Review Guardrails (Prohibited Actions)
+- **Do NOT review or modify** abigen-generated Go bindings under `contract/`
+- **Do NOT adjust** code formatting, indentation, or import ordering — for format issues, just say "please run `go fmt`"
+- **Do NOT suggest** abstracting fewer than three similar lines of code
+- **Do NOT add** defensive nil checks or redundant error wrapping "just in case"
+- **Do NOT suggest** variable naming style changes (unless the name is clearly misleading)
+- **Do NOT split** GORM chained calls into multiple lines (this is the project's code style)
+- **Do NOT suggest** modifications to code in `libs/` or `token-counter/` submodules
+
+### Review Priority (Enforced Order)
+1. 🔴 Private key leaks / signature bypass / smart contract interaction safety
+2. 🔴 TEE verification gaps or bypasses
+3. 🟡 Goroutine leaks / unclosed resources / concurrency races
+4. 🟡 Missing state machine transitions (fine-tuning task lifecycle)
+5. 🟢 Database N+1 queries / performance regressions
+6. ⚪ Other
+
+### Output Requirements
+- All issues must be tagged `[CRITICAL]` / `[HIGH]` / `[MEDIUM]` / `[NIT]`
+- Tag code highlights with `[PRAISE]`
+- Write review reports in English
+
+---
+
 ## Project Overview
 
 **0G Serving Broker** is the core infrastructure component of the 0G Compute Network, a decentralized GPU marketplace that connects AI service users with compute providers. The broker acts as a trusted intermediary, handling authentication, request routing, settlement, and verification.

--- a/api/inference/cmd/server/main.go
+++ b/api/inference/cmd/server/main.go
@@ -54,10 +54,12 @@ func Main() {
 
 	engine := gin.New()
 
+	monitorCtx, monitorCancel := context.WithCancel(context.Background())
+
 	if config.Monitor.Enable {
 		monitor.PrometheusInit(config.Service.ServingURL)
-		monitor.StartDAUUpdater(db.CountUniqueUsersLast24h, 1*time.Minute, logger)
-		monitor.StartAllTimeStatsUpdater(func() (monitor.TotalStatsResult, error) {
+		monitor.StartDAUUpdater(monitorCtx, db.CountUniqueUsersLast24h, 1*time.Minute, logger)
+		monitor.StartAllTimeStatsUpdater(monitorCtx, func() (monitor.TotalStatsResult, error) {
 			s, err := db.GetCombinedTotalStats()
 			if err != nil {
 				return monitor.TotalStatsResult{}, err
@@ -200,6 +202,9 @@ func Main() {
 	if err := srv.Shutdown(shutdownCtx); err != nil {
 		logger.Errorf("Server forced to shutdown: %v", err)
 	}
+
+	// Shutdown monitor background goroutines
+	monitorCancel()
 
 	// Shutdown LoRA event watcher and manager
 	if loraCancel != nil {

--- a/api/inference/cmd/server/main.go
+++ b/api/inference/cmd/server/main.go
@@ -56,6 +56,19 @@ func Main() {
 
 	if config.Monitor.Enable {
 		monitor.PrometheusInit(config.Service.ServingURL)
+		monitor.StartDAUUpdater(db.CountUniqueUsersLast24h, 1*time.Minute, logger)
+		monitor.StartAllTimeStatsUpdater(func() (monitor.TotalStatsResult, error) {
+			s, err := db.GetCombinedTotalStats()
+			if err != nil {
+				return monitor.TotalStatsResult{}, err
+			}
+			return monitor.TotalStatsResult{
+				TotalRequests:     s.TotalRequests,
+				TotalInputTokens:  s.TotalInputTokens,
+				TotalOutputTokens: s.TotalOutputTokens,
+				TotalUniqueUsers:  s.TotalUniqueUsers,
+			}, nil
+		}, 1*time.Minute, logger)
 		engine.GET("/metrics", gin.WrapH(promhttp.Handler()))
 	}
 

--- a/api/inference/internal/ctrl/chatbot.go
+++ b/api/inference/internal/ctrl/chatbot.go
@@ -440,6 +440,7 @@ func (c *Ctrl) processSingleResponse(ctx context.Context, decodedBody []byte, ou
 		if chunk.Usage != nil {
 			*usage = chunk.Usage
 			monitor.RecordTokens("chatbot", int64(chunk.Usage.PromptTokens), int64(chunk.Usage.CompletionTokens))
+			monitor.RecordWhitelistTokens("chatbot", int64(chunk.Usage.PromptTokens), int64(chunk.Usage.CompletionTokens))
 			monitor.RecordTPSFromContext(ctx, "chatbot", int64(chunk.Usage.CompletionTokens))
 		}
 		return nil
@@ -740,6 +741,7 @@ func (c *Ctrl) processOpenAIStream(ctx context.Context, lines [][]byte, outputPr
 			if isWhitelisted {
 				if *usage != nil {
 					monitor.RecordTokens("chatbot", int64((*usage).PromptTokens), int64((*usage).CompletionTokens))
+					monitor.RecordWhitelistTokens("chatbot", int64((*usage).PromptTokens), int64((*usage).CompletionTokens))
 					monitor.RecordTPSFromContext(ctx, "chatbot", int64((*usage).CompletionTokens))
 				}
 				break

--- a/api/inference/internal/ctrl/chatbot_litellm.go
+++ b/api/inference/internal/ctrl/chatbot_litellm.go
@@ -98,6 +98,7 @@ func (c *Ctrl) processLiteLLMSingleResponse(ctx context.Context, decodedBody []b
 		// Skip billing for whitelisted users, but still record token metrics
 		if isWhitelisted {
 			monitor.RecordTokens("chatbot", int64(response.Usage.InputTokens), int64(response.Usage.OutputTokens))
+			monitor.RecordWhitelistTokens("chatbot", int64(response.Usage.InputTokens), int64(response.Usage.OutputTokens))
 			monitor.RecordTPSFromContext(ctx, "chatbot", int64(response.Usage.OutputTokens))
 			return nil
 		}
@@ -172,6 +173,7 @@ func (c *Ctrl) processLiteLLMStream(ctx context.Context, lines [][]byte, outputP
 					if isWhitelisted {
 						if *usage != nil {
 							monitor.RecordTokens("chatbot", int64((*usage).PromptTokens), int64((*usage).CompletionTokens))
+							monitor.RecordWhitelistTokens("chatbot", int64((*usage).PromptTokens), int64((*usage).CompletionTokens))
 							monitor.RecordTPSFromContext(ctx, "chatbot", int64((*usage).CompletionTokens))
 						}
 						return nil

--- a/api/inference/internal/ctrl/image_editing.go
+++ b/api/inference/internal/ctrl/image_editing.go
@@ -12,6 +12,7 @@ import (
 	"github.com/0glabs/0g-serving-broker/common/errors"
 	"github.com/0glabs/0g-serving-broker/common/util"
 	"github.com/0glabs/0g-serving-broker/inference/model"
+	"github.com/0glabs/0g-serving-broker/inference/monitor"
 )
 
 // ImageEditingRequest defines the structure of an image editing request
@@ -196,8 +197,10 @@ func (c *Ctrl) handleImageEditingResponse(ctx *gin.Context, resp *http.Response,
 		_ = c.signChatWithKey(reqBody, body, chatKey)
 	}
 
-	// Skip billing for whitelisted users
+	// Skip billing for whitelisted users, but record whitelist traffic metrics
 	if reqModel.IsWhitelisted {
+		monitor.RecordTokens("image-editing", 0, reqModel.OutputCount)
+		monitor.RecordWhitelistTokens("image-editing", 0, reqModel.OutputCount)
 		return nil
 	}
 
@@ -221,6 +224,7 @@ func (c *Ctrl) handleImageEditingResponse(ctx *gin.Context, resp *http.Response,
 		return errors.Wrap(err, "update request fees and count in database")
 	}
 
+	monitor.RecordTokens("image-editing", 0, imageNum)
 	return nil
 }
 

--- a/api/inference/internal/ctrl/settlement_tee.go
+++ b/api/inference/internal/ctrl/settlement_tee.go
@@ -777,9 +777,10 @@ func (c *Ctrl) deleteRequests(requests []*model.Request) error {
 		return nil
 	}
 
-	requestHashes := c.getRequestHashes(requests)
-	if err := c.db.DeleteRequestsByHashes(requestHashes); err != nil {
-		c.logger.Errorf("CRITICAL: failed to delete settled requests: %v, hashes: %v", err, requestHashes)
+	// Atomically accumulate stats and delete requests in a single transaction
+	// to prevent double-counting if deletion fails after accumulation
+	if err := c.db.AccumulateAndDeleteRequests(requests); err != nil {
+		c.logger.Errorf("CRITICAL: failed to accumulate stats and delete settled requests: %v", err)
 		return err
 	}
 	return nil

--- a/api/inference/internal/ctrl/speech_to_text.go
+++ b/api/inference/internal/ctrl/speech_to_text.go
@@ -125,8 +125,12 @@ func (c *Ctrl) handleNonStreamingSpeechToText(ctx *gin.Context, resp *http.Respo
 		_ = c.signChatWithKey(reqBody, body, chatKey)
 	}
 
-	// Skip billing for whitelisted users
+	// Skip billing for whitelisted users, but record whitelist traffic metrics
 	if reqModel.IsWhitelisted {
+		if transcriptionResp.Usage != nil {
+			monitor.RecordTokens("speech_to_text", int64(transcriptionResp.Usage.InputTokens), int64(transcriptionResp.Usage.OutputTokens))
+			monitor.RecordWhitelistTokens("speech_to_text", int64(transcriptionResp.Usage.InputTokens), int64(transcriptionResp.Usage.OutputTokens))
+		}
 		return nil
 	}
 
@@ -222,8 +226,12 @@ func (c *Ctrl) handleStreamingSpeechToText(ctx *gin.Context, resp *http.Response
 		_ = c.signChatWithKey(reqBody, rawBody.Bytes(), chatKey)
 	}
 
-	// Skip billing for whitelisted users
+	// Skip billing for whitelisted users, but record whitelist traffic metrics
 	if reqModel.IsWhitelisted {
+		if usage != nil {
+			monitor.RecordTokens("speech_to_text", int64(usage.InputTokens), int64(usage.OutputTokens))
+			monitor.RecordWhitelistTokens("speech_to_text", int64(usage.InputTokens), int64(usage.OutputTokens))
+		}
 		return nil
 	}
 

--- a/api/inference/internal/ctrl/text_to_image.go
+++ b/api/inference/internal/ctrl/text_to_image.go
@@ -11,6 +11,7 @@ import (
 	"github.com/0glabs/0g-serving-broker/common/errors"
 	"github.com/0glabs/0g-serving-broker/common/util"
 	"github.com/0glabs/0g-serving-broker/inference/model"
+	"github.com/0glabs/0g-serving-broker/inference/monitor"
 )
 
 // GetTextToImageInputFeeAndImageNum gets input fee and imageNum for text-to-image generation
@@ -64,8 +65,10 @@ func (c *Ctrl) handleTextToImageResponse(ctx *gin.Context, resp *http.Response, 
 		_ = c.signChatWithKey(reqBody, body, chatKey)
 	}
 
-	// Skip billing for whitelisted users
+	// Skip billing for whitelisted users, but record whitelist traffic metrics
 	if reqModel.IsWhitelisted {
+		monitor.RecordTokens("text-to-image", 0, reqModel.OutputCount)
+		monitor.RecordWhitelistTokens("text-to-image", 0, reqModel.OutputCount)
 		return nil
 	}
 
@@ -82,5 +85,6 @@ func (c *Ctrl) handleTextToImageResponse(ctx *gin.Context, resp *http.Response, 
 		return errors.Wrap(err, "update request fees and count in database")
 	}
 
+	monitor.RecordTokens("text-to-image", 0, imageNum)
 	return nil
 }

--- a/api/inference/internal/ctrl/video.go
+++ b/api/inference/internal/ctrl/video.go
@@ -13,6 +13,7 @@ import (
 	"github.com/0glabs/0g-serving-broker/common/errors"
 	"github.com/0glabs/0g-serving-broker/common/util"
 	"github.com/0glabs/0g-serving-broker/inference/model"
+	"github.com/0glabs/0g-serving-broker/inference/monitor"
 )
 
 // parseMultipartField extracts a named field value from multipart/form-data body.
@@ -83,6 +84,20 @@ func (c *Ctrl) handleVideoGenerationResponse(ctx *gin.Context, resp *http.Respon
 	}
 
 	if reqModel.IsWhitelisted {
+		// Parse seconds from response for whitelist traffic metrics
+		var wlFields videoResponseFields
+		if err := json.Unmarshal(body, &wlFields); err != nil {
+			c.logger.Warnf("whitelist video: failed to parse response for metrics: %v", err)
+		} else if sec, err := wlFields.Seconds.Int64(); err != nil {
+			c.logger.Warnf("whitelist video: failed to parse seconds field: %v", err)
+		} else if sec <= 0 {
+			c.logger.Warnf("whitelist video: invalid seconds value: %d", sec)
+		} else {
+			sizeRatio := c.Service.GetVideoSizeRatio(wlFields.Size)
+			outputCount := int64(math.Ceil(float64(sec) * sizeRatio))
+			monitor.RecordTokens("video-generation", 0, outputCount)
+			monitor.RecordWhitelistTokens("video-generation", 0, outputCount)
+		}
 		return nil
 	}
 
@@ -115,6 +130,7 @@ func (c *Ctrl) handleVideoGenerationResponse(ctx *gin.Context, resp *http.Respon
 		return errors.Wrap(err, "update request fees and count in database")
 	}
 
+	monitor.RecordTokens("video-generation", 0, outputCount)
 	return nil
 }
 

--- a/api/inference/internal/db/daily_stat.go
+++ b/api/inference/internal/db/daily_stat.go
@@ -1,0 +1,114 @@
+package db
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/0glabs/0g-serving-broker/inference/model"
+	"gorm.io/gorm"
+)
+
+// AccumulateAndDeleteRequests atomically accumulates request stats into daily_stat
+// and deletes the requests in a single transaction. This prevents double-counting
+// that would occur if accumulation succeeds but deletion fails.
+func (d *DB) AccumulateAndDeleteRequests(requests []*model.Request) error {
+	if len(requests) == 0 {
+		return nil
+	}
+
+	var totalRequests int64
+	var inputTokens, outputTokens int64
+	hashes := make([]string, 0, len(requests))
+
+	for _, req := range requests {
+		totalRequests++
+		inputTokens += req.InputCount
+		outputTokens += req.OutputCount
+		hashes = append(hashes, req.RequestHash)
+	}
+
+	today := time.Now().UTC().Format("2006-01-02")
+
+	return d.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Exec(
+			`INSERT INTO daily_stat (date, total_requests, input_tokens, output_tokens)
+			 VALUES (?, ?, ?, ?)
+			 ON DUPLICATE KEY UPDATE
+			   total_requests = total_requests + VALUES(total_requests),
+			   input_tokens = input_tokens + VALUES(input_tokens),
+			   output_tokens = output_tokens + VALUES(output_tokens)`,
+			today, totalRequests, inputTokens, outputTokens,
+		).Error; err != nil {
+			return fmt.Errorf("failed to accumulate daily stats: %w", err)
+		}
+
+		if err := tx.Where("request_hash IN ?", hashes).Delete(&model.Request{}).Error; err != nil {
+			return fmt.Errorf("failed to delete requests: %w", err)
+		}
+
+		return nil
+	})
+}
+
+// TotalStats holds the all-time cumulative statistics.
+type TotalStats struct {
+	TotalRequests     int64 `json:"totalRequests"`
+	TotalInputTokens  int64 `json:"totalInputTokens"`
+	TotalOutputTokens int64 `json:"totalOutputTokens"`
+	TotalUniqueUsers  int64 `json:"totalUniqueUsers"`
+}
+
+// GetTotalStats returns the all-time cumulative stats by summing all daily_stat rows.
+func (d *DB) GetTotalStats() (TotalStats, error) {
+	var stats TotalStats
+	err := d.db.Model(&model.DailyStat{}).
+		Select("COALESCE(SUM(total_requests), 0) as total_requests, COALESCE(SUM(input_tokens), 0) as total_input_tokens, COALESCE(SUM(output_tokens), 0) as total_output_tokens").
+		Scan(&stats).Error
+	return stats, err
+}
+
+// GetTotalUniqueUsers returns the all-time count of unique users
+// by counting distinct users in the user table (which uses soft delete, never hard deleted).
+func (d *DB) GetTotalUniqueUsers() (int64, error) {
+	var count int64
+	err := d.db.Model(&model.User{}).
+		Where("deleted_at = 0").
+		Count(&count).Error
+	return count, err
+}
+
+// GetPendingRequestStats returns the stats from requests that haven't been settled yet
+// (still in the request table). These need to be added to daily_stats totals for accuracy.
+func (d *DB) GetPendingRequestStats() (TotalStats, error) {
+	var stats TotalStats
+	err := d.db.Model(&model.Request{}).
+		Select("COUNT(*) as total_requests, COALESCE(SUM(input_count), 0) as total_input_tokens, COALESCE(SUM(output_count), 0) as total_output_tokens").
+		Scan(&stats).Error
+	return stats, err
+}
+
+// GetCombinedTotalStats returns the true all-time totals by combining
+// daily_stat (settled) + pending requests (unsettled) + unique users from user table.
+func (d *DB) GetCombinedTotalStats() (TotalStats, error) {
+	settled, err := d.GetTotalStats()
+	if err != nil {
+		return TotalStats{}, fmt.Errorf("failed to get settled stats: %w", err)
+	}
+
+	pending, err := d.GetPendingRequestStats()
+	if err != nil {
+		return TotalStats{}, fmt.Errorf("failed to get pending stats: %w", err)
+	}
+
+	users, err := d.GetTotalUniqueUsers()
+	if err != nil {
+		return TotalStats{}, fmt.Errorf("failed to get total unique users: %w", err)
+	}
+
+	return TotalStats{
+		TotalRequests:     settled.TotalRequests + pending.TotalRequests,
+		TotalInputTokens:  settled.TotalInputTokens + pending.TotalInputTokens,
+		TotalOutputTokens: settled.TotalOutputTokens + pending.TotalOutputTokens,
+		TotalUniqueUsers:  users,
+	}, nil
+}

--- a/api/inference/internal/db/daily_stat.go
+++ b/api/inference/internal/db/daily_stat.go
@@ -2,7 +2,6 @@ package db
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/0glabs/0g-serving-broker/inference/model"
 	"gorm.io/gorm"
@@ -27,17 +26,15 @@ func (d *DB) AccumulateAndDeleteRequests(requests []*model.Request) error {
 		hashes = append(hashes, req.RequestHash)
 	}
 
-	today := time.Now().UTC().Format("2006-01-02")
-
 	return d.db.Transaction(func(tx *gorm.DB) error {
 		if err := tx.Exec(
 			`INSERT INTO daily_stat (date, total_requests, input_tokens, output_tokens)
-			 VALUES (?, ?, ?, ?)
+			 VALUES (UTC_DATE(), ?, ?, ?) AS new_vals
 			 ON DUPLICATE KEY UPDATE
-			   total_requests = total_requests + VALUES(total_requests),
-			   input_tokens = input_tokens + VALUES(input_tokens),
-			   output_tokens = output_tokens + VALUES(output_tokens)`,
-			today, totalRequests, inputTokens, outputTokens,
+			   total_requests = total_requests + new_vals.total_requests,
+			   input_tokens = input_tokens + new_vals.input_tokens,
+			   output_tokens = output_tokens + new_vals.output_tokens`,
+			totalRequests, inputTokens, outputTokens,
 		).Error; err != nil {
 			return fmt.Errorf("failed to accumulate daily stats: %w", err)
 		}
@@ -58,57 +55,44 @@ type TotalStats struct {
 	TotalUniqueUsers  int64 `json:"totalUniqueUsers"`
 }
 
-// GetTotalStats returns the all-time cumulative stats by summing all daily_stat rows.
-func (d *DB) GetTotalStats() (TotalStats, error) {
-	var stats TotalStats
-	err := d.db.Model(&model.DailyStat{}).
-		Select("COALESCE(SUM(total_requests), 0) as total_requests, COALESCE(SUM(input_tokens), 0) as total_input_tokens, COALESCE(SUM(output_tokens), 0) as total_output_tokens").
-		Scan(&stats).Error
-	return stats, err
-}
-
-// GetTotalUniqueUsers returns the all-time count of unique users
-// by counting distinct users in the user table (which uses soft delete, never hard deleted).
-func (d *DB) GetTotalUniqueUsers() (int64, error) {
-	var count int64
-	err := d.db.Model(&model.User{}).
-		Where("deleted_at = 0").
-		Count(&count).Error
-	return count, err
-}
-
-// GetPendingRequestStats returns the stats from requests that haven't been settled yet
-// (still in the request table). These need to be added to daily_stats totals for accuracy.
-func (d *DB) GetPendingRequestStats() (TotalStats, error) {
-	var stats TotalStats
-	err := d.db.Model(&model.Request{}).
-		Select("COUNT(*) as total_requests, COALESCE(SUM(input_count), 0) as total_input_tokens, COALESCE(SUM(output_count), 0) as total_output_tokens").
-		Scan(&stats).Error
-	return stats, err
-}
-
 // GetCombinedTotalStats returns the true all-time totals by combining
 // daily_stat (settled) + pending requests (unsettled) + unique users from user table.
+// All three queries run in a single transaction to avoid read skew when settlement
+// concurrently moves data from the request table into daily_stat.
 func (d *DB) GetCombinedTotalStats() (TotalStats, error) {
-	settled, err := d.GetTotalStats()
-	if err != nil {
-		return TotalStats{}, fmt.Errorf("failed to get settled stats: %w", err)
-	}
+	var result TotalStats
+	err := d.db.Transaction(func(tx *gorm.DB) error {
+		// Settled stats from daily_stat
+		var settled TotalStats
+		if err := tx.Model(&model.DailyStat{}).
+			Select("COALESCE(SUM(total_requests), 0) as total_requests, COALESCE(SUM(input_tokens), 0) as total_input_tokens, COALESCE(SUM(output_tokens), 0) as total_output_tokens").
+			Scan(&settled).Error; err != nil {
+			return fmt.Errorf("failed to get settled stats: %w", err)
+		}
 
-	pending, err := d.GetPendingRequestStats()
-	if err != nil {
-		return TotalStats{}, fmt.Errorf("failed to get pending stats: %w", err)
-	}
+		// Pending stats from request table
+		var pending TotalStats
+		if err := tx.Model(&model.Request{}).
+			Select("COUNT(*) as total_requests, COALESCE(SUM(input_count), 0) as total_input_tokens, COALESCE(SUM(output_count), 0) as total_output_tokens").
+			Scan(&pending).Error; err != nil {
+			return fmt.Errorf("failed to get pending stats: %w", err)
+		}
 
-	users, err := d.GetTotalUniqueUsers()
-	if err != nil {
-		return TotalStats{}, fmt.Errorf("failed to get total unique users: %w", err)
-	}
+		// Unique users from user table
+		var users int64
+		if err := tx.Model(&model.User{}).
+			Where("deleted_at = 0").
+			Count(&users).Error; err != nil {
+			return fmt.Errorf("failed to get total unique users: %w", err)
+		}
 
-	return TotalStats{
-		TotalRequests:     settled.TotalRequests + pending.TotalRequests,
-		TotalInputTokens:  settled.TotalInputTokens + pending.TotalInputTokens,
-		TotalOutputTokens: settled.TotalOutputTokens + pending.TotalOutputTokens,
-		TotalUniqueUsers:  users,
-	}, nil
+		result = TotalStats{
+			TotalRequests:     settled.TotalRequests + pending.TotalRequests,
+			TotalInputTokens:  settled.TotalInputTokens + pending.TotalInputTokens,
+			TotalOutputTokens: settled.TotalOutputTokens + pending.TotalOutputTokens,
+			TotalUniqueUsers:  users,
+		}
+		return nil
+	})
+	return result, err
 }

--- a/api/inference/internal/db/migrate.go
+++ b/api/inference/internal/db/migrate.go
@@ -228,6 +228,38 @@ func (d *DB) Migrate() error {
 				return tx.AutoMigrate(&AdapterKey{})
 			},
 		},
+		{
+			ID: "create-daily-stat",
+			Migrate: func(tx *gorm.DB) error {
+				type DailyStat struct {
+					Date          string `gorm:"type:date;primaryKey"`
+					TotalRequests int64  `gorm:"type:bigint;not null;default:0"`
+					InputTokens   int64  `gorm:"type:bigint;not null;default:0"`
+					OutputTokens  int64  `gorm:"type:bigint;not null;default:0"`
+				}
+				return tx.AutoMigrate(&DailyStat{})
+			},
+		},
+		{
+			ID: "add-last-active-at-to-user",
+			Migrate: func(tx *gorm.DB) error {
+				type User struct {
+					LastActiveAt *time.Time `gorm:"type:datetime;index:idx_user_last_active"`
+				}
+				return tx.AutoMigrate(&User{})
+			},
+		},
+		{
+			ID: "add-created-at-index-to-request",
+			Migrate: func(tx *gorm.DB) error {
+				var count int64
+				tx.Raw("SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'request' AND index_name = 'idx_request_created_at'").Scan(&count)
+				if count == 0 {
+					return tx.Exec("CREATE INDEX `idx_request_created_at` ON `request`(`created_at`);").Error
+				}
+				return nil
+			},
+		},
 	})
 
 	return errors.Wrap(m.Migrate(), "migrate database")

--- a/api/inference/internal/db/migrate.go
+++ b/api/inference/internal/db/migrate.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/0glabs/0g-serving-broker/inference/model"
@@ -253,7 +254,9 @@ func (d *DB) Migrate() error {
 			ID: "add-created-at-index-to-request",
 			Migrate: func(tx *gorm.DB) error {
 				var count int64
-				tx.Raw("SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'request' AND index_name = 'idx_request_created_at'").Scan(&count)
+				if err := tx.Raw("SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = 'request' AND index_name = 'idx_request_created_at'").Scan(&count).Error; err != nil {
+					return fmt.Errorf("check for existing index idx_request_created_at: %w", err)
+				}
 				if count == 0 {
 					return tx.Exec("CREATE INDEX `idx_request_created_at` ON `request`(`created_at`);").Error
 				}

--- a/api/inference/internal/db/request.go
+++ b/api/inference/internal/db/request.go
@@ -144,6 +144,8 @@ func (d *DB) CreateRequest(req model.Request) error {
 
 	// Update user's last_active_at for DAU tracking.
 	// Uses a raw update to avoid triggering full model callbacks.
+	// Non-fatal: request creation already succeeded, so don't fail the request.
+	// Errors are logged by GORM's built-in logger at the SQL level.
 	now := time.Now()
 	d.db.Model(&model.User{}).
 		Where("user = ?", req.UserAddress).

--- a/api/inference/internal/db/request.go
+++ b/api/inference/internal/db/request.go
@@ -138,8 +138,18 @@ func (d *DB) UpdateRequestWithAccurateTokens(requestHash, inputFee, outputFee, t
 }
 
 func (d *DB) CreateRequest(req model.Request) error {
-	ret := d.db.Create(&req)
-	return ret.Error
+	if err := d.db.Create(&req).Error; err != nil {
+		return err
+	}
+
+	// Update user's last_active_at for DAU tracking.
+	// Uses a raw update to avoid triggering full model callbacks.
+	now := time.Now()
+	d.db.Model(&model.User{}).
+		Where("user = ?", req.UserAddress).
+		Update("last_active_at", now)
+
+	return nil
 }
 
 func (d *DB) PruneRequest(pruneThreshold time.Duration) error {
@@ -190,6 +200,19 @@ func (d *DB) ClearExpiredSkipUntil() error {
 	return d.db.Model(&model.Request{}).
 		Where("skip_until IS NOT NULL AND skip_until <= ?", now).
 		Update("skip_until", nil).Error
+}
+
+// CountUniqueUsersLast24h returns the number of unique users active in the last 24 hours.
+// Queries the user table's last_active_at field, which is only updated when a user
+// makes an actual request (not during contract sync or other system operations).
+func (d *DB) CountUniqueUsersLast24h() (int64, error) {
+	var count int64
+	cutoff := time.Now().Add(-24 * time.Hour)
+	err := d.db.Model(&model.User{}).
+		Where("deleted_at = 0").
+		Where("last_active_at >= ?", cutoff).
+		Count(&count).Error
+	return count, err
 }
 
 // DeleteRequestsByHashes deletes specific requests by their hashes

--- a/api/inference/internal/handler/async.go
+++ b/api/inference/internal/handler/async.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/0glabs/0g-serving-broker/inference/model"
+	"github.com/0glabs/0g-serving-broker/inference/monitor"
 )
 
 // submitAsyncJob is the shared logic for all async submit endpoints.
@@ -43,6 +44,9 @@ func (h *Handler) submitAsyncJob(ctx *gin.Context, svcType string) {
 
 	// Check whitelist
 	isWhitelisted := h.asyncCtrl.IsWhitelistedUser(userAddress)
+	if isWhitelisted {
+		monitor.RecordWhitelistRequest(svcType)
+	}
 
 	// Store only necessary request headers (Content-Type is critical for multipart boundary)
 	headerMap := map[string][]string{}

--- a/api/inference/internal/proxy/proxy.go
+++ b/api/inference/internal/proxy/proxy.go
@@ -339,9 +339,6 @@ func (p *Proxy) proxyHTTPRequest(ctx *gin.Context) {
 		return
 	}
 
-	// Record unique user for DAU tracking
-	monitor.RecordUniqueUser(userAddress)
-
 	// LoRA owner check: for ft-* models, verify requester is the task owner
 	reqModelName := ctrl.ExtractModelName(reqBody)
 	if err := p.ctrl.CheckLoRAOwnership(reqModelName, userAddress); err != nil {

--- a/api/inference/internal/proxy/proxy.go
+++ b/api/inference/internal/proxy/proxy.go
@@ -356,6 +356,7 @@ func (p *Proxy) proxyHTTPRequest(ctx *gin.Context) {
 			logPath = logPath[:idx]
 		}
 		p.logger.Infof("Whitelist user request: user=%s, service=%s, path=%s", userAddress, svcType, logPath)
+		monitor.RecordWhitelistRequest(svcType)
 
 		// Create a minimal request model for whitelist user
 		// IsWhitelisted flag will skip billing but preserve response processing (stream handling, signing, etc.)

--- a/api/inference/model/daily_stat.go
+++ b/api/inference/model/daily_stat.go
@@ -1,0 +1,11 @@
+package model
+
+// DailyStat stores aggregated daily statistics for marketing and analytics.
+// Each row represents one calendar day (UTC). Token counts and request counts
+// are accumulated before settled requests are deleted.
+type DailyStat struct {
+	Date          string `gorm:"type:date;primaryKey" json:"date"`
+	TotalRequests int64  `gorm:"type:bigint;not null;default:0" json:"totalRequests"`
+	InputTokens   int64  `gorm:"type:bigint;not null;default:0" json:"inputTokens"`
+	OutputTokens  int64  `gorm:"type:bigint;not null;default:0" json:"outputTokens"`
+}

--- a/api/inference/model/user.go
+++ b/api/inference/model/user.go
@@ -13,6 +13,7 @@ type User struct {
 	LastBalanceCheckTime *time.Time            `json:"lastBalanceCheckTime"`
 	Signer               StringSlice           `gorm:"type:json;not null;default:('[]')" json:"signer"`
 	SkipUntil            *time.Time            `gorm:"type:datetime;index" json:"skipUntil,omitempty"`
+	LastActiveAt         *time.Time            `gorm:"type:datetime;index:idx_user_last_active" json:"lastActiveAt,omitempty"`
 	DeletedAt            soft_delete.DeletedAt `gorm:"softDelete:nano;not null;default:0;index:deleted_user_provider" json:"-" readonly:"true"`
 }
 

--- a/api/inference/monitor/server.go
+++ b/api/inference/monitor/server.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/0glabs/0g-serving-broker/common/log"
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -24,8 +25,11 @@ var (
 	// TokensPerSecond records per-request output token generation rate as a histogram, labeled by service_type.
 	TokensPerSecond *prometheus.HistogramVec
 
-	// uniqueUsersChan is a buffered channel for async user recording (non-blocking)
-	uniqueUsersChan chan string
+	// All-time cumulative gauges (queried from database, survive restarts)
+	AllTimeRequests    prometheus.Gauge
+	AllTimeInputTokens prometheus.Gauge
+	AllTimeOutputTokens prometheus.Gauge
+	AllTimeUniqueUsers prometheus.Gauge
 )
 
 func PrometheusInit(serverName string) {
@@ -64,7 +68,7 @@ func PrometheusInit(serverName string) {
 	UniqueUsersTotal = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name:        "broker_unique_users_total",
-			Help:        "Number of unique users for the current day (resets daily at UTC midnight).",
+			Help:        "Number of unique users in the last 24 hours (queried from database).",
 			ConstLabels: prometheus.Labels{"server": serverName},
 		},
 	)
@@ -97,6 +101,30 @@ func PrometheusInit(serverName string) {
 		[]string{"service_type"},
 	)
 
+	AllTimeRequests = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name:        "broker_alltime_requests_total",
+		Help:        "All-time total number of requests (from database).",
+		ConstLabels: prometheus.Labels{"server": serverName},
+	})
+
+	AllTimeInputTokens = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name:        "broker_alltime_input_tokens_total",
+		Help:        "All-time total input token count (from database).",
+		ConstLabels: prometheus.Labels{"server": serverName},
+	})
+
+	AllTimeOutputTokens = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name:        "broker_alltime_output_tokens_total",
+		Help:        "All-time total output token count (from database).",
+		ConstLabels: prometheus.Labels{"server": serverName},
+	})
+
+	AllTimeUniqueUsers = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name:        "broker_alltime_unique_users_total",
+		Help:        "All-time total unique users (from database).",
+		ConstLabels: prometheus.Labels{"server": serverName},
+	})
+
 	prometheus.MustRegister(RequestCount)
 	prometheus.MustRegister(ErrorCount)
 	prometheus.MustRegister(RequestDuration)
@@ -104,32 +132,69 @@ func PrometheusInit(serverName string) {
 	prometheus.MustRegister(InputTokensTotal)
 	prometheus.MustRegister(OutputTokensTotal)
 	prometheus.MustRegister(TokensPerSecond)
-
-	// Initialize buffered channel and start background processor
-	uniqueUsersChan = make(chan string, 10000)
-	go processUniqueUsers()
+	prometheus.MustRegister(AllTimeRequests)
+	prometheus.MustRegister(AllTimeInputTokens)
+	prometheus.MustRegister(AllTimeOutputTokens)
+	prometheus.MustRegister(AllTimeUniqueUsers)
 }
 
-// processUniqueUsers runs in background and processes user addresses without blocking requests
-func processUniqueUsers() {
-	uniqueUsers := make(map[string]struct{})
-	lastResetDay := time.Now().UTC().YearDay()
+// StartDAUUpdater starts a background goroutine that periodically queries the database
+// to count unique users in the last 24 hours and updates the Prometheus gauge.
+// This ensures the DAU metric survives process restarts.
+func StartDAUUpdater(queryFunc func() (int64, error), interval time.Duration, logger log.Logger) {
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
 
-	for userAddress := range uniqueUsersChan {
-		// Check if we need to reset (new day)
-		currentDay := time.Now().UTC().YearDay()
-		if currentDay != lastResetDay {
-			uniqueUsers = make(map[string]struct{})
-			lastResetDay = currentDay
-			UniqueUsersTotal.Set(0)
+		// Run immediately on startup
+		if count, err := queryFunc(); err != nil {
+			logger.Errorf("DAU updater: failed to query unique users: %v", err)
+		} else {
+			UniqueUsersTotal.Set(float64(count))
 		}
 
-		// Add user if not already present
-		if _, exists := uniqueUsers[userAddress]; !exists {
-			uniqueUsers[userAddress] = struct{}{}
-			UniqueUsersTotal.Set(float64(len(uniqueUsers)))
+		for range ticker.C {
+			if count, err := queryFunc(); err != nil {
+				logger.Errorf("DAU updater: failed to query unique users: %v", err)
+			} else {
+				UniqueUsersTotal.Set(float64(count))
+			}
 		}
-	}
+	}()
+}
+
+// TotalStatsResult holds the combined stats for the all-time gauges.
+type TotalStatsResult struct {
+	TotalRequests     int64
+	TotalInputTokens  int64
+	TotalOutputTokens int64
+	TotalUniqueUsers  int64
+}
+
+// StartAllTimeStatsUpdater starts a background goroutine that periodically queries
+// the database for all-time cumulative stats and updates the Prometheus gauges.
+func StartAllTimeStatsUpdater(queryFunc func() (TotalStatsResult, error), interval time.Duration, logger log.Logger) {
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		update := func() {
+			stats, err := queryFunc()
+			if err != nil {
+				logger.Errorf("All-time stats updater: failed to query: %v", err)
+				return
+			}
+			AllTimeRequests.Set(float64(stats.TotalRequests))
+			AllTimeInputTokens.Set(float64(stats.TotalInputTokens))
+			AllTimeOutputTokens.Set(float64(stats.TotalOutputTokens))
+			AllTimeUniqueUsers.Set(float64(stats.TotalUniqueUsers))
+		}
+
+		update()
+		for range ticker.C {
+			update()
+		}
+	}()
 }
 
 // RequestStartTimeKey is the gin context key for the request start time.
@@ -156,21 +221,6 @@ func TrackMetrics() gin.HandlerFunc {
 		if !ignoreError && status >= 400 {
 			ErrorCount.WithLabelValues(path, http.StatusText(status)).Inc()
 		}
-	}
-}
-
-// RecordUniqueUser records a unique user for the current day (non-blocking).
-// It sends the user address to a buffered channel for async processing.
-func RecordUniqueUser(userAddress string) {
-	if userAddress == "" || uniqueUsersChan == nil {
-		return
-	}
-
-	// Non-blocking send: if channel is full, skip this record
-	select {
-	case uniqueUsersChan <- userAddress:
-	default:
-		// Channel full, skip to avoid blocking request
 	}
 }
 

--- a/api/inference/monitor/server.go
+++ b/api/inference/monitor/server.go
@@ -30,6 +30,13 @@ var (
 	AllTimeInputTokens prometheus.Gauge
 	AllTimeOutputTokens prometheus.Gauge
 	AllTimeUniqueUsers prometheus.Gauge
+
+	// Whitelist traffic metrics — track requests and tokens from whitelisted
+	// (internal/exempt) users so operators can gauge their share of total traffic
+	// and set appropriate RPM/TPM limits for the provider.
+	WhitelistRequestsTotal  *prometheus.CounterVec
+	WhitelistInputTokensTotal  *prometheus.CounterVec
+	WhitelistOutputTokensTotal *prometheus.CounterVec
 )
 
 func PrometheusInit(serverName string) {
@@ -125,6 +132,33 @@ func PrometheusInit(serverName string) {
 		ConstLabels: prometheus.Labels{"server": serverName},
 	})
 
+	WhitelistRequestsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name:        "broker_whitelist_requests_total",
+			Help:        "Total number of requests from whitelisted (internal) users, labeled by service_type.",
+			ConstLabels: prometheus.Labels{"server": serverName},
+		},
+		[]string{"service_type"},
+	)
+
+	WhitelistInputTokensTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name:        "broker_whitelist_input_tokens_total",
+			Help:        "Cumulative input token count from whitelisted (internal) users.",
+			ConstLabels: prometheus.Labels{"server": serverName},
+		},
+		[]string{"service_type"},
+	)
+
+	WhitelistOutputTokensTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name:        "broker_whitelist_output_tokens_total",
+			Help:        "Cumulative output token count from whitelisted (internal) users.",
+			ConstLabels: prometheus.Labels{"server": serverName},
+		},
+		[]string{"service_type"},
+	)
+
 	prometheus.MustRegister(RequestCount)
 	prometheus.MustRegister(ErrorCount)
 	prometheus.MustRegister(RequestDuration)
@@ -136,12 +170,16 @@ func PrometheusInit(serverName string) {
 	prometheus.MustRegister(AllTimeInputTokens)
 	prometheus.MustRegister(AllTimeOutputTokens)
 	prometheus.MustRegister(AllTimeUniqueUsers)
+	prometheus.MustRegister(WhitelistRequestsTotal)
+	prometheus.MustRegister(WhitelistInputTokensTotal)
+	prometheus.MustRegister(WhitelistOutputTokensTotal)
 }
 
 // StartDAUUpdater starts a background goroutine that periodically queries the database
 // to count unique users in the last 24 hours and updates the Prometheus gauge.
 // This ensures the DAU metric survives process restarts.
-func StartDAUUpdater(queryFunc func() (int64, error), interval time.Duration, logger log.Logger) {
+// The goroutine exits when ctx is cancelled.
+func StartDAUUpdater(ctx context.Context, queryFunc func() (int64, error), interval time.Duration, logger log.Logger) {
 	go func() {
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
@@ -153,11 +191,16 @@ func StartDAUUpdater(queryFunc func() (int64, error), interval time.Duration, lo
 			UniqueUsersTotal.Set(float64(count))
 		}
 
-		for range ticker.C {
-			if count, err := queryFunc(); err != nil {
-				logger.Errorf("DAU updater: failed to query unique users: %v", err)
-			} else {
-				UniqueUsersTotal.Set(float64(count))
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if count, err := queryFunc(); err != nil {
+					logger.Errorf("DAU updater: failed to query unique users: %v", err)
+				} else {
+					UniqueUsersTotal.Set(float64(count))
+				}
 			}
 		}
 	}()
@@ -173,7 +216,8 @@ type TotalStatsResult struct {
 
 // StartAllTimeStatsUpdater starts a background goroutine that periodically queries
 // the database for all-time cumulative stats and updates the Prometheus gauges.
-func StartAllTimeStatsUpdater(queryFunc func() (TotalStatsResult, error), interval time.Duration, logger log.Logger) {
+// The goroutine exits when ctx is cancelled.
+func StartAllTimeStatsUpdater(ctx context.Context, queryFunc func() (TotalStatsResult, error), interval time.Duration, logger log.Logger) {
 	go func() {
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
@@ -191,8 +235,13 @@ func StartAllTimeStatsUpdater(queryFunc func() (TotalStatsResult, error), interv
 		}
 
 		update()
-		for range ticker.C {
-			update()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				update()
+			}
 		}
 	}()
 }
@@ -234,6 +283,27 @@ func RecordTokens(serviceType string, inputTokens, outputTokens int64) {
 	}
 	if outputTokens > 0 {
 		OutputTokensTotal.WithLabelValues(serviceType).Add(float64(outputTokens))
+	}
+}
+
+// RecordWhitelistRequest increments the whitelist request counter for the given service type.
+func RecordWhitelistRequest(serviceType string) {
+	if WhitelistRequestsTotal == nil {
+		return
+	}
+	WhitelistRequestsTotal.WithLabelValues(serviceType).Inc()
+}
+
+// RecordWhitelistTokens increments the whitelist input and output token counters.
+func RecordWhitelistTokens(serviceType string, inputTokens, outputTokens int64) {
+	if WhitelistInputTokensTotal == nil || WhitelistOutputTokensTotal == nil {
+		return
+	}
+	if inputTokens > 0 {
+		WhitelistInputTokensTotal.WithLabelValues(serviceType).Add(float64(inputTokens))
+	}
+	if outputTokens > 0 {
+		WhitelistOutputTokensTotal.WithLabelValues(serviceType).Add(float64(outputTokens))
 	}
 }
 

--- a/api/inference/monitor/server_test.go
+++ b/api/inference/monitor/server_test.go
@@ -7,10 +7,42 @@ import (
 	"testing"
 	"time"
 
+	"github.com/0glabs/0g-serving-broker/common/log"
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
+	logrus "github.com/sirupsen/logrus"
 )
+
+// testLogger is a no-op logger for testing.
+type testLogger struct{}
+
+func (testLogger) Debugf(string, ...interface{})   {}
+func (testLogger) Infof(string, ...interface{})     {}
+func (testLogger) Printf(string, ...interface{})    {}
+func (testLogger) Warnf(string, ...interface{})     {}
+func (testLogger) Warningf(string, ...interface{})  {}
+func (testLogger) Errorf(string, ...interface{})    {}
+func (testLogger) Fatalf(string, ...interface{})    {}
+func (testLogger) Panicf(string, ...interface{})    {}
+func (testLogger) Debug(...interface{})             {}
+func (testLogger) Info(...interface{})              {}
+func (testLogger) Print(...interface{})             {}
+func (testLogger) Warn(...interface{})              {}
+func (testLogger) Warning(...interface{})           {}
+func (testLogger) Error(...interface{})             {}
+func (testLogger) Fatal(...interface{})             {}
+func (testLogger) Panic(...interface{})             {}
+func (testLogger) Debugln(...interface{})           {}
+func (testLogger) Infoln(...interface{})            {}
+func (testLogger) Println(...interface{})           {}
+func (testLogger) Warnln(...interface{})            {}
+func (testLogger) Warningln(...interface{})         {}
+func (testLogger) Errorln(...interface{})           {}
+func (testLogger) Fatalln(...interface{})           {}
+func (testLogger) Panicln(...interface{})           {}
+func (testLogger) WithFields(logrus.Fields) log.Logger { return testLogger{} }
+func (testLogger) InnerLogger() *logrus.Logger         { return logrus.New() }
 
 // setupTestMetrics creates fresh metrics with a unique server name to avoid
 // registration conflicts between tests. Each test gets its own registry.
@@ -379,54 +411,33 @@ func TestRecordTPSFromContextCalculation(t *testing.T) {
 	}
 }
 
-// TestRecordUniqueUser verifies non-blocking user recording behavior.
-func TestRecordUniqueUser(t *testing.T) {
-	// Initialize channel for testing
-	uniqueUsersChan = make(chan string, 10)
+// TestStartDAUUpdater verifies the DB-backed DAU updater sets the gauge correctly.
+func TestStartDAUUpdater(t *testing.T) {
+	setupTestMetrics(t)
 
-	t.Run("records non-empty address", func(t *testing.T) {
-		RecordUniqueUser("0xabc123")
-		select {
-		case addr := <-uniqueUsersChan:
-			if addr != "0xabc123" {
-				t.Errorf("got %q, want %q", addr, "0xabc123")
-			}
-		default:
-			t.Error("expected address in channel, but channel was empty")
+	// Create a fresh gauge for testing
+	UniqueUsersTotal = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name:        "broker_unique_users_total_test",
+		Help:        "Test gauge",
+		ConstLabels: prometheus.Labels{"server": t.Name()},
+	})
+
+	t.Run("sets gauge from query function on startup", func(t *testing.T) {
+		queryFunc := func() (int64, error) {
+			return 42, nil
 		}
-	})
 
-	t.Run("skips empty address", func(t *testing.T) {
-		RecordUniqueUser("")
-		select {
-		case addr := <-uniqueUsersChan:
-			t.Errorf("expected no address in channel, got %q", addr)
-		default:
-			// expected
+		StartDAUUpdater(queryFunc, 1*time.Hour, testLogger{})
+
+		// Give the goroutine time to run the initial query
+		time.Sleep(50 * time.Millisecond)
+
+		m := &dto.Metric{}
+		if err := UniqueUsersTotal.Write(m); err != nil {
+			t.Fatalf("failed to read gauge: %v", err)
 		}
-	})
-
-	t.Run("skips when channel is nil", func(t *testing.T) {
-		saved := uniqueUsersChan
-		uniqueUsersChan = nil
-		defer func() { uniqueUsersChan = saved }()
-
-		// Should not panic
-		RecordUniqueUser("0xabc123")
-	})
-
-	t.Run("non-blocking when channel is full", func(t *testing.T) {
-		fullChan := make(chan string, 1)
-		fullChan <- "existing"
-		uniqueUsersChan = fullChan
-
-		// Should not block
-		RecordUniqueUser("0xnew")
-
-		// Channel should still contain only the original item
-		addr := <-fullChan
-		if addr != "existing" {
-			t.Errorf("got %q, want %q", addr, "existing")
+		if got := m.GetGauge().GetValue(); got != 42 {
+			t.Errorf("UniqueUsersTotal = %v, want 42", got)
 		}
 	})
 }

--- a/api/inference/monitor/server_test.go
+++ b/api/inference/monitor/server_test.go
@@ -108,8 +108,36 @@ func setupTestMetrics(t *testing.T) *prometheus.Registry {
 		[]string{"path"},
 	)
 
+	WhitelistRequestsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name:        "broker_whitelist_requests_total",
+			Help:        "Total whitelist requests.",
+			ConstLabels: prometheus.Labels{"server": serverName},
+		},
+		[]string{"service_type"},
+	)
+
+	WhitelistInputTokensTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name:        "broker_whitelist_input_tokens_total",
+			Help:        "Whitelist input tokens.",
+			ConstLabels: prometheus.Labels{"server": serverName},
+		},
+		[]string{"service_type"},
+	)
+
+	WhitelistOutputTokensTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name:        "broker_whitelist_output_tokens_total",
+			Help:        "Whitelist output tokens.",
+			ConstLabels: prometheus.Labels{"server": serverName},
+		},
+		[]string{"service_type"},
+	)
+
 	registry.MustRegister(InputTokensTotal, OutputTokensTotal, TokensPerSecond,
-		RequestCount, ErrorCount, RequestDuration)
+		RequestCount, ErrorCount, RequestDuration,
+		WhitelistRequestsTotal, WhitelistInputTokensTotal, WhitelistOutputTokensTotal)
 
 	return registry
 }
@@ -427,7 +455,10 @@ func TestStartDAUUpdater(t *testing.T) {
 			return 42, nil
 		}
 
-		StartDAUUpdater(queryFunc, 1*time.Hour, testLogger{})
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		StartDAUUpdater(ctx, queryFunc, 1*time.Hour, testLogger{})
 
 		// Give the goroutine time to run the initial query
 		time.Sleep(50 * time.Millisecond)
@@ -550,4 +581,126 @@ func TestTrackMetricsIgnoreError(t *testing.T) {
 	if afterCount != beforeCount {
 		t.Errorf("error count delta = %v, want 0 (ignoreError was set)", afterCount-beforeCount)
 	}
+}
+
+// TestRecordWhitelistRequest verifies the whitelist request counter.
+func TestRecordWhitelistRequest(t *testing.T) {
+	setupTestMetrics(t)
+
+	tests := []struct {
+		name        string
+		serviceType string
+		calls       int
+		wantDelta   float64
+	}{
+		{
+			name:        "single chatbot request",
+			serviceType: "chatbot",
+			calls:       1,
+			wantDelta:   1,
+		},
+		{
+			name:        "multiple text-to-image requests",
+			serviceType: "text-to-image",
+			calls:       3,
+			wantDelta:   3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			before := getCounterValue(WhitelistRequestsTotal, tt.serviceType)
+			for i := 0; i < tt.calls; i++ {
+				RecordWhitelistRequest(tt.serviceType)
+			}
+			after := getCounterValue(WhitelistRequestsTotal, tt.serviceType)
+			if delta := after - before; delta != tt.wantDelta {
+				t.Errorf("whitelist requests delta = %v, want %v", delta, tt.wantDelta)
+			}
+		})
+	}
+}
+
+// TestRecordWhitelistRequestNilMetrics verifies no panic when metrics are nil.
+func TestRecordWhitelistRequestNilMetrics(t *testing.T) {
+	saved := WhitelistRequestsTotal
+	WhitelistRequestsTotal = nil
+	defer func() { WhitelistRequestsTotal = saved }()
+
+	RecordWhitelistRequest("chatbot") // should not panic
+}
+
+// TestRecordWhitelistTokens verifies the whitelist token counters.
+func TestRecordWhitelistTokens(t *testing.T) {
+	setupTestMetrics(t)
+
+	tests := []struct {
+		name                string
+		serviceType         string
+		inputTokens         int64
+		outputTokens        int64
+		wantInputIncrement  float64
+		wantOutputIncrement float64
+	}{
+		{
+			name:                "both input and output tokens",
+			serviceType:         "chatbot",
+			inputTokens:         100,
+			outputTokens:        50,
+			wantInputIncrement:  100,
+			wantOutputIncrement: 50,
+		},
+		{
+			name:                "only input tokens",
+			serviceType:         "chatbot",
+			inputTokens:         200,
+			outputTokens:        0,
+			wantInputIncrement:  200,
+			wantOutputIncrement: 0,
+		},
+		{
+			name:                "only output tokens",
+			serviceType:         "text-to-image",
+			inputTokens:         0,
+			outputTokens:        75,
+			wantInputIncrement:  0,
+			wantOutputIncrement: 75,
+		},
+		{
+			name:                "negative tokens ignored",
+			serviceType:         "chatbot",
+			inputTokens:         -10,
+			outputTokens:        -5,
+			wantInputIncrement:  0,
+			wantOutputIncrement: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			beforeInput := getCounterValue(WhitelistInputTokensTotal, tt.serviceType)
+			beforeOutput := getCounterValue(WhitelistOutputTokensTotal, tt.serviceType)
+
+			RecordWhitelistTokens(tt.serviceType, tt.inputTokens, tt.outputTokens)
+
+			afterInput := getCounterValue(WhitelistInputTokensTotal, tt.serviceType)
+			afterOutput := getCounterValue(WhitelistOutputTokensTotal, tt.serviceType)
+
+			if delta := afterInput - beforeInput; delta != tt.wantInputIncrement {
+				t.Errorf("whitelist input tokens delta = %v, want %v", delta, tt.wantInputIncrement)
+			}
+			if delta := afterOutput - beforeOutput; delta != tt.wantOutputIncrement {
+				t.Errorf("whitelist output tokens delta = %v, want %v", delta, tt.wantOutputIncrement)
+			}
+		})
+	}
+}
+
+// TestRecordWhitelistTokensNilMetrics verifies no panic when metrics are nil.
+func TestRecordWhitelistTokensNilMetrics(t *testing.T) {
+	saved := WhitelistInputTokensTotal
+	WhitelistInputTokensTotal = nil
+	defer func() { WhitelistInputTokensTotal = saved }()
+
+	RecordWhitelistTokens("chatbot", 100, 50) // should not panic
 }


### PR DESCRIPTION
…tats

Replace in-memory DAU tracking (channel + map, lost on restart) with database-backed approach using user.last_active_at field. Add daily_stat table to preserve token/request totals across settlement deletions.

Key changes:
- Add last_active_at field to user table, updated only on real requests
- Add daily_stat table for per-day aggregated stats (requests, tokens)
- AccumulateAndDeleteRequests: atomic transaction prevents double-counting
- New Prometheus gauges: broker_alltime_{requests,input_tokens,output_tokens,unique_users}_total
- DAU now queries user.last_active_at (immune to SyncUserAccounts pollution)
- GetCombinedTotalStats = daily_stat (settled) + request table (pending)
- Migrations: daily_stat table, last_active_at field+index, created_at index