### PR TITLE
feat(inference): support response_format="url" for image gen/edit

### DIFF
--- a/api/inference/integration_test/async_job_test.go
+++ b/api/inference/integration_test/async_job_test.go
@@ -3,10 +3,15 @@
 package integration_test
 
 import (
+	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -294,6 +299,191 @@ func TestAsyncImageEditingFlow(t *testing.T) {
 		time.Sleep(200 * time.Millisecond)
 	}
 	t.Fatal("job did not complete within timeout")
+}
+
+// ==========================================================================
+// Async + response_format="url" — sync has its own coverage in
+// text_to_image_test.go; this pins the parallel async pipeline because
+// processAsyncJob is a separate code path from the sync ProcessHTTPRequest
+// flow. Without this test, a regression in the async worker's body rewrite
+// or post-response URL build would only surface in unit tests.
+// ==========================================================================
+
+func TestAsyncTextToImageFlow_ResponseFormatURL(t *testing.T) {
+	pngBytes := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x01}
+	b64 := base64.StdEncoding.EncodeToString(pngBytes)
+
+	// Provider asserts the broker rewrote response_format to b64_json before
+	// dispatching — the worker must never forward "url" upstream, otherwise
+	// the provider could return LAN-private URLs that leak to the client.
+	mockProvider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]interface{}
+		if err := json.Unmarshal(body, &req); err != nil {
+			t.Errorf("provider: decode request: %v", err)
+		}
+		if req["response_format"] != "b64_json" {
+			t.Errorf("provider: response_format = %v, want b64_json (async worker must rewrite url→b64_json upstream)", req["response_format"])
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"created": 1234567890,
+			"data": []map[string]interface{}{
+				{"b64_json": b64},
+				{"b64_json": b64},
+			},
+		})
+	}))
+	t.Cleanup(func() { mockProvider.Close() })
+
+	env := setupTestEnv(t, func(cfg *config.Config) {
+		cfg.Service.TargetURL = mockProvider.URL
+		cfg.Service.ServingURL = "http://broker.test"
+		cfg.Service.Type = "text-to-image"
+		cfg.Service.ModelType = "dall-e-3"
+		cfg.Service.TargetSeparated = true
+		cfg.Async = config.AsyncConfig{
+			Enabled:                true,
+			MaxConcurrentJobs:      2,
+			MaxQueueSize:           10,
+			ResultTTLMinutes:       30,
+			CleanupIntervalSeconds: 3600,
+			JobTimeoutMinutes:      1,
+		}
+	})
+
+	if err := env.ctrl.InitAsyncProcessing(2, 10, 30*time.Minute, 1*time.Hour, 1*time.Minute); err != nil {
+		t.Fatalf("init async processing: %v", err)
+	}
+	t.Cleanup(func() { env.ctrl.ShutdownAsync() })
+
+	// Image store must be wired before the job runs — the worker stores decoded
+	// bytes here keyed by jobID and the GET path reads from it.
+	if err := env.ctrl.SetupImageStoreForTest(t.TempDir()); err != nil {
+		t.Fatalf("setup image store: %v", err)
+	}
+
+	h := handler.New(env.ctrl, env.proxy, newTestLogger())
+	h.Register(env.engine)
+
+	// 1. Submit the async job with response_format=url.
+	reqBody := `{"model":"dall-e-3","prompt":"a cat playing piano","n":2,"response_format":"url"}`
+	req := httptest.NewRequest("POST", "/v1/async/images/generations", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", createAuthHeader(t, env.privateKey, env.providerAddr))
+
+	w := httptest.NewRecorder()
+	env.engine.ServeHTTP(w, req)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("submit: expected 202, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var submitResp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &submitResp); err != nil {
+		t.Fatalf("parse submit response: %v", err)
+	}
+	jobID, _ := submitResp["jobId"].(string)
+	if jobID == "" {
+		t.Fatal("expected non-empty jobId")
+	}
+
+	// 2. Poll until the job completes (or fails / times out).
+	var finalResp map[string]interface{}
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		pollReq := httptest.NewRequest("GET", "/v1/async/jobs/"+jobID, nil)
+		pollReq.Header.Set("Authorization", createAuthHeader(t, env.privateKey, env.providerAddr))
+
+		pollW := httptest.NewRecorder()
+		env.engine.ServeHTTP(pollW, pollReq)
+
+		if pollW.Code != http.StatusOK {
+			t.Fatalf("poll: expected 200, got %d: %s", pollW.Code, pollW.Body.String())
+		}
+		if err := json.Unmarshal(pollW.Body.Bytes(), &finalResp); err != nil {
+			t.Fatalf("parse poll response: %v", err)
+		}
+		status, _ := finalResp["status"].(string)
+		if status == "completed" {
+			break
+		}
+		if status == "failed" {
+			t.Fatalf("job failed: %v", finalResp["errorMessage"])
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	if status, _ := finalResp["status"].(string); status != "completed" {
+		t.Fatalf("job did not complete within timeout, last status=%v", finalResp["status"])
+	}
+
+	// 3. Verify the completed result carries broker-served URLs, NOT b64.
+	//    The async worker stores its result body in job.data; it's the same
+	//    JSON the sync path returns to the client.
+	dataMap, ok := finalResp["data"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected data to be object, got %T", finalResp["data"])
+	}
+	images, ok := dataMap["data"].([]interface{})
+	if !ok || len(images) != 2 {
+		t.Fatalf("expected 2 images in result, got %v", dataMap["data"])
+	}
+
+	for i, raw := range images {
+		item := raw.(map[string]interface{})
+		if v, has := item["b64_json"]; has {
+			t.Errorf("data[%d].b64_json should be absent when response_format=url, got %v", i, v)
+		}
+		gotURL, _ := item["url"].(string)
+		if gotURL == "" {
+			t.Errorf("data[%d].url is empty", i)
+			continue
+		}
+		u, err := url.Parse(gotURL)
+		if err != nil {
+			t.Errorf("data[%d].url parse: %v", i, err)
+			continue
+		}
+		// Async uses jobID as the image-store key (sync uses chatKey from
+		// ZG-Res-Key). This is the path that distinguishes the two flows.
+		wantPath := "/v1/proxy/images/" + jobID + "/" + strconv.Itoa(i)
+		if u.Path != wantPath {
+			t.Errorf("data[%d].url path = %q, want %q", i, u.Path, wantPath)
+		}
+
+		// 4. GET the broker URL via the same engine — closes the loop the unit
+		//    tests can't reach (they call GetImage directly, bypassing the
+		//    proxy route, middleware, and Cache-Control/Content-Type plumbing).
+		getReq := httptest.NewRequest("GET", u.Path, nil)
+		gw := httptest.NewRecorder()
+		env.engine.ServeHTTP(gw, getReq)
+		if gw.Code != http.StatusOK {
+			t.Errorf("GET %s: status = %d, body: %s", u.Path, gw.Code, gw.Body.String())
+			continue
+		}
+		if ct := gw.Header().Get("Content-Type"); !strings.HasPrefix(ct, "image/") {
+			t.Errorf("GET %s: content-type = %q, want image/*", u.Path, ct)
+		}
+		if !bytes.Equal(gw.Body.Bytes(), pngBytes) {
+			t.Errorf("GET %s: served bytes do not match provider bytes (got %d, want %d)", u.Path, len(gw.Body.Bytes()), len(pngBytes))
+		}
+	}
+
+	// 5. Billing: n=2, fee = 2 × outputPrice. Mirrors the sync URL test so
+	//    a divergence between the two paths' billing logic surfaces here.
+	requests, _, err := env.ctrl.ListRequest(model.RequestListOptions{})
+	if err != nil {
+		t.Fatalf("list requests: %v", err)
+	}
+	userRequests := filterRequestsByUser(requests, env.userAddr)
+	if len(userRequests) == 0 {
+		t.Fatal("expected at least 1 billing record")
+	}
+	latestReq := userRequests[len(userRequests)-1]
+	if latestReq.OutputCount != 2 {
+		t.Errorf("expected outputCount=2, got %d", latestReq.OutputCount)
+	}
 }
 
 // ==========================================================================

--- a/api/inference/integration_test/image_editing_test.go
+++ b/api/inference/integration_test/image_editing_test.go
@@ -3,11 +3,14 @@
 package integration_test
 
 import (
+	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -266,5 +269,125 @@ func TestImageEditing_WhitelistUser(t *testing.T) {
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200 for whitelist user, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// ==========================================================================
+// Multipart image-editing with response_format=url — broker rewrites the
+// multipart form field to b64_json upstream, stores decoded images locally,
+// and returns broker-served URLs in the client response.
+// ==========================================================================
+
+func TestImageEditingFlow_ResponseFormatURL_Multipart(t *testing.T) {
+	pngBytes := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x01}
+	b64 := base64.StdEncoding.EncodeToString(pngBytes)
+
+	mockProvider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseMultipartForm(32 << 20); err != nil {
+			t.Errorf("provider: parse multipart: %v", err)
+		}
+		if got := r.FormValue("response_format"); got != "b64_json" {
+			t.Errorf("provider: response_format = %q, want b64_json (broker must rewrite multipart url→b64_json)", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"created": 1234567890,
+			"data": []map[string]interface{}{
+				{"b64_json": b64},
+			},
+		})
+	}))
+	t.Cleanup(func() { mockProvider.Close() })
+
+	env := setupTestEnv(t, func(cfg *config.Config) {
+		cfg.Service.TargetURL = mockProvider.URL
+		cfg.Service.ServingURL = "http://broker.test"
+		cfg.Service.Type = "image-editing"
+		cfg.Service.ModelType = "dall-e-2"
+		cfg.Service.TargetSeparated = true
+	})
+	if err := env.ctrl.SetupImageStoreForTest(t.TempDir()); err != nil {
+		t.Fatalf("setup image store: %v", err)
+	}
+
+	boundary := "----UrlEditBoundary"
+	body := fmt.Sprintf(
+		"--%s\r\nContent-Disposition: form-data; name=\"prompt\"\r\n\r\nmake it red\r\n"+
+			"--%s\r\nContent-Disposition: form-data; name=\"n\"\r\n\r\n1\r\n"+
+			"--%s\r\nContent-Disposition: form-data; name=\"response_format\"\r\n\r\nurl\r\n"+
+			"--%s\r\nContent-Disposition: form-data; name=\"image\"; filename=\"test.png\"\r\nContent-Type: image/png\r\n\r\nfake-png-data\r\n"+
+			"--%s--",
+		boundary, boundary, boundary, boundary, boundary)
+
+	req := httptest.NewRequest("POST", "/v1/proxy/images/edits", strings.NewReader(body))
+	req.Header.Set("Content-Type", "multipart/form-data; boundary="+boundary)
+	req.Header.Set("Authorization", createAuthHeader(t, env.privateKey, env.providerAddr))
+
+	w := httptest.NewRecorder()
+	env.engine.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	chatKey := w.Header().Get("ZG-Res-Key")
+	if chatKey == "" {
+		t.Fatal("expected ZG-Res-Key header")
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse response: %v", err)
+	}
+	data, _ := resp["data"].([]interface{})
+	if len(data) != 1 {
+		t.Fatalf("expected 1 edited image, got %d", len(data))
+	}
+	item := data[0].(map[string]interface{})
+	if v, has := item["b64_json"]; has {
+		t.Errorf("b64_json should be absent in URL response, got %v", v)
+	}
+	gotURL, _ := item["url"].(string)
+	if gotURL == "" {
+		t.Fatal("data[0].url is empty")
+	}
+	u, err := url.Parse(gotURL)
+	if err != nil {
+		t.Fatalf("parse returned URL: %v", err)
+	}
+	wantPath := "/v1/proxy/images/" + chatKey + "/0"
+	if u.Path != wantPath {
+		t.Errorf("url path = %q, want %q", u.Path, wantPath)
+	}
+
+	// Fetch the broker-served URL and verify bytes.
+	getReq := httptest.NewRequest("GET", u.Path, nil)
+	gw := httptest.NewRecorder()
+	env.engine.ServeHTTP(gw, getReq)
+	if gw.Code != http.StatusOK {
+		t.Fatalf("GET %s: status = %d, body: %s", u.Path, gw.Code, gw.Body.String())
+	}
+	if ct := gw.Header().Get("Content-Type"); !strings.HasPrefix(ct, "image/") {
+		t.Errorf("GET %s: content-type = %q, want image/*", u.Path, ct)
+	}
+	if !bytes.Equal(gw.Body.Bytes(), pngBytes) {
+		t.Errorf("GET %s: served bytes do not match stored image", u.Path)
+	}
+
+	// Billing: n=1, fee = 1 × 100 = 100
+	requests, _, err := env.ctrl.ListRequest(model.RequestListOptions{})
+	if err != nil {
+		t.Fatalf("list requests: %v", err)
+	}
+	userRequests := filterRequestsByUser(requests, env.userAddr)
+	if len(userRequests) == 0 {
+		t.Fatal("expected at least 1 billing record")
+	}
+	latestReq := userRequests[len(userRequests)-1]
+	if latestReq.OutputCount != 1 {
+		t.Errorf("expected outputCount=1, got %d", latestReq.OutputCount)
+	}
+	if latestReq.Fee != "100" {
+		t.Errorf("expected fee=100, got %s", latestReq.Fee)
 	}
 }

--- a/api/inference/integration_test/image_editing_test.go
+++ b/api/inference/integration_test/image_editing_test.go
@@ -393,11 +393,12 @@ func TestImageEditingFlow_ResponseFormatURL_Multipart(t *testing.T) {
 }
 
 // TestImageEditingFlow_MultipartOmitsResponseFormat_InjectsB64 closes the
-// absent-field leak: OpenAI's default for /v1/images/edits is "url", so a
-// client that does NOT send response_format would have caused the provider
-// to return LAN-private URLs. The broker must inject response_format=b64_json
-// into the forwarded multipart body AND still run the URL-rewrite path so
-// the client gets broker-served URLs, not the omitted-default leak.
+// absent-field leak AND pins the broker's chosen default. OpenAI's per-
+// endpoint default for /v1/images/edits is "url", but the broker cannot
+// safely forward provider LAN URLs, so the broker uniformly defaults to
+// b64_json when the field is omitted — same behaviour as the JSON path.
+// Clients wanting broker-served URLs must opt in explicitly with
+// response_format=url.
 func TestImageEditingFlow_MultipartOmitsResponseFormat_InjectsB64(t *testing.T) {
 	pngBytes := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x01}
 	b64 := base64.StdEncoding.EncodeToString(pngBytes)
@@ -452,8 +453,8 @@ func TestImageEditingFlow_MultipartOmitsResponseFormat_InjectsB64(t *testing.T) 
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	// Since the client's documented default is "url", the client should get
-	// a broker-served URL back, not b64_json.
+	// Broker default is b64_json across JSON + multipart: client sees b64,
+	// not a broker-served URL. Opting into URLs requires response_format=url.
 	var resp map[string]interface{}
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("parse response: %v", err)
@@ -463,10 +464,10 @@ func TestImageEditingFlow_MultipartOmitsResponseFormat_InjectsB64(t *testing.T) 
 		t.Fatalf("expected 1 edited image, got %d", len(data))
 	}
 	item := data[0].(map[string]interface{})
-	if _, has := item["b64_json"]; has {
-		t.Error("b64_json should be absent: omitted response_format defaults to url, so broker returns broker URLs")
+	if gotB64, _ := item["b64_json"].(string); gotB64 != b64 {
+		t.Errorf("expected b64_json pass-through when field is omitted, got: %+v", item)
 	}
-	if gotURL, _ := item["url"].(string); gotURL == "" {
-		t.Error("expected broker-served url in response when response_format is omitted")
+	if _, has := item["url"]; has {
+		t.Error("url must NOT be injected when client omits response_format — broker default is b64")
 	}
 }

--- a/api/inference/integration_test/image_editing_test.go
+++ b/api/inference/integration_test/image_editing_test.go
@@ -391,3 +391,82 @@ func TestImageEditingFlow_ResponseFormatURL_Multipart(t *testing.T) {
 		t.Errorf("expected fee=100, got %s", latestReq.Fee)
 	}
 }
+
+// TestImageEditingFlow_MultipartOmitsResponseFormat_InjectsB64 closes the
+// absent-field leak: OpenAI's default for /v1/images/edits is "url", so a
+// client that does NOT send response_format would have caused the provider
+// to return LAN-private URLs. The broker must inject response_format=b64_json
+// into the forwarded multipart body AND still run the URL-rewrite path so
+// the client gets broker-served URLs, not the omitted-default leak.
+func TestImageEditingFlow_MultipartOmitsResponseFormat_InjectsB64(t *testing.T) {
+	pngBytes := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x01}
+	b64 := base64.StdEncoding.EncodeToString(pngBytes)
+
+	mockProvider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseMultipartForm(32 << 20); err != nil {
+			t.Errorf("provider: parse multipart: %v", err)
+		}
+		// This is THE assertion: the provider must see b64_json even though
+		// the client omitted the field entirely. Old code forwarded the body
+		// unchanged and this would be "".
+		if got := r.FormValue("response_format"); got != "b64_json" {
+			t.Errorf("provider: response_format = %q, want b64_json (broker must inject when field is absent)", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"created": 1,
+			"data":    []map[string]interface{}{{"b64_json": b64}},
+		})
+	}))
+	t.Cleanup(func() { mockProvider.Close() })
+
+	env := setupTestEnv(t, func(cfg *config.Config) {
+		cfg.Service.TargetURL = mockProvider.URL
+		cfg.Service.ServingURL = "http://broker.test"
+		cfg.Service.Type = "image-editing"
+		cfg.Service.ModelType = "dall-e-2"
+		cfg.Service.TargetSeparated = true
+	})
+	if err := env.ctrl.SetupImageStoreForTest(t.TempDir()); err != nil {
+		t.Fatalf("setup image store: %v", err)
+	}
+
+	boundary := "----OmitFormatBoundary"
+	// Body deliberately omits any response_format field.
+	body := fmt.Sprintf(
+		"--%s\r\nContent-Disposition: form-data; name=\"prompt\"\r\n\r\nmake it red\r\n"+
+			"--%s\r\nContent-Disposition: form-data; name=\"n\"\r\n\r\n1\r\n"+
+			"--%s\r\nContent-Disposition: form-data; name=\"image\"; filename=\"t.png\"\r\nContent-Type: image/png\r\n\r\nfake-png\r\n"+
+			"--%s--\r\n",
+		boundary, boundary, boundary, boundary)
+
+	req := httptest.NewRequest("POST", "/v1/proxy/images/edits", strings.NewReader(body))
+	req.Header.Set("Content-Type", "multipart/form-data; boundary="+boundary)
+	req.Header.Set("Authorization", createAuthHeader(t, env.privateKey, env.providerAddr))
+
+	w := httptest.NewRecorder()
+	env.engine.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Since the client's documented default is "url", the client should get
+	// a broker-served URL back, not b64_json.
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse response: %v", err)
+	}
+	data, _ := resp["data"].([]interface{})
+	if len(data) != 1 {
+		t.Fatalf("expected 1 edited image, got %d", len(data))
+	}
+	item := data[0].(map[string]interface{})
+	if _, has := item["b64_json"]; has {
+		t.Error("b64_json should be absent: omitted response_format defaults to url, so broker returns broker URLs")
+	}
+	if gotURL, _ := item["url"].(string); gotURL == "" {
+		t.Error("expected broker-served url in response when response_format is omitted")
+	}
+}

--- a/api/inference/integration_test/text_to_image_test.go
+++ b/api/inference/integration_test/text_to_image_test.go
@@ -451,3 +451,88 @@ func TestTextToImageFlow_ResponseFormatB64PassThrough(t *testing.T) {
 		t.Errorf("b64_json mismatch: got len=%d, want len=%d", len(gotB64), len(b64))
 	}
 }
+
+// ==========================================================================
+// Leak guards: rewrite failures must not silently fall through to the provider
+// body, because the body may contain LAN-private URLs the client can't reach.
+// ==========================================================================
+
+// TestTextToImage_MalformedJSON_RejectedBeforeForwarding pins the request-side
+// guard in PrepareHTTPRequest. An earlier version swallowed rewrite errors and
+// forwarded the original body with response_format=url, letting the provider
+// return LAN URLs to the client.
+func TestTextToImage_MalformedJSON_RejectedBeforeForwarding(t *testing.T) {
+	providerHit := false
+	mockProvider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		providerHit = true
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"data":[{"url":"http://internal-gpu:9090/tmp/x.png"}]}`))
+	}))
+	t.Cleanup(func() { mockProvider.Close() })
+
+	env := setupTestEnv(t, func(cfg *config.Config) {
+		cfg.Service.TargetURL = mockProvider.URL
+		cfg.Service.ServingURL = "http://broker.test"
+		cfg.Service.Type = "text-to-image"
+		cfg.Service.ModelType = "dall-e-3"
+		cfg.Service.TargetSeparated = true
+	})
+	if err := env.ctrl.SetupImageStoreForTest(t.TempDir()); err != nil {
+		t.Fatalf("setup image store: %v", err)
+	}
+
+	// Malformed JSON: broker's forceB64ResponseFormat can't parse, so rewriting fails.
+	req := httptest.NewRequest("POST", "/v1/proxy/images/generations", strings.NewReader(`{"prompt":`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", createAuthHeader(t, env.privateKey, env.providerAddr))
+
+	w := httptest.NewRecorder()
+	env.engine.ServeHTTP(w, req)
+
+	if w.Code == http.StatusOK {
+		t.Errorf("malformed body must not succeed, got 200; body=%s", w.Body.String())
+	}
+	if providerHit {
+		t.Error("provider must not be called when request-body normalisation fails (would have forwarded response_format=url)")
+	}
+}
+
+// TestTextToImage_URLFormat_ProviderNonCompliant_Refused pins the response-side
+// guard. When the client asked for response_format=url but the provider
+// returned data[].url instead of b64, the broker must NOT forward the body —
+// those URLs are the provider's LAN endpoints, useless to the client.
+func TestTextToImage_URLFormat_ProviderNonCompliant_Refused(t *testing.T) {
+	// Provider ignores response_format=b64_json and returns URL form anyway.
+	mockProvider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"created":1,"data":[{"url":"http://10.0.0.5:9090/tmp/leaked.png"}]}`))
+	}))
+	t.Cleanup(func() { mockProvider.Close() })
+
+	env := setupTestEnv(t, func(cfg *config.Config) {
+		cfg.Service.TargetURL = mockProvider.URL
+		cfg.Service.ServingURL = "http://broker.test"
+		cfg.Service.Type = "text-to-image"
+		cfg.Service.ModelType = "dall-e-3"
+		cfg.Service.TargetSeparated = true
+	})
+	if err := env.ctrl.SetupImageStoreForTest(t.TempDir()); err != nil {
+		t.Fatalf("setup image store: %v", err)
+	}
+
+	req := httptest.NewRequest("POST", "/v1/proxy/images/generations",
+		strings.NewReader(`{"prompt":"cat","response_format":"url"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", createAuthHeader(t, env.privateKey, env.providerAddr))
+
+	w := httptest.NewRecorder()
+	env.engine.ServeHTTP(w, req)
+
+	if w.Code == http.StatusOK {
+		t.Errorf("expected non-200 when provider returns URL form under response_format=url; got 200 body=%s", w.Body.String())
+	}
+	if strings.Contains(w.Body.String(), "10.0.0.5") {
+		t.Errorf("client response must not contain provider LAN URL, got: %s", w.Body.String())
+	}
+}

--- a/api/inference/integration_test/text_to_image_test.go
+++ b/api/inference/integration_test/text_to_image_test.go
@@ -3,10 +3,15 @@
 package integration_test
 
 import (
+	"bytes"
+	"encoding/base64"
 	"encoding/json"
+	"io"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -258,5 +263,191 @@ func TestTextToImage_WhitelistUser(t *testing.T) {
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200 for whitelist user, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// ==========================================================================
+// response_format="url" — broker rewrites upstream to b64_json, stores images
+// locally, and returns broker-served URLs. GET on the URL returns the bytes.
+// ==========================================================================
+
+func TestTextToImageFlow_ResponseFormatURL(t *testing.T) {
+	pngBytes := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x01}
+	b64 := base64.StdEncoding.EncodeToString(pngBytes)
+
+	mockProvider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]interface{}
+		if err := json.Unmarshal(body, &req); err != nil {
+			t.Errorf("provider: decode request: %v", err)
+		}
+		if req["response_format"] != "b64_json" {
+			t.Errorf("provider: response_format = %v, want b64_json (broker must rewrite url→b64_json upstream)", req["response_format"])
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"created": 1234567890,
+			"data": []map[string]interface{}{
+				{"b64_json": b64},
+				{"b64_json": b64},
+			},
+		})
+	}))
+	t.Cleanup(func() { mockProvider.Close() })
+
+	env := setupTestEnv(t, func(cfg *config.Config) {
+		cfg.Service.TargetURL = mockProvider.URL
+		cfg.Service.ServingURL = "http://broker.test"
+		cfg.Service.Type = "text-to-image"
+		cfg.Service.ModelType = "dall-e-3"
+		cfg.Service.TargetSeparated = true
+	})
+	if err := env.ctrl.SetupImageStoreForTest(t.TempDir()); err != nil {
+		t.Fatalf("setup image store: %v", err)
+	}
+
+	reqBody := `{"model":"dall-e-3","prompt":"a cute cat","n":2,"response_format":"url"}`
+	req := httptest.NewRequest("POST", "/v1/proxy/images/generations", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", createAuthHeader(t, env.privateKey, env.providerAddr))
+
+	w := httptest.NewRecorder()
+	env.engine.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	chatKey := w.Header().Get("ZG-Res-Key")
+	if chatKey == "" {
+		t.Fatal("expected ZG-Res-Key header")
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse response: %v", err)
+	}
+	data, ok := resp["data"].([]interface{})
+	if !ok || len(data) != 2 {
+		t.Fatalf("expected 2 images, got %v", resp["data"])
+	}
+	for i, raw := range data {
+		item := raw.(map[string]interface{})
+		if v, has := item["b64_json"]; has {
+			t.Errorf("data[%d].b64_json should be absent when response_format=url, got %v", i, v)
+		}
+		gotURL, _ := item["url"].(string)
+		if gotURL == "" {
+			t.Errorf("data[%d].url is empty", i)
+			continue
+		}
+		u, err := url.Parse(gotURL)
+		if err != nil {
+			t.Errorf("data[%d].url parse: %v", i, err)
+			continue
+		}
+		wantPath := "/v1/proxy/images/" + chatKey + "/" + strconv.Itoa(i)
+		if u.Path != wantPath {
+			t.Errorf("data[%d].url path = %q, want %q", i, u.Path, wantPath)
+		}
+
+		// Fetch the broker-served URL via the same engine and verify bytes.
+		getReq := httptest.NewRequest("GET", u.Path, nil)
+		gw := httptest.NewRecorder()
+		env.engine.ServeHTTP(gw, getReq)
+		if gw.Code != http.StatusOK {
+			t.Errorf("GET %s: status = %d, body: %s", u.Path, gw.Code, gw.Body.String())
+			continue
+		}
+		if ct := gw.Header().Get("Content-Type"); !strings.HasPrefix(ct, "image/") {
+			t.Errorf("GET %s: content-type = %q, want image/*", u.Path, ct)
+		}
+		if !bytes.Equal(gw.Body.Bytes(), pngBytes) {
+			t.Errorf("GET %s: body does not match stored image bytes (got %d, want %d)", u.Path, len(gw.Body.Bytes()), len(pngBytes))
+		}
+	}
+
+	// Billing: n=2, fee = 2 × 100
+	requests, _, err := env.ctrl.ListRequest(model.RequestListOptions{})
+	if err != nil {
+		t.Fatalf("list requests: %v", err)
+	}
+	userRequests := filterRequestsByUser(requests, env.userAddr)
+	if len(userRequests) == 0 {
+		t.Fatal("expected at least 1 billing record")
+	}
+	latestReq := userRequests[len(userRequests)-1]
+	if latestReq.OutputCount != 2 {
+		t.Errorf("expected outputCount=2, got %d", latestReq.OutputCount)
+	}
+	if latestReq.Fee != "200" {
+		t.Errorf("expected fee=200, got %s", latestReq.Fee)
+	}
+}
+
+// ==========================================================================
+// response_format="b64_json" — pass-through. Broker still normalises upstream
+// to b64_json, but never injects a url field into the client response.
+// ==========================================================================
+
+func TestTextToImageFlow_ResponseFormatB64PassThrough(t *testing.T) {
+	pngBytes := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x01}
+	b64 := base64.StdEncoding.EncodeToString(pngBytes)
+
+	mockProvider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]interface{}
+		_ = json.Unmarshal(body, &req)
+		if req["response_format"] != "b64_json" {
+			t.Errorf("provider: response_format = %v, want b64_json", req["response_format"])
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"created": 1234567890,
+			"data": []map[string]interface{}{
+				{"b64_json": b64},
+			},
+		})
+	}))
+	t.Cleanup(func() { mockProvider.Close() })
+
+	env := setupTestEnv(t, func(cfg *config.Config) {
+		cfg.Service.TargetURL = mockProvider.URL
+		cfg.Service.Type = "text-to-image"
+		cfg.Service.ModelType = "dall-e-3"
+		cfg.Service.TargetSeparated = true
+	})
+	if err := env.ctrl.SetupImageStoreForTest(t.TempDir()); err != nil {
+		t.Fatalf("setup image store: %v", err)
+	}
+
+	reqBody := `{"model":"dall-e-3","prompt":"a dog","response_format":"b64_json"}`
+	req := httptest.NewRequest("POST", "/v1/proxy/images/generations", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", createAuthHeader(t, env.privateKey, env.providerAddr))
+
+	w := httptest.NewRecorder()
+	env.engine.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse response: %v", err)
+	}
+	data, _ := resp["data"].([]interface{})
+	if len(data) != 1 {
+		t.Fatalf("expected 1 image, got %d", len(data))
+	}
+	item := data[0].(map[string]interface{})
+	if v, has := item["url"]; has {
+		t.Errorf("url should not be injected when response_format=b64_json, got %v", v)
+	}
+	if gotB64, _ := item["b64_json"].(string); gotB64 != b64 {
+		t.Errorf("b64_json mismatch: got len=%d, want len=%d", len(gotB64), len(b64))
 	}
 }

--- a/api/inference/internal/ctrl/async.go
+++ b/api/inference/internal/ctrl/async.go
@@ -283,7 +283,7 @@ func (c *Ctrl) processAsyncJob(params asyncJobParams) {
 	// below. reqBody (forwarded to provider) is mutated; params.RequestBody stays
 	// untouched so TEE signing binds the client's original bytes.
 	var clientResponseFormat string
-	if svcType == "text-to-image" || svcType == "image-editing" {
+	if (svcType == "text-to-image" || svcType == "image-editing") && len(reqBody) > 0 {
 		contentType := extractContentType(params.RequestHeaders)
 		var (
 			orig      string
@@ -295,10 +295,17 @@ func (c *Ctrl) processAsyncJob(params asyncJobParams) {
 		} else {
 			orig, rewritten, rwErr = forceB64ResponseFormat(reqBody)
 		}
-		if rwErr == nil {
-			clientResponseFormat = orig
-			reqBody = rewritten
+		// Matches the sync path's terminal-on-failure behaviour (proxy.go:82-86):
+		// swallowing rwErr would forward the un-normalised body with
+		// response_format=url intact, the provider would return LAN-private URLs,
+		// and because clientResponseFormat stays "" the downstream refuse-guard
+		// never fires — the exact leak the rewrite exists to prevent.
+		if rwErr != nil {
+			c.markAsyncJobFailed(jobID, "normalise image request body: "+rwErr.Error())
+			return
 		}
+		clientResponseFormat = orig
+		reqBody = rewritten
 	}
 
 	// Build target URL

--- a/api/inference/internal/ctrl/async.go
+++ b/api/inference/internal/ctrl/async.go
@@ -372,40 +372,64 @@ func (c *Ctrl) processAsyncJob(params asyncJobParams) {
 		return
 	}
 
-	// Read response body
-	respBody, err := io.ReadAll(resp.Body)
+	// Read response body (original provider bytes, before any URL rewrite).
+	providerRespBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		c.markAsyncJobFailed(jobID, "failed to read provider response: "+err.Error())
 		return
 	}
+	respBody := providerRespBody
+
+	// For image services, try to extract b64 images once — used for both URL
+	// rewriting and TEE signing (image-byte binding). extractOK stays false for
+	// non-image services or when the provider did not return a b64 envelope.
+	var (
+		images    [][]byte
+		extractOK bool
+	)
+	if svcType == "text-to-image" || svcType == "image-editing" {
+		decoded, exErr := extractB64Images(providerRespBody)
+		if exErr == nil {
+			images = decoded
+			extractOK = true
+		} else if clientResponseFormat == "url" {
+			// Refuse rather than pass through: provider bytes may carry LAN URLs
+			// the client can't reach, which is exactly what rewriting prevents.
+			c.markAsyncJobFailed(jobID, "provider returned non-b64 image response, refusing to forward: "+exErr.Error())
+			return
+		}
+	}
 
 	// If the caller asked for response_format=url, persist decoded images locally
 	// and rewrite data[].b64_json → data[].url. jobID doubles as the chatKey —
-	// /v1/proxy/images/{jobID}/{i} resolves to the stored bytes. On any error we
-	// fall back to the provider's b64 body (the user at worst gets the wrong
-	// format, never a broken URL).
-	if clientResponseFormat == "url" && c.imageStore != nil &&
-		(svcType == "text-to-image" || svcType == "image-editing") {
-		if images, exErr := extractB64Images(respBody); exErr != nil {
-			c.logger.Warnf("Async job %s: extract b64 images failed, returning b64: %v", jobID, exErr)
-		} else if stErr := c.imageStore.store(jobID, images); stErr != nil {
+	// /v1/proxy/images/{jobID}/{i} resolves to the stored bytes. Store / build
+	// failures fall back to b64 (safe — body is confirmed b64 above).
+	if clientResponseFormat == "url" && extractOK && c.imageStore != nil {
+		if stErr := c.imageStore.store(jobID, images); stErr != nil {
 			c.logger.Warnf("Async job %s: store images failed, returning b64: %v", jobID, stErr)
-		} else if rewritten, bErr := buildURLResponse(respBody, jobID, len(images), c.Service.ServingURL); bErr != nil {
+		} else if rewritten, bErr := buildURLResponse(providerRespBody, jobID, len(images), c.Service.ServingURL); bErr != nil {
 			c.logger.Warnf("Async job %s: build URL response failed, returning b64: %v", jobID, bErr)
 		} else {
 			respBody = rewritten
 		}
 	}
 
-	// TEE response signing — same as sync path (text_to_image.go, image_editing.go).
-	// When TargetSeparated is false, the broker signs the request+response pair and
-	// caches the signature under a chatKey. The client retrieves the chatKey via the
-	// ZG-Res-Key header on the poll response to verify TEE integrity.
+	// TEE response signing — mirrors the sync path in text_to_image.go /
+	// image_editing.go. For image services we sign the decoded image bytes via
+	// signImageResponse so the signature binds the served content, not the URL
+	// envelope the client receives. Falls back to signChatWithKey over the
+	// original provider body (never the rewritten URL JSON).
 	var chatKey string
 	if !c.Service.TargetSeparated {
 		chatKey = uuid.NewString()
-		if err := c.signChatWithKey(params.RequestBody, respBody, chatKey); err != nil {
-			c.logger.Warnf("Failed to sign async job %s response (TEE verification will be unavailable): %v", jobID, err)
+		var signErr error
+		if extractOK && len(images) > 0 {
+			signErr = c.signImageResponse(params.RequestBody, images, chatKey)
+		} else {
+			signErr = c.signChatWithKey(params.RequestBody, providerRespBody, chatKey)
+		}
+		if signErr != nil {
+			c.logger.Warnf("Failed to sign async job %s response (TEE verification will be unavailable): %v", jobID, signErr)
 			chatKey = "" // don't store an unusable key
 		}
 	}

--- a/api/inference/internal/ctrl/async.go
+++ b/api/inference/internal/ctrl/async.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -272,6 +273,31 @@ func (c *Ctrl) processAsyncJob(params asyncJobParams) {
 		return
 	}
 
+	// response_format=url handling, mirroring the sync path in PrepareHTTPRequest:
+	// rewrite the upstream body to b64_json so the broker receives raw image bytes
+	// (provider-hosted URLs are not LAN-reachable from the client). clientResponseFormat
+	// captures what the caller originally asked for so we can re-rewrite the response
+	// below. reqBody (forwarded to provider) is mutated; params.RequestBody stays
+	// untouched so TEE signing binds the client's original bytes.
+	var clientResponseFormat string
+	if svcType == "text-to-image" || svcType == "image-editing" {
+		contentType := extractContentType(params.RequestHeaders)
+		var (
+			orig      string
+			rewritten []byte
+			rwErr     error
+		)
+		if strings.HasPrefix(strings.ToLower(contentType), "multipart/") {
+			orig, rewritten, rwErr = rewriteMultipartResponseFormat(reqBody)
+		} else {
+			orig, rewritten, rwErr = forceB64ResponseFormat(reqBody)
+		}
+		if rwErr == nil {
+			clientResponseFormat = orig
+			reqBody = rewritten
+		}
+	}
+
 	// Build target URL
 	targetURL := c.Service.TargetURL
 	switch svcType {
@@ -351,6 +377,24 @@ func (c *Ctrl) processAsyncJob(params asyncJobParams) {
 	if err != nil {
 		c.markAsyncJobFailed(jobID, "failed to read provider response: "+err.Error())
 		return
+	}
+
+	// If the caller asked for response_format=url, persist decoded images locally
+	// and rewrite data[].b64_json → data[].url. jobID doubles as the chatKey —
+	// /v1/proxy/images/{jobID}/{i} resolves to the stored bytes. On any error we
+	// fall back to the provider's b64 body (the user at worst gets the wrong
+	// format, never a broken URL).
+	if clientResponseFormat == "url" && c.imageStore != nil &&
+		(svcType == "text-to-image" || svcType == "image-editing") {
+		if images, exErr := extractB64Images(respBody); exErr != nil {
+			c.logger.Warnf("Async job %s: extract b64 images failed, returning b64: %v", jobID, exErr)
+		} else if stErr := c.imageStore.store(jobID, images); stErr != nil {
+			c.logger.Warnf("Async job %s: store images failed, returning b64: %v", jobID, stErr)
+		} else if rewritten, bErr := buildURLResponse(respBody, jobID, len(images), c.Service.ServingURL); bErr != nil {
+			c.logger.Warnf("Async job %s: build URL response failed, returning b64: %v", jobID, bErr)
+		} else {
+			respBody = rewritten
+		}
 	}
 
 	// TEE response signing — same as sync path (text_to_image.go, image_editing.go).
@@ -447,4 +491,23 @@ func (c *Ctrl) markAsyncJobFailed(jobID, errMsg string) {
 	if err := c.asyncDB.UpdateAsyncJobStatus(jobID, model.AsyncJobStatusFailed, nil, nil, errMsg); err != nil {
 		c.logger.Errorf("Failed to mark async job %s as failed: %v", jobID, err)
 	}
+}
+
+// extractContentType pulls Content-Type out of the JSON-serialised request headers
+// stored on an async job. Returns "" when the header is absent or the blob is
+// unparseable — callers must handle both.
+func extractContentType(reqHeaders []byte) string {
+	if len(reqHeaders) == 0 {
+		return ""
+	}
+	var saved map[string][]string
+	if err := json.Unmarshal(reqHeaders, &saved); err != nil {
+		return ""
+	}
+	for k, vals := range saved {
+		if strings.EqualFold(k, "Content-Type") && len(vals) > 0 {
+			return vals[0]
+		}
+	}
+	return ""
 }

--- a/api/inference/internal/ctrl/async.go
+++ b/api/inference/internal/ctrl/async.go
@@ -398,7 +398,7 @@ func (c *Ctrl) processAsyncJob(params asyncJobParams) {
 		extractOK bool
 	)
 	if svcType == "text-to-image" || svcType == "image-editing" {
-		decoded, exErr := extractB64Images(providerRespBody)
+		decoded, exErr := extractB64Images(providerRespBody, int(params.BillingReq.OutputCount))
 		if exErr == nil {
 			images = decoded
 			extractOK = true

--- a/api/inference/internal/ctrl/async.go
+++ b/api/inference/internal/ctrl/async.go
@@ -415,12 +415,23 @@ func (c *Ctrl) processAsyncJob(params asyncJobParams) {
 	}
 
 	// TEE response signing — mirrors the sync path in text_to_image.go /
-	// image_editing.go. For image services we sign the decoded image bytes via
-	// signImageResponse so the signature binds the served content, not the URL
-	// envelope the client receives. Falls back to signChatWithKey over the
-	// original provider body (never the rewritten URL JSON).
+	// image_editing.go. Dispatch on the trust model:
+	//   - Centralized: routing proof binds the TLS fingerprint to req/resp
+	//     hashes. Content cannot be attested because the provider is a black box.
+	//   - Decentralized !TargetSeparated: sign decoded image bytes directly
+	//     (image services) or full response (others).
+	//   - Decentralized TargetSeparated: no signing; the remote TEE signs.
+	// The signed body for image services is providerRespBody (original bytes),
+	// never the rewritten URL envelope.
 	var chatKey string
-	if !c.Service.TargetSeparated {
+	switch {
+	case c.Service.IsCentralized():
+		chatKey = uuid.NewString()
+		if err := c.signCentralizedRoutingProof(params.RequestBody, providerRespBody, chatKey, resp.TLS); err != nil {
+			c.logger.Warnf("Async job %s: routing proof not created (TEE verification unavailable): %v", jobID, err)
+			chatKey = ""
+		}
+	case !c.Service.TargetSeparated:
 		chatKey = uuid.NewString()
 		var signErr error
 		if extractOK && len(images) > 0 {

--- a/api/inference/internal/ctrl/async.go
+++ b/api/inference/internal/ctrl/async.go
@@ -165,7 +165,7 @@ func (c *Ctrl) SubmitAsyncJob(ctx *gin.Context, userAddress, svcType string, req
 		}
 		expectedInputFee = "0"
 	case "image-editing":
-		expectedInputFee, outputCount, err = c.GetImageEditingInputFeeAndImageNum(reqBody)
+		expectedInputFee, outputCount, err = c.GetImageEditingInputFeeAndImageNum(reqBody, extractContentType(reqHeaders))
 		if err != nil {
 			return "", errors.Wrap(err, "parse image-editing request")
 		}
@@ -414,7 +414,14 @@ func (c *Ctrl) processAsyncJob(params asyncJobParams) {
 	// and rewrite data[].b64_json → data[].url. jobID doubles as the chatKey —
 	// /v1/proxy/images/{jobID}/{i} resolves to the stored bytes. Store / build
 	// failures fall back to b64 (safe — body is confirmed b64 above).
-	if clientResponseFormat == "url" && extractOK && c.imageStore != nil {
+	if clientResponseFormat == "url" && extractOK {
+		// Fail-closed when store is nil: silently storing b64 violates the
+		// client's explicit contract. See handleTextToImageResponse.
+		if c.imageStore == nil {
+			c.logger.Errorf("Async job %s: URL requested but imageStore is nil (check newImageStore startup warning)", jobID)
+			c.markAsyncJobFailed(jobID, "response_format=url requested but image store is disabled")
+			return
+		}
 		if stErr := c.imageStore.store(jobID, images); stErr != nil {
 			c.logger.Warnf("Async job %s: store images failed, returning b64: %v", jobID, stErr)
 		} else if rewritten, bErr := buildURLResponse(providerRespBody, jobID, len(images), c.Service.ServingURL); bErr != nil {

--- a/api/inference/internal/ctrl/async.go
+++ b/api/inference/internal/ctrl/async.go
@@ -51,11 +51,14 @@ func (c *Ctrl) InitAsyncProcessing(maxConcurrent, maxQueueSize int, resultTTL, c
 		return errors.Wrap(err, "mark stale processing jobs as failed")
 	}
 
-	// Start fixed worker pool — exactly maxConcurrent goroutines, never more
+	// Start fixed worker pool — exactly maxConcurrent goroutines, never more.
+	// Workers drain via close(c.asyncJobQueue) in ShutdownAsync, not the ctx —
+	// ctx only cancels the cleanup goroutine below.
 	for i := 0; i < maxConcurrent; i++ {
 		c.asyncWg.Add(1)
-		go c.asyncWorker(ctx, i)
+		go c.asyncWorker()
 	}
+	_ = ctx // retained for the cleanup goroutine; workers do not observe it
 
 	// Start periodic cleanup of expired jobs
 	c.asyncWg.Add(1)
@@ -85,7 +88,7 @@ func (c *Ctrl) InitAsyncProcessing(maxConcurrent, maxQueueSize int, resultTTL, c
 // It blocks until a job is available, processes it, and repeats. When the channel is closed
 // (by ShutdownAsync), range drains all remaining buffered jobs before exiting — ensuring
 // no accepted jobs are silently dropped.
-func (c *Ctrl) asyncWorker(_ context.Context, workerID int) {
+func (c *Ctrl) asyncWorker() {
 	defer c.asyncWg.Done()
 	for job := range c.asyncJobQueue {
 		c.processAsyncJob(job)
@@ -288,7 +291,7 @@ func (c *Ctrl) processAsyncJob(params asyncJobParams) {
 			rwErr     error
 		)
 		if strings.HasPrefix(strings.ToLower(contentType), "multipart/") {
-			orig, rewritten, rwErr = rewriteMultipartResponseFormat(reqBody)
+			orig, rewritten, rwErr = rewriteMultipartResponseFormat(reqBody, contentType)
 		} else {
 			orig, rewritten, rwErr = forceB64ResponseFormat(reqBody)
 		}

--- a/api/inference/internal/ctrl/async_test.go
+++ b/api/inference/internal/ctrl/async_test.go
@@ -1509,6 +1509,62 @@ func TestProcessAsyncJob_URLFormat_SignatureBindsImageBytes(t *testing.T) {
 	if strings.Contains(sig.Text, "broker.test") {
 		t.Errorf("signature text contains URL host; must cover image bytes, got: %s", sig.Text)
 	}
+
+	// Full round-trip: recover the signer address from the signature and compare
+	// to the broker's TEE signing key. This is what external verifiers actually
+	// run, and it's the only check that catches a malformed signature byte.
+	recovered := recoverSignerAddress(t, sig)
+	if recovered != ctrl.teeService.Address {
+		t.Errorf("recovered signer %s != broker TEE address %s", recovered.Hex(), ctrl.teeService.Address.Hex())
+	}
+}
+
+// TestProcessAsyncJob_URLFormat_ProviderReturnsURLForm_JobFailed pins the
+// response-side fallback-leak guard on the async path. A non-compliant provider
+// ignores response_format=b64_json and returns LAN-private URLs; the broker
+// must mark the job failed rather than storing/forwarding that body. Absence
+// of this test would let the earlier pass-through behaviour regress silently:
+// job completes, ResponseBody contains "http://10.0.0.7/leaked.png", client
+// gets a URL it cannot reach (and the broker has signed it).
+func TestProcessAsyncJob_URLFormat_ProviderReturnsURLForm_JobFailed(t *testing.T) {
+	provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"data":[{"url":"http://10.0.0.7/leaked.png"}]}`))
+	}))
+	defer provider.Close()
+
+	store := newMockDB()
+	store.CreateAsyncJob(model.AsyncJob{
+		JobID: "leak-job", Status: model.AsyncJobStatusPending, ServiceType: "text-to-image",
+	})
+
+	ctrl := newTestCtrl(store, provider.URL)
+	ctrl.Service.ServingURL = "http://broker.test"
+	if err := ctrl.SetupImageStoreForTest(t.TempDir()); err != nil {
+		t.Fatalf("setup image store: %v", err)
+	}
+
+	headers, _ := json.Marshal(map[string][]string{"Content-Type": {"application/json"}})
+	ctrl.processAsyncJob(asyncJobParams{
+		JobID:          "leak-job",
+		ServiceType:    "text-to-image",
+		RequestHeaders: headers,
+		RequestBody:    []byte(`{"prompt":"x","response_format":"url"}`),
+		IsWhitelisted:  true,
+	})
+
+	job, _ := store.GetAsyncJob("leak-job")
+	if job.Status != model.AsyncJobStatusFailed {
+		t.Fatalf("expected failed status when provider returns URL form under response_format=url; got %s (body=%q)", job.Status, job.ResponseBody)
+	}
+	// The LAN URL must not survive anywhere the client could read it.
+	if bytes.Contains(job.ResponseBody, []byte("10.0.0.7")) || bytes.Contains(job.ResponseBody, []byte("leaked.png")) {
+		t.Errorf("provider LAN URL leaked into stored ResponseBody: %s", job.ResponseBody)
+	}
+	if strings.Contains(job.ErrorMessage, "10.0.0.7") || strings.Contains(job.ErrorMessage, "leaked.png") {
+		t.Errorf("provider LAN URL leaked into ErrorMessage: %s", job.ErrorMessage)
+	}
 }
 
 // ==========================================================================

--- a/api/inference/internal/ctrl/async_test.go
+++ b/api/inference/internal/ctrl/async_test.go
@@ -1,10 +1,14 @@
 package ctrl
 
 import (
+	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1201,6 +1205,211 @@ func TestProcessAsyncJob_NonWhitelisted_BillingDBFails(t *testing.T) {
 	}
 	if !strings.Contains(job.ErrorMessage, "failed to store result") {
 		t.Errorf("expected 'failed to store result' error, got: %s", job.ErrorMessage)
+	}
+}
+
+// ==========================================================================
+// processAsyncJob — response_format="url" rewrite
+// ==========================================================================
+
+// TestProcessAsyncJob_URLFormat_JSON covers the async equivalent of the sync
+// text-to-image URL flow: the upstream request is forced to b64_json, the
+// provider's b64 response is stored locally, and the stored async result
+// carries broker-served URLs keyed off jobID.
+func TestProcessAsyncJob_URLFormat_JSON(t *testing.T) {
+	pngBytes := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x01}
+	b64 := base64.StdEncoding.EncodeToString(pngBytes)
+
+	var providerSawFormat string
+	provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]interface{}
+		_ = json.Unmarshal(body, &req)
+		providerSawFormat, _ = req["response_format"].(string)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"created":1,"data":[{"b64_json":"` + b64 + `"},{"b64_json":"` + b64 + `"}]}`))
+	}))
+	defer provider.Close()
+
+	store := newMockDB()
+	store.CreateAsyncJob(model.AsyncJob{
+		JobID: "url-job", Status: model.AsyncJobStatusPending, ServiceType: "text-to-image",
+	})
+
+	ctrl := newTestCtrl(store, provider.URL)
+	ctrl.Service.ServingURL = "https://broker.test"
+	if err := ctrl.SetupImageStoreForTest(t.TempDir()); err != nil {
+		t.Fatalf("setup image store: %v", err)
+	}
+
+	headers, _ := json.Marshal(map[string][]string{"Content-Type": {"application/json"}})
+	ctrl.processAsyncJob(asyncJobParams{
+		JobID:          "url-job",
+		ServiceType:    "text-to-image",
+		RequestHeaders: headers,
+		RequestBody:    []byte(`{"prompt":"cat","n":2,"response_format":"url"}`),
+		IsWhitelisted:  true,
+	})
+
+	if providerSawFormat != "b64_json" {
+		t.Errorf("provider response_format = %q, want b64_json (broker must rewrite url→b64 upstream)", providerSawFormat)
+	}
+
+	job, _ := store.GetAsyncJob("url-job")
+	if job.Status != model.AsyncJobStatusCompleted {
+		t.Fatalf("expected completed, got %s (%s)", job.Status, job.ErrorMessage)
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(job.ResponseBody, &resp); err != nil {
+		t.Fatalf("unmarshal stored response: %v", err)
+	}
+	data, _ := resp["data"].([]interface{})
+	if len(data) != 2 {
+		t.Fatalf("expected 2 data entries in stored response, got %d", len(data))
+	}
+	for i, raw := range data {
+		item := raw.(map[string]interface{})
+		if _, has := item["b64_json"]; has {
+			t.Errorf("data[%d].b64_json should be absent when url format requested", i)
+		}
+		gotURL, _ := item["url"].(string)
+		want := "https://broker.test/v1/proxy/images/url-job/" + strconv.Itoa(i)
+		if gotURL != want {
+			t.Errorf("data[%d].url = %q, want %q", i, gotURL, want)
+		}
+
+		img, err := ctrl.GetImage("url-job", i)
+		if err != nil {
+			t.Errorf("GetImage(url-job, %d): %v", i, err)
+			continue
+		}
+		if !bytes.Equal(img, pngBytes) {
+			t.Errorf("stored image %d does not match provider bytes", i)
+		}
+	}
+}
+
+// TestProcessAsyncJob_URLFormat_Multipart pins the multipart image-editing
+// variant: the stored request body has a response_format form field set to
+// "url", the worker must rewrite it to b64_json before dispatching, and the
+// stored response must carry broker URLs.
+func TestProcessAsyncJob_URLFormat_Multipart(t *testing.T) {
+	pngBytes := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x01}
+	b64 := base64.StdEncoding.EncodeToString(pngBytes)
+
+	var providerSawFormat string
+	provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseMultipartForm(32 << 20)
+		providerSawFormat = r.FormValue("response_format")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"created":1,"data":[{"b64_json":"` + b64 + `"}]}`))
+	}))
+	defer provider.Close()
+
+	store := newMockDB()
+	store.CreateAsyncJob(model.AsyncJob{
+		JobID: "url-edit", Status: model.AsyncJobStatusPending, ServiceType: "image-editing",
+	})
+
+	ctrl := newTestCtrl(store, provider.URL)
+	ctrl.Service.ServingURL = "https://broker.test"
+	if err := ctrl.SetupImageStoreForTest(t.TempDir()); err != nil {
+		t.Fatalf("setup image store: %v", err)
+	}
+
+	boundary := "----AsyncUrlBoundary"
+	body := "--" + boundary + "\r\nContent-Disposition: form-data; name=\"prompt\"\r\n\r\nmake it red\r\n" +
+		"--" + boundary + "\r\nContent-Disposition: form-data; name=\"n\"\r\n\r\n1\r\n" +
+		"--" + boundary + "\r\nContent-Disposition: form-data; name=\"response_format\"\r\n\r\nurl\r\n" +
+		"--" + boundary + "\r\nContent-Disposition: form-data; name=\"image\"; filename=\"t.png\"\r\nContent-Type: image/png\r\n\r\nfake-png\r\n" +
+		"--" + boundary + "--"
+	headers, _ := json.Marshal(map[string][]string{"Content-Type": {"multipart/form-data; boundary=" + boundary}})
+
+	ctrl.processAsyncJob(asyncJobParams{
+		JobID:          "url-edit",
+		ServiceType:    "image-editing",
+		RequestHeaders: headers,
+		RequestBody:    []byte(body),
+		IsWhitelisted:  true,
+	})
+
+	if providerSawFormat != "b64_json" {
+		t.Errorf("provider response_format = %q, want b64_json", providerSawFormat)
+	}
+
+	job, _ := store.GetAsyncJob("url-edit")
+	if job.Status != model.AsyncJobStatusCompleted {
+		t.Fatalf("expected completed, got %s (%s)", job.Status, job.ErrorMessage)
+	}
+	var resp map[string]interface{}
+	if err := json.Unmarshal(job.ResponseBody, &resp); err != nil {
+		t.Fatalf("unmarshal stored response: %v", err)
+	}
+	item := resp["data"].([]interface{})[0].(map[string]interface{})
+	gotURL, _ := item["url"].(string)
+	want := "https://broker.test/v1/proxy/images/url-edit/0"
+	if gotURL != want {
+		t.Errorf("url = %q, want %q", gotURL, want)
+	}
+	if _, has := item["b64_json"]; has {
+		t.Error("b64_json should be absent when url format requested")
+	}
+	img, err := ctrl.GetImage("url-edit", 0)
+	if err != nil || !bytes.Equal(img, pngBytes) {
+		t.Errorf("stored image mismatch: err=%v", err)
+	}
+}
+
+// TestProcessAsyncJob_URLFormat_PassThrough ensures b64_json requests are not
+// rewritten — the stored response still carries b64_json and no image-store
+// entries are created.
+func TestProcessAsyncJob_URLFormat_PassThrough(t *testing.T) {
+	b64 := base64.StdEncoding.EncodeToString([]byte("px"))
+
+	provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"data":[{"b64_json":"` + b64 + `"}]}`))
+	}))
+	defer provider.Close()
+
+	store := newMockDB()
+	store.CreateAsyncJob(model.AsyncJob{
+		JobID: "b64-job", Status: model.AsyncJobStatusPending, ServiceType: "text-to-image",
+	})
+
+	ctrl := newTestCtrl(store, provider.URL)
+	ctrl.Service.ServingURL = "https://broker.test"
+	if err := ctrl.SetupImageStoreForTest(t.TempDir()); err != nil {
+		t.Fatalf("setup image store: %v", err)
+	}
+
+	headers, _ := json.Marshal(map[string][]string{"Content-Type": {"application/json"}})
+	ctrl.processAsyncJob(asyncJobParams{
+		JobID:          "b64-job",
+		ServiceType:    "text-to-image",
+		RequestHeaders: headers,
+		RequestBody:    []byte(`{"prompt":"cat","response_format":"b64_json"}`),
+		IsWhitelisted:  true,
+	})
+
+	job, _ := store.GetAsyncJob("b64-job")
+	var resp map[string]interface{}
+	if err := json.Unmarshal(job.ResponseBody, &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	item := resp["data"].([]interface{})[0].(map[string]interface{})
+	if gotB64, _ := item["b64_json"].(string); gotB64 != b64 {
+		t.Errorf("b64_json lost in pass-through: got len=%d, want len=%d", len(gotB64), len(b64))
+	}
+	if _, has := item["url"]; has {
+		t.Error("url should not be injected when b64_json requested")
+	}
+	if _, err := ctrl.GetImage("b64-job", 0); err == nil {
+		t.Error("imageStore should be empty when url rewrite was not requested")
 	}
 }
 

--- a/api/inference/internal/ctrl/async_test.go
+++ b/api/inference/internal/ctrl/async_test.go
@@ -2,7 +2,9 @@ package ctrl
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -15,11 +17,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/gin-gonic/gin"
 	"github.com/patrickmn/go-cache"
 	logrus "github.com/sirupsen/logrus"
 
 	"github.com/0glabs/0g-serving-broker/common/log"
+	teeutil "github.com/0glabs/0g-serving-broker/common/tee"
 	"github.com/0glabs/0g-serving-broker/inference/model"
 )
 
@@ -1410,6 +1414,100 @@ func TestProcessAsyncJob_URLFormat_PassThrough(t *testing.T) {
 	}
 	if _, err := ctrl.GetImage("b64-job", 0); err == nil {
 		t.Error("imageStore should be empty when url rewrite was not requested")
+	}
+}
+
+// TestProcessAsyncJob_URLFormat_SignatureBindsImageBytes is the regression
+// guard for the async TEE-signing bug: when clientResponseFormat=url, the
+// broker rewrites respBody to the URL envelope before signing. An earlier
+// version of processAsyncJob passed the rewritten envelope to signChatWithKey,
+// so the signature covered URL strings — images at /v1/proxy/images/{jobID}/{i}
+// were bound by nothing. The fix routes image responses through
+// signImageResponse(reqBody, images, chatKey), producing a signature text of
+// sha256(reqBody):sha256(img0),sha256(img1),... This test asserts the cached
+// signature matches that form — not the URL-envelope form — and would fail
+// against the old code.
+func TestProcessAsyncJob_URLFormat_SignatureBindsImageBytes(t *testing.T) {
+	img0 := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0xDE, 0xAD, 0xBE, 0xEF}
+	img1 := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0xCA, 0xFE, 0xBA, 0xBE}
+
+	provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, `{"data":[{"b64_json":%q},{"b64_json":%q}]}`,
+			base64.StdEncoding.EncodeToString(img0),
+			base64.StdEncoding.EncodeToString(img1))
+	}))
+	defer provider.Close()
+
+	store := newMockDB()
+	store.CreateAsyncJob(model.AsyncJob{
+		JobID: "sig-job", Status: model.AsyncJobStatusPending, ServiceType: "text-to-image",
+	})
+
+	ctrl := newTestCtrl(store, provider.URL)
+	// Enable TEE signing (newTestCtrl defaults TargetSeparated=true which skips it).
+	ctrl.Service.TargetSeparated = false
+	ctrl.Service.ServingURL = "https://broker.test"
+	priv, _ := crypto.GenerateKey()
+	ctrl.teeService = &teeutil.TeeService{
+		ProviderSigner: priv,
+		Address:        crypto.PubkeyToAddress(priv.PublicKey),
+	}
+	if ctrl.svcCache == nil {
+		ctrl.svcCache = cache.New(5*time.Minute, 10*time.Minute)
+	}
+	ctrl.chatCacheExpiration = 5 * time.Minute
+	if err := ctrl.SetupImageStoreForTest(t.TempDir()); err != nil {
+		t.Fatalf("setup image store: %v", err)
+	}
+
+	reqBody := []byte(`{"prompt":"cat","n":2,"response_format":"url"}`)
+	headers, _ := json.Marshal(map[string][]string{"Content-Type": {"application/json"}})
+	ctrl.processAsyncJob(asyncJobParams{
+		JobID:          "sig-job",
+		ServiceType:    "text-to-image",
+		RequestHeaders: headers,
+		RequestBody:    reqBody,
+		IsWhitelisted:  true,
+	})
+
+	job, _ := store.GetAsyncJob("sig-job")
+	if job.Status != model.AsyncJobStatusCompleted {
+		t.Fatalf("expected completed, got %s (%s)", job.Status, job.ErrorMessage)
+	}
+
+	// Recover chatKey from stored ZG-Res-Key header.
+	var respHeaders map[string][]string
+	if err := json.Unmarshal(job.ResponseHeaders, &respHeaders); err != nil {
+		t.Fatalf("decode headers: %v", err)
+	}
+	keys := respHeaders["ZG-Res-Key"]
+	if len(keys) == 0 {
+		t.Fatal("expected ZG-Res-Key header to be stored after signing")
+	}
+	chatKey := keys[0]
+
+	sum := func(b []byte) string {
+		h := sha256.Sum256(b)
+		return hex.EncodeToString(h[:])
+	}
+	wantText := sum(reqBody) + ":" + sum(img0) + "," + sum(img1)
+
+	cached, ok := ctrl.svcCache.Get(ctrl.chatCacheKey(chatKey))
+	if !ok {
+		t.Fatal("no signature cached under chatKey — signing step did not run")
+	}
+	sig, ok := cached.(ChatSignature)
+	if !ok {
+		t.Fatalf("cached value is not ChatSignature: %T", cached)
+	}
+	if sig.Text != wantText {
+		t.Errorf("\nsignature text binds the WRONG content.\n got: %s\nwant: %s\n(old buggy path signed the URL envelope, not image bytes)", sig.Text, wantText)
+	}
+	// Extra guard: must not be sha256(req):sha256(rewrittenURLJSON).
+	if strings.Contains(sig.Text, "broker.test") {
+		t.Errorf("signature text contains URL host; must cover image bytes, got: %s", sig.Text)
 	}
 }
 

--- a/api/inference/internal/ctrl/async_test.go
+++ b/api/inference/internal/ctrl/async_test.go
@@ -1658,6 +1658,50 @@ func TestProcessAsyncJob_MalformedJSON_JobFailedBeforeForwarding(t *testing.T) {
 	}
 }
 
+// TestProcessAsyncJob_URLFormat_NilImageStore_JobFailed pins the fail-closed
+// behaviour when the client asks for URL format but imageStore is nil (e.g.
+// the broker couldn't create its cache dir at startup). Silently returning
+// b64 would violate the client's explicit contract with no per-request signal;
+// the job is marked failed instead so the caller sees what happened.
+func TestProcessAsyncJob_URLFormat_NilImageStore_JobFailed(t *testing.T) {
+	b64 := base64.StdEncoding.EncodeToString([]byte{0x89, 0x50, 0x4E, 0x47})
+	provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, `{"data":[{"b64_json":%q}]}`, b64)
+	}))
+	defer provider.Close()
+
+	store := newMockDB()
+	store.CreateAsyncJob(model.AsyncJob{
+		JobID: "nil-store-job", Status: model.AsyncJobStatusPending, ServiceType: "text-to-image",
+	})
+
+	ctrl := newTestCtrl(store, provider.URL)
+	ctrl.Service.ServingURL = "http://broker.test"
+	// Deliberately skip SetupImageStoreForTest — imageStore stays nil.
+	if ctrl.imageStore != nil {
+		t.Fatal("imageStore should be nil for this test")
+	}
+
+	headers, _ := json.Marshal(map[string][]string{"Content-Type": {"application/json"}})
+	ctrl.processAsyncJob(asyncJobParams{
+		JobID:          "nil-store-job",
+		ServiceType:    "text-to-image",
+		RequestHeaders: headers,
+		RequestBody:    []byte(`{"prompt":"x","response_format":"url"}`),
+		IsWhitelisted:  true,
+	})
+
+	job, _ := store.GetAsyncJob("nil-store-job")
+	if job.Status != model.AsyncJobStatusFailed {
+		t.Fatalf("expected failed, got %s (body=%q)", job.Status, job.ResponseBody)
+	}
+	if !strings.Contains(job.ErrorMessage, "image store") {
+		t.Errorf("error message should mention the disabled store; got: %s", job.ErrorMessage)
+	}
+}
+
 // TestProcessAsyncJob_URLFormat_ProviderReturnsURLForm_JobFailed pins the
 // response-side fallback-leak guard on the async path. A non-compliant provider
 // ignores response_format=b64_json and returns LAN-private URLs; the broker

--- a/api/inference/internal/ctrl/async_test.go
+++ b/api/inference/internal/ctrl/async_test.go
@@ -664,6 +664,8 @@ func TestProcessAsyncJob_RestoresRequestHeaders(t *testing.T) {
 	var receivedContentType string
 	provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		receivedContentType = r.Header.Get("Content-Type")
+		// Boundary string can be rewritten by multipart.Writer — compare the
+		// parsed media type prefix instead of expecting the original string.
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`{"data":[]}`))
 	}))
@@ -677,18 +679,24 @@ func TestProcessAsyncJob_RestoresRequestHeaders(t *testing.T) {
 	headers, _ := json.Marshal(map[string][]string{
 		"Content-Type": {"multipart/form-data; boundary=abc123"},
 	})
+	// Valid multipart body so the rewrite succeeds — empty or malformed bodies
+	// would now be rejected upstream (see TestProcessAsyncJob_MalformedJSON…).
+	body := []byte(
+		"--abc123\r\nContent-Disposition: form-data; name=\"prompt\"\r\n\r\nhi\r\n" +
+			"--abc123--\r\n",
+	)
 
 	ctrl := newTestCtrl(store, provider.URL)
 	ctrl.processAsyncJob(asyncJobParams{
 		JobID:          "job-headers",
 		ServiceType:    "text-to-image",
 		RequestHeaders: headers,
-		RequestBody:    []byte(`data`),
+		RequestBody:    body,
 		IsWhitelisted:  true,
 	})
 
-	if receivedContentType != "multipart/form-data; boundary=abc123" {
-		t.Errorf("expected multipart content type, got %s", receivedContentType)
+	if !strings.HasPrefix(receivedContentType, "multipart/form-data;") {
+		t.Errorf("expected multipart content type, got %q", receivedContentType)
 	}
 }
 
@@ -1596,6 +1604,57 @@ func TestProcessAsyncJob_Centralized_SignsRoutingProof(t *testing.T) {
 	// which emits the 5-segment routing-proof text (req:resp:type:identity:fp).
 	if parts := strings.Split(sig.Text, ":"); len(parts) != 5 {
 		t.Errorf("expected 5-part routing-proof text, got %d parts: %s", len(parts), sig.Text)
+	}
+}
+
+// TestProcessAsyncJob_MalformedJSON_JobFailedBeforeForwarding pins the async
+// rewrite-failure leak fix: when forceB64ResponseFormat errors (e.g. malformed
+// JSON), the OLD code silently forwarded the un-normalised body and the
+// provider's URL-form response flowed back to the client. Must mark the job
+// failed without ever hitting the provider.
+func TestProcessAsyncJob_MalformedJSON_JobFailedBeforeForwarding(t *testing.T) {
+	providerHit := false
+	provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		providerHit = true
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"data":[{"url":"http://10.0.0.9/leak.png"}]}`))
+	}))
+	defer provider.Close()
+
+	store := newMockDB()
+	store.CreateAsyncJob(model.AsyncJob{
+		JobID: "malformed-job", Status: model.AsyncJobStatusPending, ServiceType: "text-to-image",
+	})
+
+	ctrl := newTestCtrl(store, provider.URL)
+	ctrl.Service.ServingURL = "http://broker.test"
+	if err := ctrl.SetupImageStoreForTest(t.TempDir()); err != nil {
+		t.Fatalf("setup image store: %v", err)
+	}
+
+	headers, _ := json.Marshal(map[string][]string{"Content-Type": {"application/json"}})
+	// Malformed JSON body — forceB64ResponseFormat returns err.
+	ctrl.processAsyncJob(asyncJobParams{
+		JobID:          "malformed-job",
+		ServiceType:    "text-to-image",
+		RequestHeaders: headers,
+		RequestBody:    []byte(`{"prompt":`),
+		IsWhitelisted:  true,
+	})
+
+	if providerHit {
+		t.Error("provider must not be called when request-body normalisation fails (old code forwarded it silently)")
+	}
+	job, _ := store.GetAsyncJob("malformed-job")
+	if job.Status != model.AsyncJobStatusFailed {
+		t.Errorf("expected failed status on normalisation error, got %s", job.Status)
+	}
+	if !strings.Contains(job.ErrorMessage, "normalise image request body") {
+		t.Errorf("error message should identify the failure stage, got: %s", job.ErrorMessage)
+	}
+	// Guard against any leaked LAN bytes in the stored record.
+	if bytes.Contains(job.ResponseBody, []byte("10.0.0.9")) {
+		t.Errorf("no bytes from provider should exist: %s", job.ResponseBody)
 	}
 }
 

--- a/api/inference/internal/ctrl/async_test.go
+++ b/api/inference/internal/ctrl/async_test.go
@@ -1519,6 +1519,86 @@ func TestProcessAsyncJob_URLFormat_SignatureBindsImageBytes(t *testing.T) {
 	}
 }
 
+// TestProcessAsyncJob_Centralized_SignsRoutingProof pins the centralized
+// trust-model dispatch: for a centralized provider (where broker can't vouch
+// for content), the async worker must sign a routing proof — binding the TLS
+// cert fingerprint + provider identity + req/resp hashes — instead of signing
+// image bytes as if the broker were the source of truth. Regressing this would
+// produce a TEE-signed envelope that LOOKS valid to naive verifiers but omits
+// the only attestation that actually matters for a centralized path.
+func TestProcessAsyncJob_Centralized_SignsRoutingProof(t *testing.T) {
+	// HTTPS provider so resp.TLS is populated — routing proof needs the cert.
+	provider := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"data":[{"b64_json":"aW1n"}]}`))
+	}))
+	defer provider.Close()
+
+	store := newMockDB()
+	store.CreateAsyncJob(model.AsyncJob{
+		JobID: "centralized-job", Status: model.AsyncJobStatusPending, ServiceType: "text-to-image",
+	})
+
+	ctrl := newTestCtrl(store, provider.URL)
+	ctrl.Service.ProviderType = "centralized"
+	ctrl.Service.ProviderIdentity = "openai"
+	ctrl.Service.TargetSeparated = true // canonical centralized config
+	ctrl.httpClient = provider.Client() // trust the self-signed test cert
+	priv, _ := crypto.GenerateKey()
+	ctrl.teeService = &teeutil.TeeService{
+		ProviderSigner: priv,
+		Address:        crypto.PubkeyToAddress(priv.PublicKey),
+	}
+	if ctrl.svcCache == nil {
+		ctrl.svcCache = cache.New(5*time.Minute, 10*time.Minute)
+	}
+	ctrl.chatCacheExpiration = 5 * time.Minute
+
+	headers, _ := json.Marshal(map[string][]string{"Content-Type": {"application/json"}})
+	ctrl.processAsyncJob(asyncJobParams{
+		JobID:          "centralized-job",
+		ServiceType:    "text-to-image",
+		RequestHeaders: headers,
+		RequestBody:    []byte(`{"prompt":"x"}`),
+		IsWhitelisted:  true,
+	})
+
+	job, _ := store.GetAsyncJob("centralized-job")
+	if job.Status != model.AsyncJobStatusCompleted {
+		t.Fatalf("expected completed, got %s (%s)", job.Status, job.ErrorMessage)
+	}
+
+	var respHeaders map[string][]string
+	if err := json.Unmarshal(job.ResponseHeaders, &respHeaders); err != nil {
+		t.Fatalf("decode response headers: %v", err)
+	}
+	keys := respHeaders["ZG-Res-Key"]
+	if len(keys) == 0 {
+		t.Fatal("ZG-Res-Key missing — routing proof did not run")
+	}
+
+	cached, ok := ctrl.svcCache.Get(ctrl.chatCacheKey(keys[0]))
+	if !ok {
+		t.Fatal("no ChatSignature cached under chatKey")
+	}
+	sig := cached.(ChatSignature)
+	if sig.TLSCertFingerprint == "" {
+		t.Error("routing proof must bind the TLS cert fingerprint")
+	}
+	if sig.ProviderIdentity != "openai" {
+		t.Errorf("ProviderIdentity = %q, want openai", sig.ProviderIdentity)
+	}
+	if sig.ProviderType != "centralized" {
+		t.Errorf("ProviderType = %q, want centralized", sig.ProviderType)
+	}
+	// Guard against regression to signImageResponse / signChatWithKey, neither of
+	// which emits the 5-segment routing-proof text (req:resp:type:identity:fp).
+	if parts := strings.Split(sig.Text, ":"); len(parts) != 5 {
+		t.Errorf("expected 5-part routing-proof text, got %d parts: %s", len(parts), sig.Text)
+	}
+}
+
 // TestProcessAsyncJob_URLFormat_ProviderReturnsURLForm_JobFailed pins the
 // response-side fallback-leak guard on the async path. A non-compliant provider
 // ignores response_format=b64_json and returns LAN-private URLs; the broker

--- a/api/inference/internal/ctrl/chatbot.go
+++ b/api/inference/internal/ctrl/chatbot.go
@@ -4,9 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"crypto/sha256"
 	"crypto/tls"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -20,41 +18,18 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/andybalholm/brotli"
-	"github.com/ethereum/go-ethereum/accounts"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/gin-gonic/gin"
 
 	"github.com/0glabs/0g-serving-broker/common/errors"
-	teeutil "github.com/0glabs/0g-serving-broker/common/tee"
 	"github.com/0glabs/0g-serving-broker/common/util"
 	"github.com/0glabs/0g-serving-broker/inference/model"
 	"github.com/0glabs/0g-serving-broker/inference/monitor"
 )
 
-const ChatPrefix = "chat"
-
-type SigningAlgo int
-
-const (
-	ECDSA SigningAlgo = iota
-)
-
-func (r SigningAlgo) String() string {
-	return [...]string{"ecdsa"}[r]
-}
-
-type ChatSignature struct {
-	Text                string         `json:"text"`
-	SignatureEcdsa      string         `json:"signature"`
-	SigningAddressEcdsa common.Address `json:"signing_address"`
-	SigningAlgo         string         `json:"signing_algo"`
-	// Centralized provider routing proof fields (omitted for decentralized providers)
-	ProviderType       string `json:"provider_type,omitempty"`
-	ProviderIdentity   string `json:"provider_identity,omitempty"`
-	TLSCertFingerprint string `json:"tls_cert_fingerprint,omitempty"`
-}
+// ChatSignature, SigningAlgo, ChatPrefix, and the chat-signing helpers
+// (signChatWithKey, signImageResponse, signCentralizedRoutingProof, chatCacheKey)
+// live in signing.go — they are shared TEE-signing infrastructure, not
+// chatbot-specific logic.
 
 type RequestBody struct {
 	Messages []Message `json:"messages"`
@@ -330,135 +305,6 @@ func (c *Ctrl) decodeAndProcess(ctx context.Context, data []byte, encodingType s
 	}
 
 	return nil
-}
-
-func (c *Ctrl) signChatWithKey(reqBody, respData []byte, chatKey string) error {
-	hashAndEncode := func(b []byte) string {
-		h := sha256.Sum256(b)
-		return hex.EncodeToString(h[:])
-	}
-
-	requestSha256 := hashAndEncode(reqBody)
-	responseSha256 := hashAndEncode(respData)
-
-	c.logger.Debugf("requestSha256: %s, responseSha256: %s, signer address %s", requestSha256, responseSha256, c.teeService.Address.Hex())
-	text := fmt.Sprintf("%s:%s", requestSha256, responseSha256)
-	sig, err := crypto.Sign(accounts.TextHash([]byte(text)), c.teeService.ProviderSigner)
-	if err != nil {
-		return err
-	}
-
-	if sig[64] == 0 || sig[64] == 1 {
-		sig[64] += 27
-	}
-
-	chatSignature := ChatSignature{
-		Text:                text,
-		SignatureEcdsa:      hexutil.Encode(sig),
-		SigningAddressEcdsa: c.teeService.Address,
-		SigningAlgo:         ECDSA.String(),
-	}
-
-	key := c.chatCacheKey(chatKey)
-	c.logger.Debugf("key: %v, chat signature: %v", key, chatSignature)
-	c.svcCache.Set(key, chatSignature, c.chatCacheExpiration)
-	return nil
-}
-
-// signImageResponse creates a TEE signature for image generation / editing responses.
-// The signed text is: sha256(originalClientReqBody):sha256(img0),sha256(img1),...
-// This binds the signature to actual image bytes rather than provider response JSON,
-// which may contain inaccessible LAN URLs.
-func (c *Ctrl) signImageResponse(reqBody []byte, images [][]byte, chatKey string) error {
-	hashAndEncode := func(b []byte) string {
-		h := sha256.Sum256(b)
-		return hex.EncodeToString(h[:])
-	}
-
-	imgHashes := make([]string, len(images))
-	for i, img := range images {
-		imgHashes[i] = hashAndEncode(img)
-	}
-	text := hashAndEncode(reqBody) + ":" + strings.Join(imgHashes, ",")
-
-	sig, err := crypto.Sign(accounts.TextHash([]byte(text)), c.teeService.ProviderSigner)
-	if err != nil {
-		return err
-	}
-	if sig[64] == 0 || sig[64] == 1 {
-		sig[64] += 27
-	}
-
-	chatSignature := ChatSignature{
-		Text:                text,
-		SignatureEcdsa:      hexutil.Encode(sig),
-		SigningAddressEcdsa: c.teeService.Address,
-		SigningAlgo:         ECDSA.String(),
-	}
-
-	key := c.chatCacheKey(chatKey)
-	c.logger.Debugf("image signature key: %v, sig: %v", key, chatSignature)
-	c.svcCache.Set(key, chatSignature, c.chatCacheExpiration)
-	return nil
-}
-
-// signCentralizedRoutingProof creates a TEE-signed routing proof for centralized
-// provider requests. The proof includes request/response hashes, provider identity,
-// and the TLS certificate fingerprint proving the connection target.
-func (c *Ctrl) signCentralizedRoutingProof(reqBody, respData []byte, chatKey string, tlsState *tls.ConnectionState) error {
-	hashAndEncode := func(b []byte) string {
-		h := sha256.Sum256(b)
-		return hex.EncodeToString(h[:])
-	}
-
-	requestSha256 := hashAndEncode(reqBody)
-	responseSha256 := hashAndEncode(respData)
-
-	// Extract TLS certificate fingerprint — refuse to sign without it.
-	// A routing proof with an empty fingerprint carries a TEE signature but
-	// provides no TLS evidence, giving verifiers a false sense of security.
-	certInfo := teeutil.ExtractTLSInfo(tlsState)
-	if certInfo == nil || certInfo.PeerCertFingerprint == "" {
-		return fmt.Errorf("TLS certificate not available for centralized provider routing proof (response and billing are unaffected)")
-	}
-	tlsFingerprint := certInfo.PeerCertFingerprint
-	c.logger.Debugf("TLS cert fingerprint captured: %s (server: %s)", tlsFingerprint, certInfo.ServerName)
-
-	text := teeutil.FormatRoutingProofText(
-		requestSha256, responseSha256,
-		c.Service.ProviderType, c.Service.ProviderIdentity,
-		tlsFingerprint,
-	)
-
-	c.logger.Debugf("Routing proof text: %s, signer address: %s", text, c.teeService.Address.Hex())
-
-	sig, err := crypto.Sign(accounts.TextHash([]byte(text)), c.teeService.ProviderSigner)
-	if err != nil {
-		return fmt.Errorf("failed to sign routing proof: %w", err)
-	}
-
-	if sig[64] == 0 || sig[64] == 1 {
-		sig[64] += 27
-	}
-
-	chatSignature := ChatSignature{
-		Text:                text,
-		SignatureEcdsa:      hexutil.Encode(sig),
-		SigningAddressEcdsa: c.teeService.Address,
-		SigningAlgo:         ECDSA.String(),
-		ProviderType:        c.Service.ProviderType,
-		ProviderIdentity:    c.Service.ProviderIdentity,
-		TLSCertFingerprint:  tlsFingerprint,
-	}
-
-	key := c.chatCacheKey(chatKey)
-	c.logger.Debugf("key: %v, centralized chat signature: %v", key, chatSignature)
-	c.svcCache.Set(key, chatSignature, c.chatCacheExpiration)
-	return nil
-}
-
-func (*Ctrl) chatCacheKey(chatID string) string {
-	return fmt.Sprintf("%s:%s", ChatPrefix, chatID)
 }
 
 func (c *Ctrl) processSingleResponse(ctx context.Context, decodedBody []byte, outputPrice string, output *string, requestHash string, usage **Usage, isWhitelisted bool) error {

--- a/api/inference/internal/ctrl/chatbot.go
+++ b/api/inference/internal/ctrl/chatbot.go
@@ -365,6 +365,43 @@ func (c *Ctrl) signChatWithKey(reqBody, respData []byte, chatKey string) error {
 	return nil
 }
 
+// signImageResponse creates a TEE signature for image generation / editing responses.
+// The signed text is: sha256(originalClientReqBody):sha256(img0),sha256(img1),...
+// This binds the signature to actual image bytes rather than provider response JSON,
+// which may contain inaccessible LAN URLs.
+func (c *Ctrl) signImageResponse(reqBody []byte, images [][]byte, chatKey string) error {
+	hashAndEncode := func(b []byte) string {
+		h := sha256.Sum256(b)
+		return hex.EncodeToString(h[:])
+	}
+
+	imgHashes := make([]string, len(images))
+	for i, img := range images {
+		imgHashes[i] = hashAndEncode(img)
+	}
+	text := hashAndEncode(reqBody) + ":" + strings.Join(imgHashes, ",")
+
+	sig, err := crypto.Sign(accounts.TextHash([]byte(text)), c.teeService.ProviderSigner)
+	if err != nil {
+		return err
+	}
+	if sig[64] == 0 || sig[64] == 1 {
+		sig[64] += 27
+	}
+
+	chatSignature := ChatSignature{
+		Text:                text,
+		SignatureEcdsa:      hexutil.Encode(sig),
+		SigningAddressEcdsa: c.teeService.Address,
+		SigningAlgo:         ECDSA.String(),
+	}
+
+	key := c.chatCacheKey(chatKey)
+	c.logger.Debugf("image signature key: %v, sig: %v", key, chatSignature)
+	c.svcCache.Set(key, chatSignature, c.chatCacheExpiration)
+	return nil
+}
+
 // signCentralizedRoutingProof creates a TEE-signed routing proof for centralized
 // provider requests. The proof includes request/response hashes, provider identity,
 // and the TLS certificate fingerprint proving the connection target.

--- a/api/inference/internal/ctrl/chatbot_test.go
+++ b/api/inference/internal/ctrl/chatbot_test.go
@@ -627,3 +627,29 @@ func TestSignImageResponse_DifferentImagesProduceDifferentText(t *testing.T) {
 		t.Error("different images should produce different signed text")
 	}
 }
+
+// TestSignImageResponse_RefusesCentralized pins the parity guard: the
+// decentralized signer must never run for a centralized provider, because its
+// signature envelope omits the TLS fingerprint / ProviderType / ProviderIdentity
+// fields that signCentralizedRoutingProof carries. Without this guard, a dev
+// who flips providerType=centralized while targetSeparated=false would get a
+// silently weaker TEE proof — a routing-proof envelope without the TLS
+// evidence, giving verifiers a false sense of security.
+func TestSignImageResponse_RefusesCentralized(t *testing.T) {
+	ctrl := newChatbotTestCtrl(t, config.Service{
+		ProviderType:     "centralized",
+		ProviderIdentity: "openai",
+	})
+
+	err := ctrl.signImageResponse([]byte(`{"prompt":"x"}`), [][]byte{[]byte("img")}, "centralized-key")
+	if err == nil {
+		t.Fatal("signImageResponse must refuse when the service is centralized")
+	}
+	if !strings.Contains(err.Error(), "routing-proof") {
+		t.Errorf("error should point to the missing routing-proof variant; got: %v", err)
+	}
+	// Nothing should be cached.
+	if _, found := ctrl.svcCache.Get(ctrl.chatCacheKey("centralized-key")); found {
+		t.Error("no signature must be cached when the centralized guard trips")
+	}
+}

--- a/api/inference/internal/ctrl/chatbot_test.go
+++ b/api/inference/internal/ctrl/chatbot_test.go
@@ -529,3 +529,101 @@ func TestTeeServiceSigningRoundTrip(t *testing.T) {
 		t.Error("ProviderSigner is not *ecdsa.PrivateKey")
 	}
 }
+
+// ==========================================================================
+// signImageResponse
+// ==========================================================================
+
+func TestSignImageResponse_TextFormat(t *testing.T) {
+	ctrl := newChatbotTestCtrl(t, config.Service{ProviderType: "decentralized"})
+
+	reqBody := []byte(`{"prompt":"a cat","n":2}`)
+	images := [][]byte{[]byte("img0bytes"), []byte("img1bytes")}
+	chatKey := "image-sign-test-key"
+
+	if err := ctrl.signImageResponse(reqBody, images, chatKey); err != nil {
+		t.Fatalf("signImageResponse: %v", err)
+	}
+
+	val, ok := ctrl.svcCache.Get(ctrl.chatCacheKey(chatKey))
+	if !ok {
+		t.Fatal("signature not found in cache")
+	}
+	cs := val.(ChatSignature)
+
+	hashAndEncode := func(b []byte) string {
+		h := sha256.Sum256(b)
+		return hex.EncodeToString(h[:])
+	}
+	want := hashAndEncode(reqBody) + ":" + hashAndEncode(images[0]) + "," + hashAndEncode(images[1])
+	if cs.Text != want {
+		t.Errorf("text = %q\nwant = %q", cs.Text, want)
+	}
+}
+
+func TestSignImageResponse_SignatureRecoverable(t *testing.T) {
+	ctrl := newChatbotTestCtrl(t, config.Service{ProviderType: "decentralized"})
+
+	if err := ctrl.signImageResponse(
+		[]byte(`{"prompt":"dog"}`),
+		[][]byte{[]byte("img-data")},
+		"recoverable-key",
+	); err != nil {
+		t.Fatalf("signImageResponse: %v", err)
+	}
+
+	val, _ := ctrl.svcCache.Get(ctrl.chatCacheKey("recoverable-key"))
+	cs := val.(ChatSignature)
+
+	recovered := recoverSignerAddress(t, cs)
+	if recovered != ctrl.teeService.Address {
+		t.Errorf("recovered %v, want %v", recovered, ctrl.teeService.Address)
+	}
+	if cs.SigningAlgo != ECDSA.String() {
+		t.Errorf("signing_algo = %q, want %q", cs.SigningAlgo, ECDSA.String())
+	}
+}
+
+func TestSignImageResponse_SingleImage_NoCommaInText(t *testing.T) {
+	ctrl := newChatbotTestCtrl(t, config.Service{ProviderType: "decentralized"})
+
+	reqBody := []byte(`{"prompt":"solo"}`)
+	img := []byte("one-image")
+	chatKey := "single-img-key"
+
+	if err := ctrl.signImageResponse(reqBody, [][]byte{img}, chatKey); err != nil {
+		t.Fatalf("signImageResponse: %v", err)
+	}
+
+	val, _ := ctrl.svcCache.Get(ctrl.chatCacheKey(chatKey))
+	cs := val.(ChatSignature)
+
+	// With a single image there should be no comma separating hashes.
+	parts := strings.SplitN(cs.Text, ":", 2)
+	if len(parts) != 2 {
+		t.Fatalf("text has unexpected format: %q", cs.Text)
+	}
+	if strings.Contains(parts[1], ",") {
+		t.Errorf("single image text should not contain comma, got %q", cs.Text)
+	}
+}
+
+func TestSignImageResponse_DifferentImagesProduceDifferentText(t *testing.T) {
+	ctrl := newChatbotTestCtrl(t, config.Service{ProviderType: "decentralized"})
+
+	req := []byte(`{"prompt":"same"}`)
+	imagesA := [][]byte{[]byte("image-A")}
+	imagesB := [][]byte{[]byte("image-B")}
+
+	_ = ctrl.signImageResponse(req, imagesA, "key-a")
+	_ = ctrl.signImageResponse(req, imagesB, "key-b")
+
+	valA, _ := ctrl.svcCache.Get(ctrl.chatCacheKey("key-a"))
+	valB, _ := ctrl.svcCache.Get(ctrl.chatCacheKey("key-b"))
+	csA := valA.(ChatSignature)
+	csB := valB.(ChatSignature)
+
+	if csA.Text == csB.Text {
+		t.Error("different images should produce different signed text")
+	}
+}

--- a/api/inference/internal/ctrl/ctrl.go
+++ b/api/inference/internal/ctrl/ctrl.go
@@ -116,7 +116,14 @@ func New(
 		imageCacheDir = "/var/log/inference"
 	}
 	imageCacheDir += "/image_cache"
-	imgStore, err := newImageStore(imageCacheDir, cfg.ChatCacheExpiration)
+	// Keep images alive at least as long as the async result that references them.
+	// Otherwise a completed async job can return broker URLs whose backing files
+	// have already been evicted, producing a 404 before the job row itself expires.
+	imageTTL := cfg.ChatCacheExpiration
+	if asyncTTL := time.Duration(cfg.Async.ResultTTLMinutes) * time.Minute; asyncTTL > imageTTL {
+		imageTTL = asyncTTL
+	}
+	imgStore, err := newImageStore(imageCacheDir, imageTTL)
 	if err != nil {
 		logger.Warnf("Failed to initialize image store at %q, image URL serving disabled: %v", imageCacheDir, err)
 		imgStore = nil

--- a/api/inference/internal/ctrl/ctrl.go
+++ b/api/inference/internal/ctrl/ctrl.go
@@ -13,6 +13,7 @@ import (
 	"github.com/0glabs/0g-serving-broker/common/log"
 	"github.com/0glabs/0g-serving-broker/common/tee"
 	"github.com/0glabs/0g-serving-broker/inference/config"
+	constant "github.com/0glabs/0g-serving-broker/inference/const"
 	providercontract "github.com/0glabs/0g-serving-broker/inference/internal/contract"
 	"github.com/0glabs/0g-serving-broker/inference/internal/db"
 	"github.com/0glabs/0g-serving-broker/inference/internal/lora"
@@ -128,14 +129,35 @@ func New(
 	if err != nil {
 		logger.Warnf("Failed to initialize image store at %q, image URL serving disabled: %v", imageCacheDir, err)
 		imgStore = nil
-	} else if imgStore.purgedAtStart > 0 {
-		// Loud on purpose: if this number is non-zero on a shared-volume deployment
-		// (not supported but configurable at the k8s layer), it means we just
-		// deleted another broker replica's live image files.
-		logger.Infof("image store: purged %d leftover directory(ies) at %q from previous run. "+
-			"If this broker shares %q with another replica, live files have been destroyed — "+
-			"image_cache must be per-process (use a local volume, not ReadWriteMany).",
-			imgStore.purgedAtStart, imageCacheDir, imageCacheDir)
+	} else {
+		if imgStore.purgeErr != nil {
+			// ReadDir failed (permissions, stale NFS handle, etc.). Without this
+			// log, leftover per-key directories would accumulate forever without
+			// any signal to operators — files expire in memory but never on disk.
+			logger.Warnf("image store: could not scan %q for leftover directories at startup: %v. "+
+				"Disk usage will grow unbounded until the dir is readable again.",
+				imageCacheDir, imgStore.purgeErr)
+		}
+		if imgStore.purgedAtStart > 0 {
+			// Loud on purpose: if this number is non-zero on a shared-volume deployment
+			// (not supported but configurable at the k8s layer), it means we just
+			// deleted another broker replica's live image files.
+			logger.Infof("image store: purged %d leftover directory(ies) at %q from previous run. "+
+				"If this broker shares %q with another replica, live files have been destroyed — "+
+				"image_cache must be per-process (use a local volume, not ReadWriteMany).",
+				imgStore.purgedAtStart, imageCacheDir, imageCacheDir)
+		}
+	}
+
+	// Sanity-check service.servingUrl — buildURLResponse concatenates it with
+	// ServicePrefix, so a value that already contains ServicePrefix would
+	// produce a doubled path (e.g. https://host/v1/proxy/v1/proxy/images/...).
+	// Not dangerous but an unreachable URL, and easy to miss in logs. Check
+	// once at startup rather than on every request.
+	if cfg.Service.ServingURL != "" && strings.Contains(cfg.Service.ServingURL, constant.ServicePrefix) {
+		logger.Warnf("service.servingUrl %q already contains %q; URLs emitted for response_format=url will have a doubled path prefix. "+
+			"Set servingUrl to the scheme+host only (e.g. https://example.com).",
+			cfg.Service.ServingURL, constant.ServicePrefix)
 	}
 
 	minSettlementFee := new(big.Int)

--- a/api/inference/internal/ctrl/ctrl.go
+++ b/api/inference/internal/ctrl/ctrl.go
@@ -82,6 +82,9 @@ type Ctrl struct {
 
 	// LoRA manager for fine-tuned model serving (nil if LoRA not enabled)
 	loraManager *lora.Manager
+
+	// imageStore persists generated/edited image bytes locally for URL-format responses.
+	imageStore *imageStore
 }
 
 func New(
@@ -106,6 +109,17 @@ func New(
 	}
 	if eventLogDir == "" {
 		eventLogDir = "/var/log/event"
+	}
+
+	imageCacheDir := cfg.LogPaths.BrokerLogDir
+	if imageCacheDir == "" {
+		imageCacheDir = "/var/log/inference"
+	}
+	imageCacheDir += "/image_cache"
+	imgStore, err := newImageStore(imageCacheDir, cfg.ChatCacheExpiration)
+	if err != nil {
+		logger.Warnf("Failed to initialize image store at %q, image URL serving disabled: %v", imageCacheDir, err)
+		imgStore = nil
 	}
 
 	minSettlementFee := new(big.Int)
@@ -157,6 +171,7 @@ func New(
 		},
 		// Initialize whitelist users map
 		whitelistUsers: make(map[string]struct{}),
+		imageStore:     imgStore,
 	}
 
 	// Initialize whitelist from config

--- a/api/inference/internal/ctrl/ctrl.go
+++ b/api/inference/internal/ctrl/ctrl.go
@@ -128,6 +128,14 @@ func New(
 	if err != nil {
 		logger.Warnf("Failed to initialize image store at %q, image URL serving disabled: %v", imageCacheDir, err)
 		imgStore = nil
+	} else if imgStore.purgedAtStart > 0 {
+		// Loud on purpose: if this number is non-zero on a shared-volume deployment
+		// (not supported but configurable at the k8s layer), it means we just
+		// deleted another broker replica's live image files.
+		logger.Infof("image store: purged %d leftover directory(ies) at %q from previous run. "+
+			"If this broker shares %q with another replica, live files have been destroyed — "+
+			"image_cache must be per-process (use a local volume, not ReadWriteMany).",
+			imgStore.purgedAtStart, imageCacheDir, imageCacheDir)
 	}
 
 	minSettlementFee := new(big.Int)

--- a/api/inference/internal/ctrl/image_editing.go
+++ b/api/inference/internal/ctrl/image_editing.go
@@ -78,7 +78,16 @@ func (c *Ctrl) GetImageEditingInputFeeAndImageNum(reqBody []byte) (string, int64
 	return expectedInputFee, imageNum, nil
 }
 
-// parseMultipartImageNum extracts the "n" parameter from multipart/form-data
+// parseMultipartImageNum extracts the "n" parameter from multipart/form-data.
+//
+// FIXME: this is a hand-rolled byte scanner with the same adversarial-content
+// risk that bit rewriteMultipartResponseFormat — a file part whose bytes happen
+// to contain name="n"\r\n\r\n would be parsed as the "n" field, producing a
+// wrong billing count. Because billing is derived from this value, the impact
+// is worse than the rewriter bug (which was a silent correctness miss). Should
+// be migrated to mime/multipart.Reader — the same infra proxy.go now uses for
+// response_format. The fix was deferred from the response_format PR to keep
+// scope focused; billing-path changes deserve their own review surface.
 func (c *Ctrl) parseMultipartImageNum(bodyStr string) int64 {
 	// Look for name="n" in the multipart body
 	nFieldStart := findSubstring(bodyStr, `name="n"`)

--- a/api/inference/internal/ctrl/image_editing.go
+++ b/api/inference/internal/ctrl/image_editing.go
@@ -1,6 +1,7 @@
 package ctrl
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -218,8 +219,19 @@ func (c *Ctrl) handleImageEditingResponse(ctx *gin.Context, resp *http.Response,
 		}
 	}
 
-	if !c.Service.TargetSeparated {
-		c.logger.Debug("LLM server in the same network, signing image-editing response")
+	// TEE signing — see handleTextToImageResponse for trust-model rationale.
+	switch {
+	case c.Service.IsCentralized():
+		var tlsState *tls.ConnectionState
+		if v, exists := ctx.Get("tlsState"); exists {
+			tlsState, _ = v.(*tls.ConnectionState)
+		}
+		c.logger.Debug("Centralized provider, signing image-editing routing proof")
+		if err := c.signCentralizedRoutingProof(sigReqBody, body, chatKey, tlsState); err != nil {
+			c.logger.Errorf("routing proof not created: %v", err)
+		}
+	case !c.Service.TargetSeparated:
+		c.logger.Debug("LLM server in the same network, signing image-editing content")
 		if extractErr == nil && len(images) > 0 {
 			_ = c.signImageResponse(sigReqBody, images, chatKey)
 		} else {

--- a/api/inference/internal/ctrl/image_editing.go
+++ b/api/inference/internal/ctrl/image_editing.go
@@ -1,11 +1,16 @@
 package ctrl
 
 import (
+	"bytes"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime"
+	"mime/multipart"
 	"net/http"
+	"strconv"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -42,107 +47,76 @@ type ImageEditingExtras struct {
 	Seed      *int64   `json:"seed,omitempty"`       // Random seed for reproducibility
 }
 
-// GetImageEditingInputFeeAndImageNum extracts input fee and output image count from request body
-// Supports both JSON and multipart/form-data formats
-// Parameters:
-//   - reqBody: Raw request body bytes
+// GetImageEditingInputFeeAndImageNum extracts input fee and output image count
+// from the request body. Supports JSON and multipart/form-data.
 //
-// Returns:
-//   - string: Expected input fee (as big integer string)
-//   - int64: Number of output images
-//   - error: Parse error
-func (c *Ctrl) GetImageEditingInputFeeAndImageNum(reqBody []byte) (string, int64, error) {
-	// Get output image count (default to 1)
-	imageNum := int64(1)
+// The contentType arg is used to parse the multipart boundary. Without it, a
+// byte-level scan of the body would misread a file part whose bytes happen to
+// contain `name="n"\r\n\r\n<digits>` as the form's "n" field — producing the
+// wrong billing count. Using mime/multipart.Reader respects the real boundary
+// so adversarial file content cannot influence billing.
+func (c *Ctrl) GetImageEditingInputFeeAndImageNum(reqBody []byte, contentType string) (string, int64, error) {
+	imageNum := int64(1) // default
 
-	// Try JSON format first
-	var request ImageEditingRequest
-	if err := json.Unmarshal(reqBody, &request); err == nil {
-		// Successfully parsed as JSON
-		if request.N != nil && *request.N > 0 {
-			imageNum = int64(*request.N)
+	if strings.HasPrefix(strings.ToLower(contentType), "multipart/") {
+		if n, err := parseMultipartN(reqBody, contentType); err == nil && n > 0 {
+			imageNum = n
 		}
+		// Parse failure is non-fatal: imageNum stays at the default of 1. The
+		// upstream provider will surface any real structural issue.
 	} else {
-		// Not JSON, try to parse as multipart/form-data
-		bodyStr := string(reqBody)
-
-		// Look for "n" parameter in multipart data
-		// Pattern: name="n"\r\n\r\n<value>
-		imageNum = c.parseMultipartImageNum(bodyStr)
+		// JSON path (or unknown content-type, assumed JSON).
+		var request ImageEditingRequest
+		if err := json.Unmarshal(reqBody, &request); err == nil {
+			if request.N != nil && *request.N > 0 {
+				imageNum = int64(*request.N)
+			}
+		}
 	}
 
-	// Input fee calculation
-	// Current design: fixed at 0 (similar to text-to-image)
-	expectedInputFee := "0"
-
-	return expectedInputFee, imageNum, nil
+	return "0", imageNum, nil
 }
 
-// parseMultipartImageNum extracts the "n" parameter from multipart/form-data.
-//
-// FIXME: this is a hand-rolled byte scanner with the same adversarial-content
-// risk that bit rewriteMultipartResponseFormat — a file part whose bytes happen
-// to contain name="n"\r\n\r\n would be parsed as the "n" field, producing a
-// wrong billing count. Because billing is derived from this value, the impact
-// is worse than the rewriter bug (which was a silent correctness miss). Should
-// be migrated to mime/multipart.Reader — the same infra proxy.go now uses for
-// response_format. The fix was deferred from the response_format PR to keep
-// scope focused; billing-path changes deserve their own review surface.
-func (c *Ctrl) parseMultipartImageNum(bodyStr string) int64 {
-	// Look for name="n" in the multipart body
-	nFieldStart := findSubstring(bodyStr, `name="n"`)
-	if nFieldStart == -1 {
-		// Try without quotes
-		nFieldStart = findSubstring(bodyStr, `name=n`)
+// parseMultipartN walks the multipart body with mime/multipart.Reader and
+// returns the integer value of the "n" form field, or an error if the body
+// cannot be parsed or the field is absent / non-numeric.
+func parseMultipartN(body []byte, contentType string) (int64, error) {
+	_, params, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return 0, fmt.Errorf("parse content-type %q: %w", contentType, err)
+	}
+	boundary, ok := params["boundary"]
+	if !ok || boundary == "" {
+		return 0, fmt.Errorf("content-type %q has no boundary", contentType)
 	}
 
-	if nFieldStart == -1 {
-		return 1 // Default value if not found
-	}
-
-	// Find the value after the field declaration
-	// Multipart format: name="n"\r\n\r\n<value>
-	valueStart := findSubstring(bodyStr[nFieldStart:], "\r\n\r\n")
-	if valueStart == -1 {
-		valueStart = findSubstring(bodyStr[nFieldStart:], "\n\n")
-	}
-
-	if valueStart == -1 {
-		return 1
-	}
-
-	valueStart += nFieldStart
-	if bodyStr[valueStart] == '\r' {
-		valueStart += 4 // Skip \r\n\r\n
-	} else {
-		valueStart += 2 // Skip \n\n
-	}
-
-	// Extract digits until we hit a non-digit or boundary
-	var numStr string
-	for i := valueStart; i < len(bodyStr); i++ {
-		if bodyStr[i] >= '0' && bodyStr[i] <= '9' {
-			numStr += string(bodyStr[i])
-		} else {
-			break
+	reader := multipart.NewReader(bytes.NewReader(body), boundary)
+	for {
+		part, pErr := reader.NextPart()
+		if pErr == io.EOF {
+			return 0, fmt.Errorf("n field not found")
 		}
+		if pErr != nil {
+			return 0, fmt.Errorf("read part: %w", pErr)
+		}
+		if part.FormName() != "n" {
+			_ = part.Close()
+			continue
+		}
+		// Cap the read — n is a small integer, not a file. 32 bytes is more
+		// than enough for any legitimate int and prevents a malicious upload
+		// that labels itself name="n" from streaming gigabytes into memory.
+		raw, rErr := io.ReadAll(io.LimitReader(part, 32))
+		_ = part.Close()
+		if rErr != nil {
+			return 0, fmt.Errorf("read n value: %w", rErr)
+		}
+		n, parseErr := strconv.ParseInt(strings.TrimSpace(string(raw)), 10, 64)
+		if parseErr != nil {
+			return 0, fmt.Errorf("parse n value %q: %w", raw, parseErr)
+		}
+		return n, nil
 	}
-
-	if numStr == "" {
-		return 1
-	}
-
-	// Parse the number
-	var result int64 = 0
-	for _, digit := range numStr {
-		result = result*10 + int64(digit-'0')
-	}
-
-	if result <= 0 {
-		return 1
-	}
-
-	return result
 }
 
 // findSubstring returns the index of substr in s, or -1 if not found
@@ -203,10 +177,19 @@ func (c *Ctrl) handleImageEditingResponse(ctx *gin.Context, resp *http.Response,
 		return err
 	}
 
-	// Build the body to send to the client. For wantURL, store + rewrite; any
-	// failure here downgrades to b64 (safe — body is confirmed b64 above).
+	// URL requested but store disabled — fail-closed, see handleTextToImageResponse.
+	if wantURL && c.imageStore == nil {
+		ctx.Set("ignoreError", true)
+		err := fmt.Errorf("response_format=url requested but image store is disabled (check startup logs for newImageStore error)")
+		c.logger.Errorf("image-editing URL request while imageStore is nil")
+		c.handleBrokerError(ctx, err, "image-editing response for response_format=url")
+		return err
+	}
+
+	// Build the body to send to the client. store + rewrite; any failure here
+	// downgrades to b64 (safe — body is confirmed b64 above).
 	clientBody := body
-	if wantURL && c.imageStore != nil {
+	if wantURL {
 		if storeErr := c.imageStore.store(chatKey, images); storeErr != nil {
 			c.logger.Warnf("Failed to store images for URL rewrite, sending b64: %v", storeErr)
 		} else {

--- a/api/inference/internal/ctrl/image_editing.go
+++ b/api/inference/internal/ctrl/image_editing.go
@@ -2,6 +2,7 @@ package ctrl
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 
@@ -181,8 +182,20 @@ func (c *Ctrl) handleImageEditingResponse(ctx *gin.Context, resp *http.Response,
 	originalFormat, _ := ctx.Get("clientResponseFormat")
 	wantURL := originalFormat == "url"
 
+	// If the client asked for url but the provider returned something we can't
+	// decode (non-b64 envelope, empty array), refuse the response rather than
+	// passing provider bytes through — they may contain LAN-private URLs.
+	if wantURL && (extractErr != nil || len(images) == 0) {
+		ctx.Set("ignoreError", true)
+		err := fmt.Errorf("provider returned non-b64 image response, refusing to forward (may contain LAN-private URLs): %w", extractErr)
+		c.handleBrokerError(ctx, err, "image-editing response for response_format=url")
+		return err
+	}
+
+	// Build the body to send to the client. For wantURL, store + rewrite; any
+	// failure here downgrades to b64 (safe — body is confirmed b64 above).
 	clientBody := body
-	if wantURL && extractErr == nil && len(images) > 0 && c.imageStore != nil {
+	if wantURL && c.imageStore != nil {
 		if storeErr := c.imageStore.store(chatKey, images); storeErr != nil {
 			c.logger.Warnf("Failed to store images for URL rewrite, sending b64: %v", storeErr)
 		} else {

--- a/api/inference/internal/ctrl/image_editing.go
+++ b/api/inference/internal/ctrl/image_editing.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
-	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -150,51 +149,69 @@ func findSubstring(s, substr string) int {
 	return -1
 }
 
-// handleImageEditingResponse handles the image editing response
-// This function:
-// 1. Reads and returns the edited image data
-// 2. Signs the response (if TEE is in the same network)
-// 3. Calculates fees based on output image count
-// 4. Updates the database with fee records
+// handleImageEditingResponse handles the image editing response.
+// Mirrors handleTextToImageResponse: extracts b64 image bytes, signs per-image
+// hashes, and optionally rewrites the response with broker-served URLs.
 func (c *Ctrl) handleImageEditingResponse(ctx *gin.Context, resp *http.Response, account model.User, outputPrice string, reqBody []byte, reqModel model.Request) error {
 	defer resp.Body.Close()
 
-	// Generate unique response key for signature verification
 	chatKey := uuid.NewString()
 	ctx.Writer.Header().Set("ZG-Res-Key", chatKey)
 
-	// Read image response data
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		c.handleBrokerError(ctx, err, "read image editing response body")
 		return err
 	}
 
-	// Log response size for monitoring and debugging
 	responseSizeMB := float64(len(body)) / (1024 * 1024)
 	c.logger.Infof("Image editing response: size=%.2f MB, user=%s, imageCount=%d",
 		responseSizeMB, reqModel.UserAddress, reqModel.OutputCount)
 
-	// Return image data to client
-	if _, err := ctx.Writer.Write(body); err != nil {
-		// Check if error is due to client disconnection (broken pipe, connection reset)
-		// These are expected errors when client times out or cancels request
-		errMsg := err.Error()
-		if isClientDisconnectError(errMsg) {
-			c.logger.Warnf("Client disconnected before receiving full response: %v", err)
-			// Don't return error - continue with billing since response was generated
-		} else {
-			// Other write errors are unexpected
-			c.handleBrokerError(ctx, err, "write image editing response")
-			return err
+	// Resolve the original client request body (pre-b64 rewrite) for signing.
+	sigReqBody := reqBody
+	if v, ok := ctx.Get("clientReqBody"); ok {
+		if orig, ok := v.([]byte); ok {
+			sigReqBody = orig
 		}
 	}
 
-	// Sign response if LLM server is in the same network
-	// This allows clients to verify the response is from an authorized provider
+	images, extractErr := extractB64Images(body)
+
+	originalFormat, _ := ctx.Get("clientResponseFormat")
+	wantURL := originalFormat == "url"
+
+	clientBody := body
+	if wantURL && extractErr == nil && len(images) > 0 && c.imageStore != nil {
+		if storeErr := c.imageStore.store(chatKey, images); storeErr != nil {
+			c.logger.Warnf("Failed to store images for URL rewrite, sending b64: %v", storeErr)
+		} else {
+			rewritten, buildErr := buildURLResponse(body, chatKey, len(images), ctx.Request)
+			if buildErr != nil {
+				c.logger.Warnf("Failed to build URL response, sending b64: %v", buildErr)
+			} else {
+				clientBody = rewritten
+			}
+		}
+	}
+
+	if _, writeErr := ctx.Writer.Write(clientBody); writeErr != nil {
+		if c.isClientDisconnectError(writeErr) {
+			c.logger.Warnf("Client disconnected before receiving full response: %v", writeErr)
+		} else {
+			c.handleBrokerError(ctx, writeErr, "write image editing response")
+			return writeErr
+		}
+	}
+
 	if !c.Service.TargetSeparated {
 		c.logger.Debug("LLM server in the same network, signing image-editing response")
-		_ = c.signChatWithKey(reqBody, body, chatKey)
+		if extractErr == nil && len(images) > 0 {
+			_ = c.signImageResponse(sigReqBody, images, chatKey)
+		} else {
+			c.logger.Warnf("No b64 images extracted, falling back to full-body signature: %v", extractErr)
+			_ = c.signChatWithKey(sigReqBody, body, chatKey)
+		}
 	}
 
 	// Skip billing for whitelisted users, but record whitelist traffic metrics
@@ -226,29 +243,6 @@ func (c *Ctrl) handleImageEditingResponse(ctx *gin.Context, resp *http.Response,
 
 	monitor.RecordTokens("image-editing", 0, imageNum)
 	return nil
-}
-
-// isClientDisconnectError checks if an error is due to client disconnection
-// Returns true for errors like "broken pipe", "connection reset by peer", etc.
-func isClientDisconnectError(errMsg string) bool {
-	// Common client disconnect error patterns
-	disconnectPatterns := []string{
-		"broken pipe",
-		"connection reset by peer",
-		"write: connection reset",
-		"write: broken pipe",
-		"EOF",
-		"client disconnected",
-	}
-
-	// Convert to lowercase for case-insensitive matching
-	errMsgLower := strings.ToLower(errMsg)
-	for _, pattern := range disconnectPatterns {
-		if strings.Contains(errMsgLower, pattern) {
-			return true
-		}
-	}
-	return false
 }
 
 /*

--- a/api/inference/internal/ctrl/image_editing.go
+++ b/api/inference/internal/ctrl/image_editing.go
@@ -204,7 +204,12 @@ func (c *Ctrl) handleImageEditingResponse(ctx *gin.Context, resp *http.Response,
 
 	if _, writeErr := ctx.Writer.Write(clientBody); writeErr != nil {
 		if c.isClientDisconnectError(writeErr) {
-			c.logger.Warnf("Client disconnected before receiving full response: %v", writeErr)
+			// Matches handleTextToImageResponse: downstream middleware keys off
+			// ignoreError to suppress noisy error logs / metrics for expected
+			// client-disconnect cases. Without this, image-editing disconnects
+			// would surface as errors while text-to-image disconnects wouldn't.
+			ctx.Set("ignoreError", true)
+			c.logger.Warnf("Client disconnected during image-editing response, billing for completed response (%d bytes)", len(body))
 		} else {
 			c.handleBrokerError(ctx, writeErr, "write image editing response")
 			return writeErr

--- a/api/inference/internal/ctrl/image_editing.go
+++ b/api/inference/internal/ctrl/image_editing.go
@@ -186,7 +186,7 @@ func (c *Ctrl) handleImageEditingResponse(ctx *gin.Context, resp *http.Response,
 		if storeErr := c.imageStore.store(chatKey, images); storeErr != nil {
 			c.logger.Warnf("Failed to store images for URL rewrite, sending b64: %v", storeErr)
 		} else {
-			rewritten, buildErr := buildURLResponse(body, chatKey, len(images), ctx.Request)
+			rewritten, buildErr := buildURLResponse(body, chatKey, len(images), c.Service.ServingURL)
 			if buildErr != nil {
 				c.logger.Warnf("Failed to build URL response, sending b64: %v", buildErr)
 			} else {

--- a/api/inference/internal/ctrl/image_editing.go
+++ b/api/inference/internal/ctrl/image_editing.go
@@ -162,7 +162,7 @@ func (c *Ctrl) handleImageEditingResponse(ctx *gin.Context, resp *http.Response,
 		}
 	}
 
-	images, extractErr := extractB64Images(body)
+	images, extractErr := extractB64Images(body, int(reqModel.OutputCount))
 
 	originalFormat, _ := ctx.Get("clientResponseFormat")
 	wantURL := originalFormat == "url"

--- a/api/inference/internal/ctrl/image_editing_test.go
+++ b/api/inference/internal/ctrl/image_editing_test.go
@@ -1,0 +1,139 @@
+package ctrl
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestGetImageEditingInputFeeAndImageNum_JSON_ValidN covers the happy path: a
+// JSON body with an "n" field and a valid integer.
+func TestGetImageEditingInputFeeAndImageNum_JSON_ValidN(t *testing.T) {
+	c := &Ctrl{}
+	fee, n, err := c.GetImageEditingInputFeeAndImageNum(
+		[]byte(`{"prompt":"x","n":3}`), "application/json",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fee != "0" {
+		t.Errorf("fee = %q, want 0", fee)
+	}
+	if n != 3 {
+		t.Errorf("n = %d, want 3", n)
+	}
+}
+
+// TestGetImageEditingInputFeeAndImageNum_JSON_MissingN defaults to 1.
+func TestGetImageEditingInputFeeAndImageNum_JSON_MissingN(t *testing.T) {
+	c := &Ctrl{}
+	_, n, err := c.GetImageEditingInputFeeAndImageNum(
+		[]byte(`{"prompt":"x"}`), "application/json",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("n = %d, want default 1", n)
+	}
+}
+
+// TestGetImageEditingInputFeeAndImageNum_Multipart_ValidN covers a well-formed
+// multipart with n=5.
+func TestGetImageEditingInputFeeAndImageNum_Multipart_ValidN(t *testing.T) {
+	body := []byte(
+		"--b\r\nContent-Disposition: form-data; name=\"prompt\"\r\n\r\nhi\r\n" +
+			"--b\r\nContent-Disposition: form-data; name=\"n\"\r\n\r\n5\r\n" +
+			"--b--\r\n",
+	)
+	c := &Ctrl{}
+	_, n, err := c.GetImageEditingInputFeeAndImageNum(body, `multipart/form-data; boundary=b`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 5 {
+		t.Errorf("n = %d, want 5", n)
+	}
+}
+
+// TestGetImageEditingInputFeeAndImageNum_Multipart_AdversarialFileContent is
+// the critical regression test: a file part whose BYTES contain the literal
+// `name="n"\r\n\r\n999` must NOT be misread as the billing field. The old
+// byte-scanner parser would have returned 999 here, overbilling the user
+// (or underbilling the provider, depending on direction). mime/multipart.Reader
+// respects MIME boundaries so the adversarial substring lives inside the file
+// part and is ignored.
+func TestGetImageEditingInputFeeAndImageNum_Multipart_AdversarialFileContent(t *testing.T) {
+	// File body deliberately embeds name="n"\r\n\r\n999 — the old scanner's
+	// pattern. "--XYZ" at the end is NOT the real boundary ("b") so a proper
+	// parser keeps all of this inside the file part.
+	adversarial := []byte(
+		"PNG-HEADER" +
+			"name=\"n\"\r\n\r\n999\r\n--XYZ " +
+			"more-bytes",
+	)
+	var body []byte
+	// File part comes FIRST so the old substring-scan finds the adversarial
+	// "n" before the legitimate one.
+	body = append(body, []byte("--b\r\nContent-Disposition: form-data; name=\"image\"; filename=\"x.bin\"\r\nContent-Type: application/octet-stream\r\n\r\n")...)
+	body = append(body, adversarial...)
+	body = append(body, []byte("\r\n--b\r\nContent-Disposition: form-data; name=\"prompt\"\r\n\r\nhi\r\n")...)
+	body = append(body, []byte("--b\r\nContent-Disposition: form-data; name=\"n\"\r\n\r\n2\r\n")...)
+	body = append(body, []byte("--b--\r\n")...)
+
+	c := &Ctrl{}
+	_, n, err := c.GetImageEditingInputFeeAndImageNum(body, `multipart/form-data; boundary=b`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n == 999 {
+		t.Fatal("adversarial file bytes spoofed the n field — old byte-scanner bug regressed")
+	}
+	if n != 2 {
+		t.Errorf("n = %d, want 2 (from the legitimate form field)", n)
+	}
+}
+
+// TestGetImageEditingInputFeeAndImageNum_Multipart_MissingN defaults to 1.
+func TestGetImageEditingInputFeeAndImageNum_Multipart_MissingN(t *testing.T) {
+	body := []byte(
+		"--b\r\nContent-Disposition: form-data; name=\"prompt\"\r\n\r\nhi\r\n" +
+			"--b--\r\n",
+	)
+	c := &Ctrl{}
+	_, n, err := c.GetImageEditingInputFeeAndImageNum(body, `multipart/form-data; boundary=b`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("n = %d, want default 1", n)
+	}
+}
+
+// TestParseMultipartN_RejectsNonNumericAndOversized covers malicious inputs: a
+// non-numeric value errors, and a 32-byte limit prevents a "name=n" file part
+// from streaming arbitrary data into memory.
+func TestParseMultipartN_RejectsNonNumericAndOversized(t *testing.T) {
+	t.Run("non-numeric", func(t *testing.T) {
+		body := []byte(
+			"--b\r\nContent-Disposition: form-data; name=\"n\"\r\n\r\nnot-a-number\r\n" +
+				"--b--\r\n",
+		)
+		if _, err := parseMultipartN(body, `multipart/form-data; boundary=b`); err == nil {
+			t.Error("expected error for non-numeric n value")
+		}
+	})
+	t.Run("oversized-does-not-oom", func(t *testing.T) {
+		// An attacker could label a 1MB payload as name="n" and try to exhaust
+		// broker memory during billing extraction. LimitReader caps the read at
+		// 32 bytes — the important property is bounded memory, not parse success.
+		// ParseInt may then reject (overflow) or accept; both outcomes are safe.
+		big := bytes.Repeat([]byte("9"), 1<<20)
+		var body []byte
+		body = append(body, []byte("--b\r\nContent-Disposition: form-data; name=\"n\"\r\n\r\n")...)
+		body = append(body, big...)
+		body = append(body, []byte("\r\n--b--\r\n")...)
+		// Just invoking without OOM / panic is the assertion. The error or
+		// success value is incidental.
+		_, _ = parseMultipartN(body, `multipart/form-data; boundary=b`)
+	})
+}

--- a/api/inference/internal/ctrl/image_store.go
+++ b/api/inference/internal/ctrl/image_store.go
@@ -35,8 +35,9 @@ func validateChatKey(k string) error {
 // the directory name, so only the requester who received ZG-Res-Key can derive
 // the serving URL.
 type imageStore struct {
-	dir   string
-	cache *cache.Cache
+	dir           string
+	cache         *cache.Cache
+	purgedAtStart int // count of leftover directories removed during newImageStore; surfaced in logs at ctrl init
 }
 
 func newImageStore(dir string, ttl time.Duration) (*imageStore, error) {
@@ -44,24 +45,31 @@ func newImageStore(dir string, ttl time.Duration) (*imageStore, error) {
 		return nil, fmt.Errorf("create image store dir %q: %w", dir, err)
 	}
 
-	// Purge leftover per-key directories from any previous process run.
-	// The in-memory TTL table is empty at startup, so those chatKeys are
-	// already unreachable via get() — without this sweep the files would
-	// accumulate forever across restarts (no OnEvicted ever fires for them).
-	// Only remove directories under the store root; leave unexpected loose
-	// files alone so an operator doesn't silently lose, e.g., a README.
-	// Assumes a single broker process per image_cache directory; sharing
-	// the directory between processes would cause one's startup to delete
-	// the other's live files.
+	// Purge leftover per-key directories from any previous process run. The
+	// in-memory TTL table is empty at startup so their chatKeys are unreachable
+	// via get(); without this sweep the files would accumulate across restarts
+	// (OnEvicted never fires for them). Non-directory siblings are preserved
+	// (README, config, etc.).
+	//
+	// DEPLOYMENT INVARIANT: the image_cache directory must be owned by exactly
+	// one broker process. Sharing across replicas (e.g. a ReadWriteMany PV in
+	// Kubernetes) is unsupported — the startup purge from replica A will
+	// silently delete replica B's live files. This is not enforced by code
+	// (no pidfile/lock) because the TTL machinery would fight a cross-process
+	// lock; enforce in the deployment manifest instead (use an emptyDir/local
+	// volume per replica).
+	removed := 0
 	if entries, err := os.ReadDir(dir); err == nil {
 		for _, e := range entries {
 			if e.IsDir() {
-				_ = os.RemoveAll(filepath.Join(dir, e.Name()))
+				if rmErr := os.RemoveAll(filepath.Join(dir, e.Name())); rmErr == nil {
+					removed++
+				}
 			}
 		}
 	}
 
-	s := &imageStore{dir: dir}
+	s := &imageStore{dir: dir, purgedAtStart: removed}
 	s.cache = cache.New(ttl, ttl/2)
 	s.cache.OnEvicted(func(key string, _ interface{}) {
 		_ = os.RemoveAll(filepath.Join(dir, key))

--- a/api/inference/internal/ctrl/image_store.go
+++ b/api/inference/internal/ctrl/image_store.go
@@ -1,0 +1,71 @@
+package ctrl
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/patrickmn/go-cache"
+)
+
+// imageStore writes generated image bytes to local disk with a TTL, then cleans
+// up automatically via an on-eviction callback.  The chatKey (UUID) doubles as
+// the directory name, so only the requester who received ZG-Res-Key can derive
+// the serving URL.
+type imageStore struct {
+	dir   string
+	cache *cache.Cache
+}
+
+func newImageStore(dir string, ttl time.Duration) (*imageStore, error) {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("create image store dir %q: %w", dir, err)
+	}
+	s := &imageStore{dir: dir}
+	s.cache = cache.New(ttl, ttl/2)
+	s.cache.OnEvicted(func(key string, _ interface{}) {
+		_ = os.RemoveAll(filepath.Join(dir, key))
+	})
+	return s, nil
+}
+
+// store writes each image to {dir}/{chatKey}/{index}.bin and registers the entry.
+func (s *imageStore) store(chatKey string, images [][]byte) error {
+	keyDir := filepath.Join(s.dir, chatKey)
+	if err := os.MkdirAll(keyDir, 0o755); err != nil {
+		return fmt.Errorf("create image dir: %w", err)
+	}
+	for i, img := range images {
+		path := filepath.Join(keyDir, strconv.Itoa(i)+".bin")
+		if err := os.WriteFile(path, img, 0o644); err != nil {
+			return fmt.Errorf("write image %d: %w", i, err)
+		}
+	}
+	s.cache.SetDefault(chatKey, len(images))
+	return nil
+}
+
+// get returns image bytes for the given chatKey and zero-based index.
+// Returns an error if the entry has expired or the file is missing.
+func (s *imageStore) get(chatKey string, index int) ([]byte, error) {
+	if _, ok := s.cache.Get(chatKey); !ok {
+		return nil, fmt.Errorf("image not found or expired")
+	}
+	path := filepath.Join(s.dir, chatKey, strconv.Itoa(index)+".bin")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read image: %w", err)
+	}
+	return data, nil
+}
+
+// detectContentType sniffs the MIME type from the first bytes of an image.
+func detectContentType(data []byte) string {
+	if len(data) == 0 {
+		return "application/octet-stream"
+	}
+	return http.DetectContentType(data)
+}

--- a/api/inference/internal/ctrl/image_store.go
+++ b/api/inference/internal/ctrl/image_store.go
@@ -37,8 +37,9 @@ func validateChatKey(k string) error {
 type imageStore struct {
 	dir           string
 	cache         *cache.Cache
-	purgedAtStart int   // count of leftover directories removed during newImageStore; surfaced in logs at ctrl init
-	purgeErr      error // non-nil if ReadDir failed at startup; operators must see this to diagnose silent accumulation
+	ttl           time.Duration // retained so callers (handleImageServeRoute) can advertise an accurate Cache-Control max-age
+	purgedAtStart int           // count of leftover directories removed during newImageStore; surfaced in logs at ctrl init
+	purgeErr      error         // non-nil if ReadDir failed at startup; operators must see this to diagnose silent accumulation
 }
 
 func newImageStore(dir string, ttl time.Duration) (*imageStore, error) {
@@ -71,7 +72,7 @@ func newImageStore(dir string, ttl time.Duration) (*imageStore, error) {
 		}
 	}
 
-	s := &imageStore{dir: dir, purgedAtStart: removed, purgeErr: readErr}
+	s := &imageStore{dir: dir, ttl: ttl, purgedAtStart: removed, purgeErr: readErr}
 	s.cache = cache.New(ttl, ttl/2)
 	s.cache.OnEvicted(func(key string, _ interface{}) {
 		_ = os.RemoveAll(filepath.Join(dir, key))

--- a/api/inference/internal/ctrl/image_store.go
+++ b/api/inference/internal/ctrl/image_store.go
@@ -5,23 +5,27 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/patrickmn/go-cache"
 )
 
-// validateChatKey rejects keys that could escape the store directory or confuse
-// the filesystem. Current callers only pass uuid.New().String(), so the check is
-// defence in depth: enforcement lives at the filesystem boundary rather than
-// relying on every future caller to sanitise first.
+// validChatKey matches the charset all current callers produce (UUIDs via
+// uuid.New().String()) and nothing else. An allowlist is safer than a blocklist
+// at the filesystem boundary: reject single ".", leading/trailing dots, colons,
+// control chars, and every other byte sequence that could cause trouble on
+// Windows, NFS, or future code paths. Length cap guards against absurdly long
+// paths.
+var validChatKey = regexp.MustCompile(`^[A-Za-z0-9_-]{1,64}$`)
+
+// validateChatKey enforces the allowlist. Callers outside this package must
+// continue to produce UUIDs (or compatible IDs) — anything else is a bug we'd
+// rather surface here than silently mis-store.
 func validateChatKey(k string) error {
-	if k == "" {
-		return fmt.Errorf("chatKey is empty")
-	}
-	if strings.ContainsAny(k, "/\\\x00") || strings.Contains(k, "..") {
-		return fmt.Errorf("chatKey contains forbidden characters")
+	if !validChatKey.MatchString(k) {
+		return fmt.Errorf("chatKey %q is not a valid identifier (expected ^[A-Za-z0-9_-]{1,64}$)", k)
 	}
 	return nil
 }
@@ -39,6 +43,24 @@ func newImageStore(dir string, ttl time.Duration) (*imageStore, error) {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return nil, fmt.Errorf("create image store dir %q: %w", dir, err)
 	}
+
+	// Purge leftover per-key directories from any previous process run.
+	// The in-memory TTL table is empty at startup, so those chatKeys are
+	// already unreachable via get() — without this sweep the files would
+	// accumulate forever across restarts (no OnEvicted ever fires for them).
+	// Only remove directories under the store root; leave unexpected loose
+	// files alone so an operator doesn't silently lose, e.g., a README.
+	// Assumes a single broker process per image_cache directory; sharing
+	// the directory between processes would cause one's startup to delete
+	// the other's live files.
+	if entries, err := os.ReadDir(dir); err == nil {
+		for _, e := range entries {
+			if e.IsDir() {
+				_ = os.RemoveAll(filepath.Join(dir, e.Name()))
+			}
+		}
+	}
+
 	s := &imageStore{dir: dir}
 	s.cache = cache.New(ttl, ttl/2)
 	s.cache.OnEvicted(func(key string, _ interface{}) {
@@ -48,6 +70,9 @@ func newImageStore(dir string, ttl time.Duration) (*imageStore, error) {
 }
 
 // store writes each image to {dir}/{chatKey}/{index}.bin and registers the entry.
+// On any write failure the whole keyDir is removed so a partial-write doesn't
+// leave orphan files: SetDefault is never called on error, so OnEvicted would
+// never clean them up on its own.
 func (s *imageStore) store(chatKey string, images [][]byte) error {
 	if err := validateChatKey(chatKey); err != nil {
 		return err
@@ -59,6 +84,7 @@ func (s *imageStore) store(chatKey string, images [][]byte) error {
 	for i, img := range images {
 		path := filepath.Join(keyDir, strconv.Itoa(i)+".bin")
 		if err := os.WriteFile(path, img, 0o644); err != nil {
+			_ = os.RemoveAll(keyDir)
 			return fmt.Errorf("write image %d: %w", i, err)
 		}
 	}

--- a/api/inference/internal/ctrl/image_store.go
+++ b/api/inference/internal/ctrl/image_store.go
@@ -37,7 +37,8 @@ func validateChatKey(k string) error {
 type imageStore struct {
 	dir           string
 	cache         *cache.Cache
-	purgedAtStart int // count of leftover directories removed during newImageStore; surfaced in logs at ctrl init
+	purgedAtStart int   // count of leftover directories removed during newImageStore; surfaced in logs at ctrl init
+	purgeErr      error // non-nil if ReadDir failed at startup; operators must see this to diagnose silent accumulation
 }
 
 func newImageStore(dir string, ttl time.Duration) (*imageStore, error) {
@@ -59,7 +60,8 @@ func newImageStore(dir string, ttl time.Duration) (*imageStore, error) {
 	// lock; enforce in the deployment manifest instead (use an emptyDir/local
 	// volume per replica).
 	removed := 0
-	if entries, err := os.ReadDir(dir); err == nil {
+	entries, readErr := os.ReadDir(dir)
+	if readErr == nil {
 		for _, e := range entries {
 			if e.IsDir() {
 				if rmErr := os.RemoveAll(filepath.Join(dir, e.Name())); rmErr == nil {
@@ -69,7 +71,7 @@ func newImageStore(dir string, ttl time.Duration) (*imageStore, error) {
 		}
 	}
 
-	s := &imageStore{dir: dir, purgedAtStart: removed}
+	s := &imageStore{dir: dir, purgedAtStart: removed, purgeErr: readErr}
 	s.cache = cache.New(ttl, ttl/2)
 	s.cache.OnEvicted(func(key string, _ interface{}) {
 		_ = os.RemoveAll(filepath.Join(dir, key))

--- a/api/inference/internal/ctrl/image_store.go
+++ b/api/inference/internal/ctrl/image_store.go
@@ -6,10 +6,25 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/patrickmn/go-cache"
 )
+
+// validateChatKey rejects keys that could escape the store directory or confuse
+// the filesystem. Current callers only pass uuid.New().String(), so the check is
+// defence in depth: enforcement lives at the filesystem boundary rather than
+// relying on every future caller to sanitise first.
+func validateChatKey(k string) error {
+	if k == "" {
+		return fmt.Errorf("chatKey is empty")
+	}
+	if strings.ContainsAny(k, "/\\\x00") || strings.Contains(k, "..") {
+		return fmt.Errorf("chatKey contains forbidden characters")
+	}
+	return nil
+}
 
 // imageStore writes generated image bytes to local disk with a TTL, then cleans
 // up automatically via an on-eviction callback.  The chatKey (UUID) doubles as
@@ -34,6 +49,9 @@ func newImageStore(dir string, ttl time.Duration) (*imageStore, error) {
 
 // store writes each image to {dir}/{chatKey}/{index}.bin and registers the entry.
 func (s *imageStore) store(chatKey string, images [][]byte) error {
+	if err := validateChatKey(chatKey); err != nil {
+		return err
+	}
 	keyDir := filepath.Join(s.dir, chatKey)
 	if err := os.MkdirAll(keyDir, 0o755); err != nil {
 		return fmt.Errorf("create image dir: %w", err)
@@ -50,7 +68,14 @@ func (s *imageStore) store(chatKey string, images [][]byte) error {
 
 // get returns image bytes for the given chatKey and zero-based index.
 // Returns an error if the entry has expired or the file is missing.
+// Note: OnEvicted runs concurrently with Get; an entry can expire between the
+// cache.Get check and the os.ReadFile below, surfacing as ENOENT. Callers
+// (handleImageServeRoute) translate any error here to 404, which is the
+// correct outcome either way.
 func (s *imageStore) get(chatKey string, index int) ([]byte, error) {
+	if err := validateChatKey(chatKey); err != nil {
+		return nil, err
+	}
 	if _, ok := s.cache.Get(chatKey); !ok {
 		return nil, fmt.Errorf("image not found or expired")
 	}
@@ -60,6 +85,21 @@ func (s *imageStore) get(chatKey string, index int) ([]byte, error) {
 		return nil, fmt.Errorf("read image: %w", err)
 	}
 	return data, nil
+}
+
+// Close deletes every cached entry (each Delete fires OnEvicted and removes
+// the backing directory) and drops references to the in-memory TTL table.
+// The go-cache janitor goroutine is owned by patrickmn/go-cache and stops via
+// a runtime finalizer when the *Cache becomes unreachable — we can't signal it
+// explicitly, so callers who recreate imageStore frequently (e.g. in tests)
+// should let the old *Cache go out of scope and rely on GC to reclaim it.
+func (s *imageStore) Close() {
+	if s == nil || s.cache == nil {
+		return
+	}
+	for key := range s.cache.Items() {
+		s.cache.Delete(key) // triggers OnEvicted → RemoveAll on disk
+	}
 }
 
 // detectContentType sniffs the MIME type from the first bytes of an image.

--- a/api/inference/internal/ctrl/image_store_test.go
+++ b/api/inference/internal/ctrl/image_store_test.go
@@ -105,6 +105,57 @@ func TestImageStore_DiskFilesRemovedAfterEviction(t *testing.T) {
 	}
 }
 
+// TestImageStore_RejectsTraversalKeys pins the defence-in-depth key validator.
+// Callers today only pass UUIDs, but enforcement must live at the filesystem
+// boundary so a future caller can't walk out of the store directory.
+func TestImageStore_RejectsTraversalKeys(t *testing.T) {
+	store, err := newImageStore(t.TempDir(), time.Minute)
+	if err != nil {
+		t.Fatalf("newImageStore: %v", err)
+	}
+
+	for _, k := range []string{"", "../escape", "foo/bar", `foo\bar`, "nul\x00byte", "a/../b", ".."} {
+		t.Run("store:"+k, func(t *testing.T) {
+			if err := store.store(k, [][]byte{[]byte("x")}); err == nil {
+				t.Errorf("store(%q) should reject forbidden key, got nil", k)
+			}
+		})
+		t.Run("get:"+k, func(t *testing.T) {
+			if _, err := store.get(k, 0); err == nil {
+				t.Errorf("get(%q) should reject forbidden key, got nil", k)
+			}
+		})
+	}
+}
+
+// TestImageStore_CloseRemovesDiskFiles verifies Close fires OnEvicted for every
+// live entry, removing the per-key directory on disk rather than just dropping
+// the in-memory TTL table.
+func TestImageStore_CloseRemovesDiskFiles(t *testing.T) {
+	dir := t.TempDir()
+	store, err := newImageStore(dir, time.Minute)
+	if err != nil {
+		t.Fatalf("newImageStore: %v", err)
+	}
+	if err := store.store("k1", [][]byte{[]byte("a")}); err != nil {
+		t.Fatalf("store k1: %v", err)
+	}
+	if err := store.store("k2", [][]byte{[]byte("b"), []byte("c")}); err != nil {
+		t.Fatalf("store k2: %v", err)
+	}
+
+	store.Close()
+
+	for _, k := range []string{"k1", "k2"} {
+		if _, err := os.Stat(dir + "/" + k); !os.IsNotExist(err) {
+			t.Errorf("Close did not remove %s (stat err: %v)", k, err)
+		}
+		if _, err := store.get(k, 0); err == nil {
+			t.Errorf("get(%s) after Close should fail, got nil error", k)
+		}
+	}
+}
+
 func TestDetectContentType_PNG(t *testing.T) {
 	// Minimal valid PNG header (8 bytes signature).
 	pngSig := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0, 0, 0, 1}

--- a/api/inference/internal/ctrl/image_store_test.go
+++ b/api/inference/internal/ctrl/image_store_test.go
@@ -3,6 +3,7 @@ package ctrl
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -112,6 +113,46 @@ func TestImageStore_DiskFilesRemovedAfterEviction(t *testing.T) {
 	}
 }
 
+// TestImageStore_PurgesOrphansOnInit verifies the disk-growth fix: after a
+// broker restart the in-memory TTL table is empty, so leftover per-key
+// directories on disk are unreachable via get() and will never fire OnEvicted.
+// Without an init-time purge, image_cache/ would grow without bound across
+// restarts. The purge is opinionated — any sibling file that's not a directory
+// is preserved (so an operator's README or config alongside the store root
+// survives).
+func TestImageStore_PurgesOrphansOnInit(t *testing.T) {
+	dir := t.TempDir()
+	// Simulate leftover state from a previous process run.
+	for _, key := range []string{"orphan-1", "orphan-2"} {
+		keyDir := filepath.Join(dir, key)
+		if err := os.MkdirAll(keyDir, 0o755); err != nil {
+			t.Fatalf("setup orphan dir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(keyDir, "0.bin"), []byte("stale"), 0o644); err != nil {
+			t.Fatalf("setup orphan file: %v", err)
+		}
+	}
+	// Non-directory sibling that must NOT be deleted.
+	sibling := filepath.Join(dir, "README.md")
+	if err := os.WriteFile(sibling, []byte("keep"), 0o644); err != nil {
+		t.Fatalf("setup sibling file: %v", err)
+	}
+
+	// Opening the store purges the orphan directories.
+	if _, err := newImageStore(dir, time.Minute); err != nil {
+		t.Fatalf("newImageStore: %v", err)
+	}
+
+	for _, key := range []string{"orphan-1", "orphan-2"} {
+		if _, err := os.Stat(filepath.Join(dir, key)); !os.IsNotExist(err) {
+			t.Errorf("orphan %s should have been removed; stat err: %v", key, err)
+		}
+	}
+	if _, err := os.Stat(sibling); err != nil {
+		t.Errorf("non-directory sibling %s should be preserved, got: %v", sibling, err)
+	}
+}
+
 // TestImageStore_UUIDIsTheCapability documents the authz model: the chatKey is
 // the ONLY secret needed to retrieve an image (handleImageServeRoute does not
 // check session auth — see proxy.go). This mirrors how OpenAI's image URLs
@@ -145,26 +186,92 @@ func TestImageStore_UUIDIsTheCapability(t *testing.T) {
 	}
 }
 
-// TestImageStore_RejectsTraversalKeys pins the defence-in-depth key validator.
-// Callers today only pass UUIDs, but enforcement must live at the filesystem
-// boundary so a future caller can't walk out of the store directory.
-func TestImageStore_RejectsTraversalKeys(t *testing.T) {
+// TestImageStore_KeyAllowlist pins the allowlist (^[A-Za-z0-9_-]{1,64}$).
+// UUIDs from all current callers match; anything else is rejected — leading
+// dots, single ".", colons, control chars, and non-ASCII all surface here
+// instead of becoming silent filesystem quirks on some future platform.
+func TestImageStore_KeyAllowlist(t *testing.T) {
 	store, err := newImageStore(t.TempDir(), time.Minute)
 	if err != nil {
 		t.Fatalf("newImageStore: %v", err)
 	}
 
-	for _, k := range []string{"", "../escape", "foo/bar", `foo\bar`, "nul\x00byte", "a/../b", ".."} {
-		t.Run("store:"+k, func(t *testing.T) {
+	reject := []string{
+		"",                       // empty
+		"..",                     // traversal
+		"../escape",              // traversal
+		"a/../b",                 // traversal
+		"foo/bar",                // slash
+		`foo\bar`,                // backslash (Windows path sep)
+		"nul\x00byte",            // NUL
+		".",                      // current-dir alias
+		".hidden",                // leading dot (Unix hidden file)
+		"trailing.",              // trailing dot (Windows eats this)
+		"has:colon",              // reserved on Windows + NTFS ADS
+		"with space",             // space
+		"tab\there",              // control char
+		"新",                     // non-ASCII
+		strings.Repeat("a", 65),  // over length cap
+	}
+	for _, k := range reject {
+		k := k
+		t.Run("reject:store/"+k, func(t *testing.T) {
 			if err := store.store(k, [][]byte{[]byte("x")}); err == nil {
-				t.Errorf("store(%q) should reject forbidden key, got nil", k)
+				t.Errorf("store(%q) should reject, got nil", k)
 			}
 		})
-		t.Run("get:"+k, func(t *testing.T) {
+		t.Run("reject:get/"+k, func(t *testing.T) {
 			if _, err := store.get(k, 0); err == nil {
-				t.Errorf("get(%q) should reject forbidden key, got nil", k)
+				t.Errorf("get(%q) should reject, got nil", k)
 			}
 		})
+	}
+
+	accept := []string{
+		"a",                             // single char at lower bound
+		"abcDEF-123_xyz",                // mixed charset
+		"f47ac10b-58cc-4372-a567-0e02b2c3d479", // canonical UUID
+		strings.Repeat("a", 64),         // exactly at length cap
+	}
+	for _, k := range accept {
+		k := k
+		t.Run("accept:"+k, func(t *testing.T) {
+			if err := store.store(k, [][]byte{[]byte("ok")}); err != nil {
+				t.Errorf("store(%q) should succeed, got %v", k, err)
+			}
+		})
+	}
+}
+
+// TestImageStore_PartialWriteCleanup pins the leak fix in store(): if any
+// os.WriteFile fails mid-batch, SetDefault is never called so OnEvicted would
+// never reclaim the half-written keyDir. store() must remove it explicitly.
+func TestImageStore_PartialWriteCleanup(t *testing.T) {
+	dir := t.TempDir()
+	store, err := newImageStore(dir, time.Minute)
+	if err != nil {
+		t.Fatalf("newImageStore: %v", err)
+	}
+
+	// Pre-create the target of image index 1 AS A DIRECTORY so the write of
+	// "1.bin" fails with EISDIR after "0.bin" is already on disk.
+	chatKey := "partial-write-test"
+	keyDir := filepath.Join(dir, chatKey)
+	if err := os.MkdirAll(filepath.Join(keyDir, "1.bin"), 0o755); err != nil {
+		t.Fatalf("seed partial-write obstacle: %v", err)
+	}
+
+	err = store.store(chatKey, [][]byte{[]byte("zero"), []byte("one")})
+	if err == nil {
+		t.Fatal("expected store to fail on obstructed index 1")
+	}
+
+	if _, statErr := os.Stat(keyDir); !os.IsNotExist(statErr) {
+		t.Errorf("keyDir %s must be cleaned up after partial write; stat err: %v", keyDir, statErr)
+	}
+	// Cache entry must also be absent — get() should fail.
+	if _, err := store.get(chatKey, 0); err == nil {
+		t.Errorf("cache entry must not be registered after partial write")
 	}
 }
 

--- a/api/inference/internal/ctrl/image_store_test.go
+++ b/api/inference/internal/ctrl/image_store_test.go
@@ -2,6 +2,7 @@ package ctrl
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -77,8 +78,13 @@ func TestImageStore_GetExpired(t *testing.T) {
 	}
 }
 
+// TestImageStore_DiskFilesRemovedAfterEviction verifies that when an entry
+// expires the backing per-key directory is removed by OnEvicted. We force the
+// eviction deterministically by sleeping past TTL and then calling
+// DeleteExpired ourselves — relying on the go-cache janitor's ttl/2 tick would
+// leave the test racing against scheduler noise.
 func TestImageStore_DiskFilesRemovedAfterEviction(t *testing.T) {
-	const ttl = 80 * time.Millisecond
+	const ttl = 10 * time.Millisecond
 	dir := t.TempDir()
 	store, err := newImageStore(dir, ttl)
 	if err != nil {
@@ -90,18 +96,52 @@ func TestImageStore_DiskFilesRemovedAfterEviction(t *testing.T) {
 		t.Fatalf("store: %v", err)
 	}
 
-	imgPath := dir + "/" + chatKey + "/0.bin"
+	imgPath := filepath.Join(dir, chatKey, "0.bin")
 	if _, err := os.Stat(imgPath); err != nil {
 		t.Fatalf("image file should exist before TTL: %v", err)
 	}
 
-	// Wait for TTL + cleanup goroutine (runs at ttl/2 intervals).
-	time.Sleep(ttl * 5)
-	// on-eviction fires synchronously inside the cache cleanup goroutine.
-	time.Sleep(20 * time.Millisecond)
+	// Let the entry expire, then fire eviction explicitly — DeleteExpired walks
+	// the cache, removes expired items, and calls OnEvicted for each (which
+	// runs RemoveAll on the disk directory).
+	time.Sleep(ttl * 2)
+	store.cache.DeleteExpired()
 
 	if _, err := os.Stat(imgPath); !os.IsNotExist(err) {
-		t.Logf("image file cleanup is timing-dependent; skipping hard assert (stat err: %v)", err)
+		t.Errorf("OnEvicted should have removed %s after TTL; stat err: %v", imgPath, err)
+	}
+}
+
+// TestImageStore_UUIDIsTheCapability documents the authz model: the chatKey is
+// the ONLY secret needed to retrieve an image (handleImageServeRoute does not
+// check session auth — see proxy.go). This mirrors how OpenAI's image URLs
+// work: the unguessable token in the path IS the access token. Security
+// therefore hinges on callers passing a crypto-random UUID; never a value
+// derived from user input or a monotonic counter.
+func TestImageStore_UUIDIsTheCapability(t *testing.T) {
+	store, err := newImageStore(t.TempDir(), time.Minute)
+	if err != nil {
+		t.Fatalf("newImageStore: %v", err)
+	}
+
+	if err := store.store("real-secret-uuid", [][]byte{[]byte("private")}); err != nil {
+		t.Fatalf("store: %v", err)
+	}
+
+	// An attacker guessing a different key — no matter how close — cannot read.
+	for _, guess := range []string{"real-secret-uui", "real-secret-uuid2", "other-uuid"} {
+		if _, err := store.get(guess, 0); err == nil {
+			t.Errorf("get(%q) must fail without exact chatKey, got nil", guess)
+		}
+	}
+
+	// The exact key retrieves the bytes.
+	got, err := store.get("real-secret-uuid", 0)
+	if err != nil {
+		t.Fatalf("get with correct key: %v", err)
+	}
+	if string(got) != "private" {
+		t.Errorf("get returned wrong bytes: %q", got)
 	}
 }
 

--- a/api/inference/internal/ctrl/image_store_test.go
+++ b/api/inference/internal/ctrl/image_store_test.go
@@ -1,0 +1,135 @@
+package ctrl
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestImageStore_StoreAndGet(t *testing.T) {
+	store, err := newImageStore(t.TempDir(), time.Minute)
+	if err != nil {
+		t.Fatalf("newImageStore: %v", err)
+	}
+
+	images := [][]byte{
+		[]byte("image-bytes-zero"),
+		[]byte("image-bytes-one"),
+	}
+	chatKey := "test-chat-abc"
+
+	if err := store.store(chatKey, images); err != nil {
+		t.Fatalf("store: %v", err)
+	}
+
+	for i, want := range images {
+		got, err := store.get(chatKey, i)
+		if err != nil {
+			t.Fatalf("get(%d): %v", i, err)
+		}
+		if string(got) != string(want) {
+			t.Errorf("image[%d] = %q, want %q", i, got, want)
+		}
+	}
+}
+
+func TestImageStore_GetUnknownKey(t *testing.T) {
+	store, err := newImageStore(t.TempDir(), time.Minute)
+	if err != nil {
+		t.Fatalf("newImageStore: %v", err)
+	}
+	if _, err := store.get("nonexistent", 0); err == nil {
+		t.Error("expected error for unknown key, got nil")
+	}
+}
+
+func TestImageStore_GetOutOfBoundsIndex(t *testing.T) {
+	store, err := newImageStore(t.TempDir(), time.Minute)
+	if err != nil {
+		t.Fatalf("newImageStore: %v", err)
+	}
+	if err := store.store("key", [][]byte{[]byte("only-one")}); err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	// index 1 never written
+	if _, err := store.get("key", 1); err == nil {
+		t.Error("expected error for out-of-bounds index, got nil")
+	}
+}
+
+func TestImageStore_GetExpired(t *testing.T) {
+	const ttl = 80 * time.Millisecond
+	store, err := newImageStore(t.TempDir(), ttl)
+	if err != nil {
+		t.Fatalf("newImageStore: %v", err)
+	}
+
+	chatKey := "expiring"
+	if err := store.store(chatKey, [][]byte{[]byte("img")}); err != nil {
+		t.Fatalf("store: %v", err)
+	}
+
+	// Wait well past TTL + cleanup interval (ttl/2).
+	time.Sleep(ttl * 4)
+
+	if _, err := store.get(chatKey, 0); err == nil {
+		t.Error("expected error after TTL expiry, got nil")
+	}
+}
+
+func TestImageStore_DiskFilesRemovedAfterEviction(t *testing.T) {
+	const ttl = 80 * time.Millisecond
+	dir := t.TempDir()
+	store, err := newImageStore(dir, ttl)
+	if err != nil {
+		t.Fatalf("newImageStore: %v", err)
+	}
+
+	chatKey := "cleanup-test"
+	if err := store.store(chatKey, [][]byte{[]byte("pixel")}); err != nil {
+		t.Fatalf("store: %v", err)
+	}
+
+	imgPath := dir + "/" + chatKey + "/0.bin"
+	if _, err := os.Stat(imgPath); err != nil {
+		t.Fatalf("image file should exist before TTL: %v", err)
+	}
+
+	// Wait for TTL + cleanup goroutine (runs at ttl/2 intervals).
+	time.Sleep(ttl * 5)
+	// on-eviction fires synchronously inside the cache cleanup goroutine.
+	time.Sleep(20 * time.Millisecond)
+
+	if _, err := os.Stat(imgPath); !os.IsNotExist(err) {
+		t.Logf("image file cleanup is timing-dependent; skipping hard assert (stat err: %v)", err)
+	}
+}
+
+func TestDetectContentType_PNG(t *testing.T) {
+	// Minimal valid PNG header (8 bytes signature).
+	pngSig := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0, 0, 0, 1}
+	ct := detectContentType(pngSig)
+	if ct != "image/png" {
+		t.Errorf("detectContentType(PNG) = %q, want image/png", ct)
+	}
+}
+
+func TestDetectContentType_JPEG(t *testing.T) {
+	// JPEG starts with FF D8 FF.
+	jpegSig := make([]byte, 16)
+	jpegSig[0] = 0xFF
+	jpegSig[1] = 0xD8
+	jpegSig[2] = 0xFF
+	jpegSig[3] = 0xE0
+	ct := detectContentType(jpegSig)
+	if ct != "image/jpeg" {
+		t.Errorf("detectContentType(JPEG) = %q, want image/jpeg", ct)
+	}
+}
+
+func TestDetectContentType_Empty(t *testing.T) {
+	ct := detectContentType([]byte{})
+	if ct != "application/octet-stream" {
+		t.Errorf("detectContentType(empty) = %q, want application/octet-stream", ct)
+	}
+}

--- a/api/inference/internal/ctrl/proxy.go
+++ b/api/inference/internal/ctrl/proxy.go
@@ -6,7 +6,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime"
+	"mime/multipart"
 	"net/http"
+	"net/textproto"
 	"net/url"
 	"strings"
 
@@ -63,14 +66,17 @@ func (c *Ctrl) PrepareHTTPRequest(ctx *gin.Context, targetURL string, reqBody []
 	// broker-side URL rewriting.
 	if (svcType == "text-to-image" || svcType == "image-editing") && len(reqBody) > 0 {
 		ctx.Set("clientReqBody", reqBody)
-		contentType := strings.ToLower(ctx.Request.Header.Get("Content-Type"))
+		// Keep the original-case Content-Type: mime.ParseMediaType lowercases
+		// only the media-type and parameter names, but the boundary VALUE is
+		// case-sensitive when matched against the body.
+		rawContentType := ctx.Request.Header.Get("Content-Type")
 		var (
 			originalFormat string
 			rewritten      []byte
 			err            error
 		)
-		if strings.HasPrefix(contentType, "multipart/") {
-			originalFormat, rewritten, err = rewriteMultipartResponseFormat(reqBody)
+		if strings.HasPrefix(strings.ToLower(rawContentType), "multipart/") {
+			originalFormat, rewritten, err = rewriteMultipartResponseFormat(reqBody, rawContentType)
 		} else {
 			originalFormat, rewritten, err = forceB64ResponseFormat(reqBody)
 		}
@@ -79,7 +85,7 @@ func (c *Ctrl) PrepareHTTPRequest(ctx *gin.Context, targetURL string, reqBody []
 		// back verbatim — the exact leak the rewrite exists to prevent.
 		if err != nil {
 			ctx.Set("ignoreError", true)
-			return nil, errors.Wrapf(err, "image request body could not be normalised (content-type=%q)", contentType)
+			return nil, errors.Wrapf(err, "image request body could not be normalised (content-type=%q)", rawContentType)
 		}
 		ctx.Set("clientResponseFormat", originalFormat)
 		reqBody = rewritten
@@ -501,48 +507,101 @@ func (c *Ctrl) EnforceConfiguredModel(body []byte, userAddr string) ([]byte, err
 	return modifiedBody, nil
 }
 
-// rewriteMultipartResponseFormat scans a multipart/form-data body for the
-// response_format form field and rewrites its value to "b64_json". Returns the
-// original field value (empty string if the field was absent) and the modified
-// body. The boundary is not altered — only the value bytes of the form field
-// are replaced, so binary file parts (e.g. the uploaded image) are preserved
-// byte-for-byte.
+// rewriteMultipartResponseFormat ensures the forwarded multipart body carries
+// response_format=b64_json, returning what the CLIENT originally asked for so
+// the response handler knows whether to rewrite provider output to broker URLs.
 //
-// Limitation: if the client did not include a response_format field at all,
-// this function leaves the body unchanged. Adding a new multipart part would
-// require parsing the boundary from the Content-Type header, which is out of
-// scope here — the URL-rewrite flow only activates when the client explicitly
-// asked for "url".
-func rewriteMultipartResponseFormat(body []byte) (originalFormat string, modified []byte, err error) {
-	marker := []byte(`name="response_format"`)
-	idx := bytes.Index(body, marker)
-	if idx == -1 {
-		return "", body, nil
+// Two cases:
+//  1. response_format field present — replace its body with "b64_json".
+//  2. response_format field absent — append a new part. OpenAI's documented
+//     default for /v1/images/edits is "url", so originalFormat is reported as
+//     "url" and the handler runs URL rewrite so the caller sees broker URLs.
+//
+// Uses mime/multipart.Reader so that adversarial file content (e.g. an image
+// byte sequence that happens to contain the literal string
+// `name="response_format"`) cannot corrupt the rewrite — the parser respects
+// MIME boundaries, the previous byte scanner did not. The writer uses
+// SetBoundary so the outgoing boundary string matches the original header;
+// part headers are preserved byte-for-byte as the reader saw them.
+func rewriteMultipartResponseFormat(body []byte, contentType string) (originalFormat string, modified []byte, err error) {
+	_, params, parseErr := mime.ParseMediaType(contentType)
+	if parseErr != nil {
+		return "", body, fmt.Errorf("multipart: parse content-type %q: %w", contentType, parseErr)
+	}
+	boundary, ok := params["boundary"]
+	if !ok || boundary == "" {
+		return "", body, fmt.Errorf("multipart: content-type %q has no boundary", contentType)
 	}
 
-	headerSep := []byte("\r\n\r\n")
-	sepIdx := bytes.Index(body[idx:], headerSep)
-	if sepIdx == -1 {
-		return "", body, fmt.Errorf("multipart: malformed response_format part (missing header terminator)")
+	type preservedPart struct {
+		header textproto.MIMEHeader
+		body   []byte
 	}
-	valueStart := idx + sepIdx + len(headerSep)
+	var parts []preservedPart
+	foundResponseFormat := false
+	originalFormat = ""
 
-	endIdx := bytes.Index(body[valueStart:], []byte("\r\n--"))
-	if endIdx == -1 {
-		return "", body, fmt.Errorf("multipart: malformed response_format part (missing boundary terminator)")
+	reader := multipart.NewReader(bytes.NewReader(body), boundary)
+	for {
+		part, pErr := reader.NextPart()
+		if pErr == io.EOF {
+			break
+		}
+		if pErr != nil {
+			return "", body, fmt.Errorf("multipart: read part: %w", pErr)
+		}
+		partBody, rErr := io.ReadAll(part)
+		_ = part.Close()
+		if rErr != nil {
+			return "", body, fmt.Errorf("multipart: read part body: %w", rErr)
+		}
+		if part.FormName() == "response_format" {
+			foundResponseFormat = true
+			originalFormat = string(partBody)
+			partBody = []byte("b64_json")
+		}
+		parts = append(parts, preservedPart{header: part.Header, body: partBody})
 	}
-	valueEnd := valueStart + endIdx
 
-	originalFormat = string(body[valueStart:valueEnd])
-	if originalFormat == "b64_json" {
+	// Fast path: already b64_json — no writer needed, forward unchanged.
+	if foundResponseFormat && originalFormat == "b64_json" {
 		return originalFormat, body, nil
 	}
 
-	newBody := make([]byte, 0, len(body)+len("b64_json"))
-	newBody = append(newBody, body[:valueStart]...)
-	newBody = append(newBody, []byte("b64_json")...)
-	newBody = append(newBody, body[valueEnd:]...)
-	return originalFormat, newBody, nil
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	if err := writer.SetBoundary(boundary); err != nil {
+		return "", body, fmt.Errorf("multipart: set boundary: %w", err)
+	}
+	for _, p := range parts {
+		w, cErr := writer.CreatePart(p.header)
+		if cErr != nil {
+			return "", body, fmt.Errorf("multipart: create part: %w", cErr)
+		}
+		if _, wErr := w.Write(p.body); wErr != nil {
+			return "", body, fmt.Errorf("multipart: write part body: %w", wErr)
+		}
+	}
+	if !foundResponseFormat {
+		hdr := textproto.MIMEHeader{}
+		hdr.Set("Content-Disposition", `form-data; name="response_format"`)
+		w, cErr := writer.CreatePart(hdr)
+		if cErr != nil {
+			return "", body, fmt.Errorf("multipart: create response_format part: %w", cErr)
+		}
+		if _, wErr := w.Write([]byte("b64_json")); wErr != nil {
+			return "", body, fmt.Errorf("multipart: write response_format part: %w", wErr)
+		}
+		// Client omitted the field → OpenAI default for /v1/images/edits is
+		// "url". Reporting "url" here routes us through the URL-rewrite path
+		// so the caller gets broker-served URLs, matching what direct-to-
+		// OpenAI behaviour would have produced.
+		originalFormat = "url"
+	}
+	if err := writer.Close(); err != nil {
+		return "", body, fmt.Errorf("multipart: close writer: %w", err)
+	}
+	return originalFormat, buf.Bytes(), nil
 }
 
 // forceB64ResponseFormat rewrites the response_format field in a JSON request body
@@ -565,6 +624,11 @@ func forceB64ResponseFormat(body []byte) (originalFormat string, modified []byte
 	}
 	if v, ok := m["response_format"].(string); ok {
 		originalFormat = v
+	}
+	// Fast path: already b64_json, forward original bytes byte-for-byte. Matches
+	// the multipart variant and avoids reshaping the body on every request.
+	if originalFormat == "b64_json" {
+		return originalFormat, body, nil
 	}
 	m["response_format"] = "b64_json"
 	modified, err = json.Marshal(m)

--- a/api/inference/internal/ctrl/proxy.go
+++ b/api/inference/internal/ctrl/proxy.go
@@ -57,9 +57,23 @@ func (c *Ctrl) PrepareHTTPRequest(ctx *gin.Context, targetURL string, reqBody []
 	// For text-to-image and image-editing: store the original client body (used for
 	// signing) and rewrite response_format to b64_json so the broker always receives
 	// raw image bytes from the provider rather than LAN-inaccessible URLs.
+	// Dispatches by Content-Type: JSON bodies go through forceB64ResponseFormat;
+	// multipart/form-data bodies go through rewriteMultipartResponseFormat so that
+	// image-editing clients posting multipart with response_format=url still trigger
+	// broker-side URL rewriting.
 	if (svcType == "text-to-image" || svcType == "image-editing") && len(reqBody) > 0 {
 		ctx.Set("clientReqBody", reqBody)
-		originalFormat, rewritten, err := forceB64ResponseFormat(reqBody)
+		contentType := strings.ToLower(ctx.Request.Header.Get("Content-Type"))
+		var (
+			originalFormat string
+			rewritten      []byte
+			err            error
+		)
+		if strings.HasPrefix(contentType, "multipart/") {
+			originalFormat, rewritten, err = rewriteMultipartResponseFormat(reqBody)
+		} else {
+			originalFormat, rewritten, err = forceB64ResponseFormat(reqBody)
+		}
 		if err == nil {
 			ctx.Set("clientResponseFormat", originalFormat)
 			reqBody = rewritten
@@ -480,6 +494,50 @@ func (c *Ctrl) EnforceConfiguredModel(body []byte, userAddr string) ([]byte, err
 	}
 
 	return modifiedBody, nil
+}
+
+// rewriteMultipartResponseFormat scans a multipart/form-data body for the
+// response_format form field and rewrites its value to "b64_json". Returns the
+// original field value (empty string if the field was absent) and the modified
+// body. The boundary is not altered — only the value bytes of the form field
+// are replaced, so binary file parts (e.g. the uploaded image) are preserved
+// byte-for-byte.
+//
+// Limitation: if the client did not include a response_format field at all,
+// this function leaves the body unchanged. Adding a new multipart part would
+// require parsing the boundary from the Content-Type header, which is out of
+// scope here — the URL-rewrite flow only activates when the client explicitly
+// asked for "url".
+func rewriteMultipartResponseFormat(body []byte) (originalFormat string, modified []byte, err error) {
+	marker := []byte(`name="response_format"`)
+	idx := bytes.Index(body, marker)
+	if idx == -1 {
+		return "", body, nil
+	}
+
+	headerSep := []byte("\r\n\r\n")
+	sepIdx := bytes.Index(body[idx:], headerSep)
+	if sepIdx == -1 {
+		return "", body, fmt.Errorf("multipart: malformed response_format part (missing header terminator)")
+	}
+	valueStart := idx + sepIdx + len(headerSep)
+
+	endIdx := bytes.Index(body[valueStart:], []byte("\r\n--"))
+	if endIdx == -1 {
+		return "", body, fmt.Errorf("multipart: malformed response_format part (missing boundary terminator)")
+	}
+	valueEnd := valueStart + endIdx
+
+	originalFormat = string(body[valueStart:valueEnd])
+	if originalFormat == "b64_json" {
+		return originalFormat, body, nil
+	}
+
+	newBody := make([]byte, 0, len(body)+len("b64_json"))
+	newBody = append(newBody, body[:valueStart]...)
+	newBody = append(newBody, []byte("b64_json")...)
+	newBody = append(newBody, body[valueEnd:]...)
+	return originalFormat, newBody, nil
 }
 
 // forceB64ResponseFormat rewrites the response_format field in a JSON request body

--- a/api/inference/internal/ctrl/proxy.go
+++ b/api/inference/internal/ctrl/proxy.go
@@ -513,9 +513,13 @@ func (c *Ctrl) EnforceConfiguredModel(body []byte, userAddr string) ([]byte, err
 //
 // Two cases:
 //  1. response_format field present — replace its body with "b64_json".
-//  2. response_format field absent — append a new part. OpenAI's documented
-//     default for /v1/images/edits is "url", so originalFormat is reported as
-//     "url" and the handler runs URL rewrite so the caller sees broker URLs.
+//     originalFormat returns the value the client sent (e.g. "url" or "b64_json").
+//  2. response_format field absent — append a new part set to "b64_json", and
+//     report originalFormat as "" (NOT "url"). We diverge from OpenAI's
+//     per-endpoint default here because forwarding the provider's fallback
+//     would leak LAN-private URLs; clients wanting broker-served URLs must
+//     opt in with response_format=url. This keeps JSON and multipart paths
+//     consistent: an absent field means b64 pass-through in both.
 //
 // Uses mime/multipart.Reader so that adversarial file content (e.g. an image
 // byte sequence that happens to contain the literal string

--- a/api/inference/internal/ctrl/proxy.go
+++ b/api/inference/internal/ctrl/proxy.go
@@ -74,10 +74,15 @@ func (c *Ctrl) PrepareHTTPRequest(ctx *gin.Context, targetURL string, reqBody []
 		} else {
 			originalFormat, rewritten, err = forceB64ResponseFormat(reqBody)
 		}
-		if err == nil {
-			ctx.Set("clientResponseFormat", originalFormat)
-			reqBody = rewritten
+		// Do NOT forward a body we could not normalise. If we did, a client that
+		// sent response_format=url would get the provider's LAN-private URL
+		// back verbatim — the exact leak the rewrite exists to prevent.
+		if err != nil {
+			ctx.Set("ignoreError", true)
+			return nil, errors.Wrapf(err, "image request body could not be normalised (content-type=%q)", contentType)
 		}
+		ctx.Set("clientResponseFormat", originalFormat)
+		reqBody = rewritten
 	}
 
 	// For text-to-image requests, ensure wait=true query parameter is set

--- a/api/inference/internal/ctrl/proxy.go
+++ b/api/inference/internal/ctrl/proxy.go
@@ -54,6 +54,18 @@ func (c *Ctrl) PrepareHTTPRequest(ctx *gin.Context, targetURL string, reqBody []
 		}
 	}
 
+	// For text-to-image and image-editing: store the original client body (used for
+	// signing) and rewrite response_format to b64_json so the broker always receives
+	// raw image bytes from the provider rather than LAN-inaccessible URLs.
+	if (svcType == "text-to-image" || svcType == "image-editing") && len(reqBody) > 0 {
+		ctx.Set("clientReqBody", reqBody)
+		originalFormat, rewritten, err := forceB64ResponseFormat(reqBody)
+		if err == nil {
+			ctx.Set("clientResponseFormat", originalFormat)
+			reqBody = rewritten
+		}
+	}
+
 	// For text-to-image requests, ensure wait=true query parameter is set
 	if svcType == "text-to-image" {
 		parsedURL, err := url.Parse(targetURL)
@@ -470,3 +482,35 @@ func (c *Ctrl) EnforceConfiguredModel(body []byte, userAddr string) ([]byte, err
 	return modifiedBody, nil
 }
 
+// forceB64ResponseFormat rewrites the response_format field in a JSON request body
+// to "b64_json", returning the original format value and the modified body.
+// Returns an error (and the unmodified body) if the body is not valid JSON.
+func forceB64ResponseFormat(body []byte) (originalFormat string, modified []byte, err error) {
+	var m map[string]interface{}
+	if err = json.Unmarshal(body, &m); err != nil {
+		return "", body, err
+	}
+	if v, ok := m["response_format"].(string); ok {
+		originalFormat = v
+	}
+	m["response_format"] = "b64_json"
+	modified, err = json.Marshal(m)
+	if err != nil {
+		return originalFormat, body, err
+	}
+	return originalFormat, modified, nil
+}
+
+// GetImage returns the stored image bytes for chatKey/index, or an error if
+// the entry has expired or the index is out of range.
+func (c *Ctrl) GetImage(chatKey string, index int) ([]byte, error) {
+	if c.imageStore == nil {
+		return nil, errors.New("image store not available")
+	}
+	return c.imageStore.get(chatKey, index)
+}
+
+// DetectImageContentType sniffs the MIME type of image bytes.
+func (c *Ctrl) DetectImageContentType(data []byte) string {
+	return detectContentType(data)
+}

--- a/api/inference/internal/ctrl/proxy.go
+++ b/api/inference/internal/ctrl/proxy.go
@@ -548,9 +548,19 @@ func rewriteMultipartResponseFormat(body []byte) (originalFormat string, modifie
 // forceB64ResponseFormat rewrites the response_format field in a JSON request body
 // to "b64_json", returning the original format value and the modified body.
 // Returns an error (and the unmodified body) if the body is not valid JSON.
+//
+// Caveat: this round-trips through map[string]interface{}, so top-level field
+// order is not preserved on output. Numeric values are decoded with UseNumber
+// to preserve integer precision — e.g. a seed value of 2^53+1 survives the
+// rewrite. The signed body used for TEE proofs is the original pre-rewrite
+// bytes (captured as clientReqBody), so this reshaping is provider-visible
+// only. If a future provider starts to care about byte-for-byte equality of
+// the forwarded body, replace this with a targeted byte-level rewrite.
 func forceB64ResponseFormat(body []byte) (originalFormat string, modified []byte, err error) {
 	var m map[string]interface{}
-	if err = json.Unmarshal(body, &m); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(body))
+	dec.UseNumber()
+	if err = dec.Decode(&m); err != nil {
 		return "", body, err
 	}
 	if v, ok := m["response_format"].(string); ok {

--- a/api/inference/internal/ctrl/proxy.go
+++ b/api/inference/internal/ctrl/proxy.go
@@ -14,6 +14,7 @@ import (
 	"net/textproto"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/andybalholm/brotli"
 	"github.com/gin-gonic/gin"
@@ -741,4 +742,15 @@ func (c *Ctrl) GetImage(chatKey string, index int) ([]byte, error) {
 // DetectImageContentType sniffs the MIME type of image bytes.
 func (c *Ctrl) DetectImageContentType(data []byte) string {
 	return detectContentType(data)
+}
+
+// ImageCacheTTL returns the configured lifetime of broker-stored images, used
+// by the serve route to set an accurate Cache-Control max-age. Zero means the
+// store is unavailable; callers should treat that as "do not advertise a
+// cache lifetime" rather than as "fresh forever".
+func (c *Ctrl) ImageCacheTTL() time.Duration {
+	if c.imageStore == nil {
+		return 0
+	}
+	return c.imageStore.ttl
 }

--- a/api/inference/internal/ctrl/proxy.go
+++ b/api/inference/internal/ctrl/proxy.go
@@ -592,11 +592,16 @@ func rewriteMultipartResponseFormat(body []byte, contentType string) (originalFo
 		if _, wErr := w.Write([]byte("b64_json")); wErr != nil {
 			return "", body, fmt.Errorf("multipart: write response_format part: %w", wErr)
 		}
-		// Client omitted the field → OpenAI default for /v1/images/edits is
-		// "url". Reporting "url" here routes us through the URL-rewrite path
-		// so the caller gets broker-served URLs, matching what direct-to-
-		// OpenAI behaviour would have produced.
-		originalFormat = "url"
+		// Broker default is b64_json for both JSON and multipart when the
+		// client omits the field — diverges from OpenAI's per-endpoint
+		// defaults (which are "url" for /v1/images/edits) but is the only
+		// value we can safely return: forwarding the provider's default
+		// would leak LAN-private URLs. Clients wanting broker-served URLs
+		// must opt in explicitly with response_format=url. Keeping
+		// originalFormat = "" (not "url") skips the handler's URL-rewrite
+		// path so the client receives b64_json straight through, matching
+		// the JSON-body branch in forceB64ResponseFormat.
+		originalFormat = ""
 	}
 	if err := writer.Close(); err != nil {
 		return "", body, fmt.Errorf("multipart: close writer: %w", err)

--- a/api/inference/internal/ctrl/signing.go
+++ b/api/inference/internal/ctrl/signing.go
@@ -82,11 +82,26 @@ func (c *Ctrl) signChatWithKey(reqBody, respData []byte, chatKey string) error {
 	return nil
 }
 
-// signImageResponse creates a TEE signature for image generation / editing responses.
-// The signed text is: sha256(originalClientReqBody):sha256(img0),sha256(img1),...
-// This binds the signature to actual image bytes rather than provider response JSON,
-// which may contain inaccessible LAN URLs.
+// signImageResponse creates a TEE signature for image generation / editing
+// responses from a DECENTRALIZED provider. The signed text is:
+//
+//	sha256(originalClientReqBody):sha256(img0),sha256(img1),...
+//
+// This binds the signature to actual image bytes rather than the provider
+// response JSON (which may contain inaccessible LAN URLs).
+//
+// Parity note: this is the image-flow counterpart of signChatWithKey, NOT of
+// signCentralizedRoutingProof. If image-editing is ever enabled for a
+// centralized provider, a sibling function (signImageResponseRoutingProof)
+// must be added that also takes *tls.ConnectionState and emits the TLS
+// fingerprint / ProviderType / ProviderIdentity fields — otherwise a verifier
+// would see a TEE-signed envelope with no evidence of which upstream served
+// the image. The guard below fails loud so the gap cannot be reached silently
+// by toggling providerType=centralized with targetSeparated=false in config.
 func (c *Ctrl) signImageResponse(reqBody []byte, images [][]byte, chatKey string) error {
+	if c.Service.IsCentralized() {
+		return fmt.Errorf("signImageResponse does not cover centralized providers; add a routing-proof variant that binds the TLS fingerprint before enabling this path")
+	}
 	imgHashes := make([]string, len(images))
 	for i, img := range images {
 		imgHashes[i] = sha256Hex(img)

--- a/api/inference/internal/ctrl/signing.go
+++ b/api/inference/internal/ctrl/signing.go
@@ -1,0 +1,165 @@
+package ctrl
+
+import (
+	"crypto/sha256"
+	"crypto/tls"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
+
+	teeutil "github.com/0glabs/0g-serving-broker/common/tee"
+)
+
+const ChatPrefix = "chat"
+
+type SigningAlgo int
+
+const (
+	ECDSA SigningAlgo = iota
+)
+
+func (r SigningAlgo) String() string {
+	return [...]string{"ecdsa"}[r]
+}
+
+// ChatSignature is the TEE-signed proof cached under a chatKey and served by
+// /v1/proxy/signature/{chatKey}. It binds request/response hashes (and, for
+// centralized providers, the TLS fingerprint and provider identity) to the
+// broker's TEE signing key.
+type ChatSignature struct {
+	Text                string         `json:"text"`
+	SignatureEcdsa      string         `json:"signature"`
+	SigningAddressEcdsa common.Address `json:"signing_address"`
+	SigningAlgo         string         `json:"signing_algo"`
+	// Centralized provider routing proof fields (omitted for decentralized providers)
+	ProviderType       string `json:"provider_type,omitempty"`
+	ProviderIdentity   string `json:"provider_identity,omitempty"`
+	TLSCertFingerprint string `json:"tls_cert_fingerprint,omitempty"`
+}
+
+func (*Ctrl) chatCacheKey(chatID string) string {
+	return fmt.Sprintf("%s:%s", ChatPrefix, chatID)
+}
+
+func sha256Hex(b []byte) string {
+	h := sha256.Sum256(b)
+	return hex.EncodeToString(h[:])
+}
+
+// signChatWithKey signs sha256(reqBody):sha256(respData) and caches the result
+// under chatKey. Used by chatbot, video, speech-to-text, and the fallback path
+// of text-to-image / image-editing when b64 images cannot be extracted.
+func (c *Ctrl) signChatWithKey(reqBody, respData []byte, chatKey string) error {
+	requestSha256 := sha256Hex(reqBody)
+	responseSha256 := sha256Hex(respData)
+
+	c.logger.Debugf("requestSha256: %s, responseSha256: %s, signer address %s", requestSha256, responseSha256, c.teeService.Address.Hex())
+	text := fmt.Sprintf("%s:%s", requestSha256, responseSha256)
+	sig, err := crypto.Sign(accounts.TextHash([]byte(text)), c.teeService.ProviderSigner)
+	if err != nil {
+		return err
+	}
+
+	if sig[64] == 0 || sig[64] == 1 {
+		sig[64] += 27
+	}
+
+	chatSignature := ChatSignature{
+		Text:                text,
+		SignatureEcdsa:      hexutil.Encode(sig),
+		SigningAddressEcdsa: c.teeService.Address,
+		SigningAlgo:         ECDSA.String(),
+	}
+
+	key := c.chatCacheKey(chatKey)
+	c.logger.Debugf("key: %v, chat signature: %v", key, chatSignature)
+	c.svcCache.Set(key, chatSignature, c.chatCacheExpiration)
+	return nil
+}
+
+// signImageResponse creates a TEE signature for image generation / editing responses.
+// The signed text is: sha256(originalClientReqBody):sha256(img0),sha256(img1),...
+// This binds the signature to actual image bytes rather than provider response JSON,
+// which may contain inaccessible LAN URLs.
+func (c *Ctrl) signImageResponse(reqBody []byte, images [][]byte, chatKey string) error {
+	imgHashes := make([]string, len(images))
+	for i, img := range images {
+		imgHashes[i] = sha256Hex(img)
+	}
+	text := sha256Hex(reqBody) + ":" + strings.Join(imgHashes, ",")
+
+	sig, err := crypto.Sign(accounts.TextHash([]byte(text)), c.teeService.ProviderSigner)
+	if err != nil {
+		return err
+	}
+	if sig[64] == 0 || sig[64] == 1 {
+		sig[64] += 27
+	}
+
+	chatSignature := ChatSignature{
+		Text:                text,
+		SignatureEcdsa:      hexutil.Encode(sig),
+		SigningAddressEcdsa: c.teeService.Address,
+		SigningAlgo:         ECDSA.String(),
+	}
+
+	key := c.chatCacheKey(chatKey)
+	c.logger.Debugf("image signature key: %v, sig: %v", key, chatSignature)
+	c.svcCache.Set(key, chatSignature, c.chatCacheExpiration)
+	return nil
+}
+
+// signCentralizedRoutingProof creates a TEE-signed routing proof for centralized
+// provider requests. The proof includes request/response hashes, provider identity,
+// and the TLS certificate fingerprint proving the connection target.
+func (c *Ctrl) signCentralizedRoutingProof(reqBody, respData []byte, chatKey string, tlsState *tls.ConnectionState) error {
+	requestSha256 := sha256Hex(reqBody)
+	responseSha256 := sha256Hex(respData)
+
+	// Extract TLS certificate fingerprint — refuse to sign without it.
+	// A routing proof with an empty fingerprint carries a TEE signature but
+	// provides no TLS evidence, giving verifiers a false sense of security.
+	certInfo := teeutil.ExtractTLSInfo(tlsState)
+	if certInfo == nil || certInfo.PeerCertFingerprint == "" {
+		return fmt.Errorf("TLS certificate not available for centralized provider routing proof (response and billing are unaffected)")
+	}
+	tlsFingerprint := certInfo.PeerCertFingerprint
+	c.logger.Debugf("TLS cert fingerprint captured: %s (server: %s)", tlsFingerprint, certInfo.ServerName)
+
+	text := teeutil.FormatRoutingProofText(
+		requestSha256, responseSha256,
+		c.Service.ProviderType, c.Service.ProviderIdentity,
+		tlsFingerprint,
+	)
+
+	c.logger.Debugf("Routing proof text: %s, signer address: %s", text, c.teeService.Address.Hex())
+
+	sig, err := crypto.Sign(accounts.TextHash([]byte(text)), c.teeService.ProviderSigner)
+	if err != nil {
+		return fmt.Errorf("failed to sign routing proof: %w", err)
+	}
+
+	if sig[64] == 0 || sig[64] == 1 {
+		sig[64] += 27
+	}
+
+	chatSignature := ChatSignature{
+		Text:                text,
+		SignatureEcdsa:      hexutil.Encode(sig),
+		SigningAddressEcdsa: c.teeService.Address,
+		SigningAlgo:         ECDSA.String(),
+		ProviderType:        c.Service.ProviderType,
+		ProviderIdentity:    c.Service.ProviderIdentity,
+		TLSCertFingerprint:  tlsFingerprint,
+	}
+
+	key := c.chatCacheKey(chatKey)
+	c.logger.Debugf("key: %v, centralized chat signature: %v", key, chatSignature)
+	c.svcCache.Set(key, chatSignature, c.chatCacheExpiration)
+	return nil
+}

--- a/api/inference/internal/ctrl/testing_helpers.go
+++ b/api/inference/internal/ctrl/testing_helpers.go
@@ -1,7 +1,9 @@
 package ctrl
 
 import (
+	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/patrickmn/go-cache"
 
@@ -26,4 +28,23 @@ func (c *Ctrl) SeedServiceCache(service model.Service) {
 // Use this to inject a client that trusts httptest.NewTLSServer certificates.
 func (c *Ctrl) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+// SetupImageStoreForTest initialises a local image store at dir for proxy-level
+// tests that exercise handleImageServeRoute without a full request flow.
+func (c *Ctrl) SetupImageStoreForTest(dir string) error {
+	store, err := newImageStore(dir, time.Minute)
+	if err != nil {
+		return fmt.Errorf("setup image store: %w", err)
+	}
+	c.imageStore = store
+	return nil
+}
+
+// StoreTestImage saves image bytes into the image store. Call SetupImageStoreForTest first.
+func (c *Ctrl) StoreTestImage(chatKey string, images [][]byte) error {
+	if c.imageStore == nil {
+		return fmt.Errorf("image store not initialised, call SetupImageStoreForTest first")
+	}
+	return c.imageStore.store(chatKey, images)
 }

--- a/api/inference/internal/ctrl/text_to_image.go
+++ b/api/inference/internal/ctrl/text_to_image.go
@@ -86,7 +86,9 @@ func (c *Ctrl) handleTextToImageResponse(ctx *gin.Context, resp *http.Response, 
 
 	// Extract decoded image bytes; fall back to signing the full response body
 	// if the provider did not return b64_json (e.g. multipart provider quirks).
-	images, extractErr := extractB64Images(body)
+	// Cap at the request's declared output count so a compromised provider
+	// cannot OOM the broker by returning a giant data array.
+	images, extractErr := extractB64Images(body, int(reqModel.OutputCount))
 
 	// Determine what the client originally asked for.
 	originalFormat, _ := ctx.Get("clientResponseFormat")
@@ -202,15 +204,24 @@ func (c *Ctrl) handleTextToImageResponse(ctx *gin.Context, resp *http.Response, 
 }
 
 // extractB64Images parses an OpenAI-style image response envelope and decodes
-// each data[i].b64_json into raw bytes.  Returns an error if parsing fails or
-// no b64 images are present.
-func extractB64Images(body []byte) ([][]byte, error) {
+// each data[i].b64_json into raw bytes.
+//
+// maxImages is the cap on envelope length (typically the request's "n" field,
+// which billing has already been committed against). Reject when the provider
+// returns more entries than requested — always a bug, and decoding everything
+// blindly lets a compromised provider OOM the broker via a giant data array
+// of tiny b64 strings. Pass <= 0 to disable the cap (tests only; production
+// callers should always supply one).
+func extractB64Images(body []byte, maxImages int) ([][]byte, error) {
 	var envelope imageResponseEnvelope
 	if err := json.Unmarshal(body, &envelope); err != nil {
 		return nil, fmt.Errorf("unmarshal image response: %w", err)
 	}
 	if len(envelope.Data) == 0 {
 		return nil, fmt.Errorf("image response has empty data array")
+	}
+	if maxImages > 0 && len(envelope.Data) > maxImages {
+		return nil, fmt.Errorf("image response has %d entries, exceeds declared output count %d", len(envelope.Data), maxImages)
 	}
 	images := make([][]byte, 0, len(envelope.Data))
 	for i, d := range envelope.Data {

--- a/api/inference/internal/ctrl/text_to_image.go
+++ b/api/inference/internal/ctrl/text_to_image.go
@@ -236,8 +236,12 @@ func extractB64Images(body []byte, maxImages int) ([][]byte, error) {
 	images := make([][]byte, 0, len(envelope.Data))
 	// base64 expands raw bytes by 4/3 (plus padding); reject the encoded blob
 	// before allocating the decode buffer when it would clearly exceed the
-	// per-image cap. This bounds peak memory at the maxB64ImageBytes limit
-	// rather than at the upstream-supplied size.
+	// per-image cap. Note: by this point json.Unmarshal has already pulled
+	// the full b64 string into memory, so this check does NOT bound peak
+	// ingest — it bounds the additional decode allocation (~maxB64ImageBytes
+	// per image) plus the downstream os.WriteFile, which is where the real
+	// amplification lives. Capping the upstream body itself would need a
+	// MaxBytesReader at the proxy ingress; out of scope here.
 	maxEncoded := base64.StdEncoding.EncodedLen(maxB64ImageBytes)
 	for i, d := range envelope.Data {
 		if d.B64JSON == "" {

--- a/api/inference/internal/ctrl/text_to_image.go
+++ b/api/inference/internal/ctrl/text_to_image.go
@@ -90,9 +90,20 @@ func (c *Ctrl) handleTextToImageResponse(ctx *gin.Context, resp *http.Response, 
 	originalFormat, _ := ctx.Get("clientResponseFormat")
 	wantURL := originalFormat == "url"
 
-	// Build the body to send to the client.
+	// If the client asked for url but the provider returned something we can't
+	// decode (non-b64 envelope, empty array), refuse the response rather than
+	// passing provider bytes through — they may contain LAN-private URLs.
+	if wantURL && (extractErr != nil || len(images) == 0) {
+		ctx.Set("ignoreError", true)
+		err := fmt.Errorf("provider returned non-b64 image response, refusing to forward (may contain LAN-private URLs): %w", extractErr)
+		c.handleBrokerError(ctx, err, "image response for response_format=url")
+		return err
+	}
+
+	// Build the body to send to the client. For wantURL, store + rewrite; any
+	// failure here downgrades to b64 (safe — body is confirmed b64 above).
 	clientBody := body
-	if wantURL && extractErr == nil && len(images) > 0 && c.imageStore != nil {
+	if wantURL && c.imageStore != nil {
 		if storeErr := c.imageStore.store(chatKey, images); storeErr != nil {
 			c.logger.Warnf("Failed to store images for URL rewrite, sending b64: %v", storeErr)
 		} else {

--- a/api/inference/internal/ctrl/text_to_image.go
+++ b/api/inference/internal/ctrl/text_to_image.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strconv"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -94,7 +96,7 @@ func (c *Ctrl) handleTextToImageResponse(ctx *gin.Context, resp *http.Response, 
 		if storeErr := c.imageStore.store(chatKey, images); storeErr != nil {
 			c.logger.Warnf("Failed to store images for URL rewrite, sending b64: %v", storeErr)
 		} else {
-			rewritten, buildErr := buildURLResponse(body, chatKey, len(images), ctx.Request)
+			rewritten, buildErr := buildURLResponse(body, chatKey, len(images), c.Service.ServingURL)
 			if buildErr != nil {
 				c.logger.Warnf("Failed to build URL response, sending b64: %v", buildErr)
 			} else {
@@ -174,17 +176,24 @@ func extractB64Images(body []byte) ([][]byte, error) {
 
 // buildURLResponse replaces each data[i].b64_json with a broker-served URL while
 // preserving all other fields (e.g. revised_prompt, created).
-func buildURLResponse(body []byte, chatKey string, count int, r *http.Request) ([]byte, error) {
+//
+// The URL base is derived from the operator-configured service.servingUrl so it
+// matches the public URL the provider registered on-chain. Returns an error if
+// servingUrl is missing or malformed; the caller falls back to b64 on error.
+func buildURLResponse(body []byte, chatKey string, count int, servingURL string) ([]byte, error) {
 	var envelope imageResponseEnvelope
 	if err := json.Unmarshal(body, &envelope); err != nil {
 		return nil, fmt.Errorf("unmarshal image response: %w", err)
 	}
 
-	scheme := "https"
-	if r.TLS == nil {
-		scheme = "http"
+	if servingURL == "" {
+		return nil, fmt.Errorf("service.servingUrl is not configured")
 	}
-	base := scheme + "://" + r.Host + constant.ServicePrefix + "/images/" + chatKey + "/"
+	u, err := url.Parse(servingURL)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return nil, fmt.Errorf("service.servingUrl %q is not a valid absolute URL", servingURL)
+	}
+	base := strings.TrimRight(servingURL, "/") + constant.ServicePrefix + "/images/" + chatKey + "/"
 
 	for i := range envelope.Data {
 		if i >= count {

--- a/api/inference/internal/ctrl/text_to_image.go
+++ b/api/inference/internal/ctrl/text_to_image.go
@@ -1,6 +1,7 @@
 package ctrl
 
 import (
+	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -127,8 +128,26 @@ func (c *Ctrl) handleTextToImageResponse(ctx *gin.Context, resp *http.Response, 
 		}
 	}
 
-	if !c.Service.TargetSeparated {
-		c.logger.Debug("LLM server in the same network, signing text-to-image response")
+	// TEE signing is a function of the trust model, not the response shape:
+	//   - Centralized: broker cannot attest to OpenAI's content; it can only
+	//     attest to the TLS path it took. Use routing proof (binds TLS cert
+	//     fingerprint + provider identity + req/resp hashes).
+	//   - Decentralized, LLM in broker TEE network (!TargetSeparated): broker
+	//     CAN vouch for content, so sign the decoded image bytes directly.
+	//   - Decentralized, TargetSeparated: the remote TEE signs its own output;
+	//     the broker does not duplicate.
+	switch {
+	case c.Service.IsCentralized():
+		var tlsState *tls.ConnectionState
+		if v, exists := ctx.Get("tlsState"); exists {
+			tlsState, _ = v.(*tls.ConnectionState)
+		}
+		c.logger.Debug("Centralized provider, signing text-to-image routing proof")
+		if err := c.signCentralizedRoutingProof(sigReqBody, body, chatKey, tlsState); err != nil {
+			c.logger.Errorf("routing proof not created: %v", err)
+		}
+	case !c.Service.TargetSeparated:
+		c.logger.Debug("LLM server in the same network, signing text-to-image content")
 		if extractErr == nil && len(images) > 0 {
 			_ = c.signImageResponse(sigReqBody, images, chatKey)
 		} else {

--- a/api/inference/internal/ctrl/text_to_image.go
+++ b/api/inference/internal/ctrl/text_to_image.go
@@ -22,6 +22,16 @@ import (
 	"github.com/0glabs/0g-serving-broker/inference/monitor"
 )
 
+// maxB64ImageBytes caps the decoded size of a single image returned by the
+// provider. Without this, a compromised or buggy provider could ship a single
+// hundred-MB b64_json blob that the broker would buffer in memory (during
+// io.ReadAll on the upstream body), decode in memory again, and then write to
+// disk — amplifying a single request into a multi-hundred-MB allocation per
+// image. 50 MiB is well above any realistic AI image output (DALL-E 3 PNGs
+// top out around 4 MB) and still small enough that even N=10 (the OpenAI
+// upper bound for "n") stays under 500 MiB worst-case.
+const maxB64ImageBytes = 50 * 1024 * 1024
+
 // imageResponseData mirrors the OpenAI image object inside data[].
 type imageResponseData struct {
 	B64JSON       string `json:"b64_json,omitempty"`
@@ -224,13 +234,24 @@ func extractB64Images(body []byte, maxImages int) ([][]byte, error) {
 		return nil, fmt.Errorf("image response has %d entries, exceeds declared output count %d", len(envelope.Data), maxImages)
 	}
 	images := make([][]byte, 0, len(envelope.Data))
+	// base64 expands raw bytes by 4/3 (plus padding); reject the encoded blob
+	// before allocating the decode buffer when it would clearly exceed the
+	// per-image cap. This bounds peak memory at the maxB64ImageBytes limit
+	// rather than at the upstream-supplied size.
+	maxEncoded := base64.StdEncoding.EncodedLen(maxB64ImageBytes)
 	for i, d := range envelope.Data {
 		if d.B64JSON == "" {
 			return nil, fmt.Errorf("data[%d] missing b64_json field", i)
 		}
+		if len(d.B64JSON) > maxEncoded {
+			return nil, fmt.Errorf("data[%d].b64_json encoded size %d exceeds per-image cap %d", i, len(d.B64JSON), maxEncoded)
+		}
 		img, err := base64.StdEncoding.DecodeString(d.B64JSON)
 		if err != nil {
 			return nil, fmt.Errorf("decode data[%d].b64_json: %w", i, err)
+		}
+		if len(img) > maxB64ImageBytes {
+			return nil, fmt.Errorf("data[%d] decoded size %d exceeds per-image cap %d", i, len(img), maxB64ImageBytes)
 		}
 		images = append(images, img)
 	}

--- a/api/inference/internal/ctrl/text_to_image.go
+++ b/api/inference/internal/ctrl/text_to_image.go
@@ -102,10 +102,24 @@ func (c *Ctrl) handleTextToImageResponse(ctx *gin.Context, resp *http.Response, 
 		return err
 	}
 
-	// Build the body to send to the client. For wantURL, store + rewrite; any
-	// failure here downgrades to b64 (safe — body is confirmed b64 above).
+	// If the client asked for url but we have no image store, the URL contract
+	// can't be honoured. Silently serving b64 instead would violate the
+	// explicitly-requested format without any per-request signal — fail-closed
+	// so operators correlate with the "image store disabled" startup warning.
+	if wantURL && c.imageStore == nil {
+		ctx.Set("ignoreError", true)
+		err := fmt.Errorf("response_format=url requested but image store is disabled (check startup logs for newImageStore error)")
+		c.logger.Errorf("text-to-image URL request while imageStore is nil")
+		c.handleBrokerError(ctx, err, "image response for response_format=url")
+		return err
+	}
+
+	// Build the body to send to the client. store + rewrite; any failure here
+	// downgrades to b64 (safe — body is confirmed b64 above, and the client
+	// gets a legitimate response just in the wrong format). Log at warn so
+	// the degradation is visible in operator logs.
 	clientBody := body
-	if wantURL && c.imageStore != nil {
+	if wantURL {
 		if storeErr := c.imageStore.store(chatKey, images); storeErr != nil {
 			c.logger.Warnf("Failed to store images for URL rewrite, sending b64: %v", storeErr)
 		} else {
@@ -233,10 +247,16 @@ func buildURLResponse(body []byte, chatKey string, count int, servingURL string)
 	}
 	base := strings.TrimRight(servingURL, "/") + constant.ServicePrefix + "/images/" + chatKey + "/"
 
+	// Callers pass count == len(extractB64Images(body)). If that diverges from
+	// the envelope length (provider envelope and our decoded image list came
+	// from the same body, so this should be impossible), refuse rather than
+	// emit a mixed b64/url response that neither the client nor the signature
+	// machinery would handle sensibly.
+	if len(envelope.Data) != count {
+		return nil, fmt.Errorf("envelope has %d data entries but %d images were stored", len(envelope.Data), count)
+	}
+
 	for i := range envelope.Data {
-		if i >= count {
-			break
-		}
 		envelope.Data[i] = imageResponseData{
 			URL:           base + strconv.Itoa(i),
 			RevisedPrompt: envelope.Data[i].RevisedPrompt,

--- a/api/inference/internal/ctrl/text_to_image.go
+++ b/api/inference/internal/ctrl/text_to_image.go
@@ -1,18 +1,35 @@
 package ctrl
 
 import (
+	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 
 	"github.com/0glabs/0g-serving-broker/common/errors"
 	"github.com/0glabs/0g-serving-broker/common/util"
+	constant "github.com/0glabs/0g-serving-broker/inference/const"
 	"github.com/0glabs/0g-serving-broker/inference/model"
 	"github.com/0glabs/0g-serving-broker/inference/monitor"
 )
+
+// imageResponseData mirrors the OpenAI image object inside data[].
+type imageResponseData struct {
+	B64JSON       string `json:"b64_json,omitempty"`
+	URL           string `json:"url,omitempty"`
+	RevisedPrompt string `json:"revised_prompt,omitempty"`
+}
+
+// imageResponseEnvelope is the top-level OpenAI image response shape.
+type imageResponseEnvelope struct {
+	Created int64               `json:"created"`
+	Data    []imageResponseData `json:"data"`
+}
 
 // GetTextToImageInputFeeAndImageNum gets input fee and imageNum for text-to-image generation
 func (c *Ctrl) GetTextToImageInputFeeAndImageNum(reqBody []byte) (string, int64, error) {
@@ -35,34 +52,75 @@ func (c *Ctrl) GetTextToImageInputFeeAndImageNum(reqBody []byte) (string, int64,
 	return expectedInputFee, imageNum, nil
 }
 
-// handleTextToImageResponse handles image generation response
+// handleTextToImageResponse handles image generation response.
+//
+// Flow:
+//  1. Read the provider response (always b64_json — enforced in PrepareHTTPRequest).
+//  2. Decode each image and sign sha256(originalClientReq):sha256(img0),...
+//  3. If the original client requested URL format, persist images to the local
+//     image store and rewrite the response with broker-served URLs before sending
+//     to the client.  Otherwise pass the b64 response through unchanged.
 func (c *Ctrl) handleTextToImageResponse(ctx *gin.Context, resp *http.Response, account model.User, outputPrice string, reqBody []byte, reqModel model.Request) error {
 	defer resp.Body.Close()
 
 	chatKey := uuid.NewString()
 	ctx.Writer.Header().Set("ZG-Res-Key", chatKey)
 
-	// Read and return image data
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		c.handleBrokerError(ctx, err, "read image response body")
 		return err
 	}
 
+	// Resolve the original client request body (pre-b64 rewrite) for signing.
+	sigReqBody := reqBody
+	if v, ok := ctx.Get("clientReqBody"); ok {
+		if orig, ok := v.([]byte); ok {
+			sigReqBody = orig
+		}
+	}
+
+	// Extract decoded image bytes; fall back to signing the full response body
+	// if the provider did not return b64_json (e.g. multipart provider quirks).
+	images, extractErr := extractB64Images(body)
+
+	// Determine what the client originally asked for.
+	originalFormat, _ := ctx.Get("clientResponseFormat")
+	wantURL := originalFormat == "url"
+
+	// Build the body to send to the client.
+	clientBody := body
+	if wantURL && extractErr == nil && len(images) > 0 && c.imageStore != nil {
+		if storeErr := c.imageStore.store(chatKey, images); storeErr != nil {
+			c.logger.Warnf("Failed to store images for URL rewrite, sending b64: %v", storeErr)
+		} else {
+			rewritten, buildErr := buildURLResponse(body, chatKey, len(images), ctx.Request)
+			if buildErr != nil {
+				c.logger.Warnf("Failed to build URL response, sending b64: %v", buildErr)
+			} else {
+				clientBody = rewritten
+			}
+		}
+	}
+
 	// Attempt to return image to client. If client disconnected, continue to billing.
-	if _, writeErr := ctx.Writer.Write(body); writeErr != nil {
+	if _, writeErr := ctx.Writer.Write(clientBody); writeErr != nil {
 		if c.isClientDisconnectError(writeErr) {
 			ctx.Set("ignoreError", true)
 			c.logger.Warnf("Client disconnected during text-to-image response, billing for completed response (%d bytes)", len(body))
 		} else {
 			c.handleBrokerError(ctx, writeErr, "write image response")
-			// Still proceed to billing below
 		}
 	}
 
 	if !c.Service.TargetSeparated {
 		c.logger.Debug("LLM server in the same network, signing text-to-image response")
-		_ = c.signChatWithKey(reqBody, body, chatKey)
+		if extractErr == nil && len(images) > 0 {
+			_ = c.signImageResponse(sigReqBody, images, chatKey)
+		} else {
+			c.logger.Warnf("No b64 images extracted, falling back to full-body signature: %v", extractErr)
+			_ = c.signChatWithKey(sigReqBody, body, chatKey)
+		}
 	}
 
 	// Skip billing for whitelisted users, but record whitelist traffic metrics
@@ -87,4 +145,60 @@ func (c *Ctrl) handleTextToImageResponse(ctx *gin.Context, resp *http.Response, 
 
 	monitor.RecordTokens("text-to-image", 0, imageNum)
 	return nil
+}
+
+// extractB64Images parses an OpenAI-style image response envelope and decodes
+// each data[i].b64_json into raw bytes.  Returns an error if parsing fails or
+// no b64 images are present.
+func extractB64Images(body []byte) ([][]byte, error) {
+	var envelope imageResponseEnvelope
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return nil, fmt.Errorf("unmarshal image response: %w", err)
+	}
+	if len(envelope.Data) == 0 {
+		return nil, fmt.Errorf("image response has empty data array")
+	}
+	images := make([][]byte, 0, len(envelope.Data))
+	for i, d := range envelope.Data {
+		if d.B64JSON == "" {
+			return nil, fmt.Errorf("data[%d] missing b64_json field", i)
+		}
+		img, err := base64.StdEncoding.DecodeString(d.B64JSON)
+		if err != nil {
+			return nil, fmt.Errorf("decode data[%d].b64_json: %w", i, err)
+		}
+		images = append(images, img)
+	}
+	return images, nil
+}
+
+// buildURLResponse replaces each data[i].b64_json with a broker-served URL while
+// preserving all other fields (e.g. revised_prompt, created).
+func buildURLResponse(body []byte, chatKey string, count int, r *http.Request) ([]byte, error) {
+	var envelope imageResponseEnvelope
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return nil, fmt.Errorf("unmarshal image response: %w", err)
+	}
+
+	scheme := "https"
+	if r.TLS == nil {
+		scheme = "http"
+	}
+	base := scheme + "://" + r.Host + constant.ServicePrefix + "/images/" + chatKey + "/"
+
+	for i := range envelope.Data {
+		if i >= count {
+			break
+		}
+		envelope.Data[i] = imageResponseData{
+			URL:           base + strconv.Itoa(i),
+			RevisedPrompt: envelope.Data[i].RevisedPrompt,
+		}
+	}
+
+	out, err := json.Marshal(envelope)
+	if err != nil {
+		return nil, fmt.Errorf("marshal URL response: %w", err)
+	}
+	return out, nil
 }

--- a/api/inference/internal/ctrl/text_to_image_test.go
+++ b/api/inference/internal/ctrl/text_to_image_test.go
@@ -3,8 +3,6 @@ package ctrl
 import (
 	"encoding/base64"
 	"encoding/json"
-	"net/http/httptest"
-	"strconv"
 	"strings"
 	"testing"
 )
@@ -157,12 +155,113 @@ func TestForceB64ResponseFormat_NonJSON_ReturnsError(t *testing.T) {
 }
 
 // ==========================================================================
+// rewriteMultipartResponseFormat
+// ==========================================================================
+
+func TestRewriteMultipartResponseFormat_RewritesURLToB64(t *testing.T) {
+	body := []byte(
+		"--b\r\nContent-Disposition: form-data; name=\"prompt\"\r\n\r\nhello\r\n" +
+			"--b\r\nContent-Disposition: form-data; name=\"response_format\"\r\n\r\nurl\r\n" +
+			"--b--\r\n",
+	)
+
+	orig, modified, err := rewriteMultipartResponseFormat(body)
+	if err != nil {
+		t.Fatalf("rewriteMultipartResponseFormat: %v", err)
+	}
+	if orig != "url" {
+		t.Errorf("original format = %q, want url", orig)
+	}
+	if !strings.Contains(string(modified), "name=\"response_format\"\r\n\r\nb64_json\r\n") {
+		t.Errorf("modified body missing rewritten response_format:\n%s", modified)
+	}
+	if strings.Contains(string(modified), "name=\"response_format\"\r\n\r\nurl\r\n") {
+		t.Error("modified body still contains url value")
+	}
+	// prompt part must be intact.
+	if !strings.Contains(string(modified), "name=\"prompt\"\r\n\r\nhello\r\n") {
+		t.Error("modified body should preserve the prompt part")
+	}
+}
+
+func TestRewriteMultipartResponseFormat_FieldAbsent_NoOp(t *testing.T) {
+	body := []byte(
+		"--b\r\nContent-Disposition: form-data; name=\"prompt\"\r\n\r\nhello\r\n" +
+			"--b--\r\n",
+	)
+
+	orig, modified, err := rewriteMultipartResponseFormat(body)
+	if err != nil {
+		t.Fatalf("rewriteMultipartResponseFormat: %v", err)
+	}
+	if orig != "" {
+		t.Errorf("original format = %q, want empty", orig)
+	}
+	if string(modified) != string(body) {
+		t.Error("body should be unchanged when response_format is absent")
+	}
+}
+
+func TestRewriteMultipartResponseFormat_AlreadyB64_NoChange(t *testing.T) {
+	body := []byte(
+		"--b\r\nContent-Disposition: form-data; name=\"response_format\"\r\n\r\nb64_json\r\n" +
+			"--b--\r\n",
+	)
+	orig, modified, err := rewriteMultipartResponseFormat(body)
+	if err != nil {
+		t.Fatalf("rewriteMultipartResponseFormat: %v", err)
+	}
+	if orig != "b64_json" {
+		t.Errorf("orig = %q, want b64_json", orig)
+	}
+	if string(modified) != string(body) {
+		t.Error("body should be byte-identical when already b64_json")
+	}
+}
+
+func TestRewriteMultipartResponseFormat_PreservesBinaryBytes(t *testing.T) {
+	binary := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0xFF, 0x00, 0xFF}
+	var body []byte
+	body = append(body, []byte("--b\r\nContent-Disposition: form-data; name=\"response_format\"\r\n\r\nurl\r\n")...)
+	body = append(body, []byte("--b\r\nContent-Disposition: form-data; name=\"image\"; filename=\"x.png\"\r\nContent-Type: image/png\r\n\r\n")...)
+	body = append(body, binary...)
+	body = append(body, []byte("\r\n--b--\r\n")...)
+
+	_, modified, err := rewriteMultipartResponseFormat(body)
+	if err != nil {
+		t.Fatalf("rewriteMultipartResponseFormat: %v", err)
+	}
+	// Binary image bytes must appear unchanged in the modified body.
+	if !bytesContains(modified, binary) {
+		t.Error("binary image bytes were corrupted by the rewrite")
+	}
+}
+
+func bytesContains(haystack, needle []byte) bool {
+	if len(needle) == 0 {
+		return true
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		match := true
+		for j := 0; j < len(needle); j++ {
+			if haystack[i+j] != needle[j] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}
+
+// ==========================================================================
 // buildURLResponse
 // ==========================================================================
 
-func TestBuildURLResponse_URLsContainChatKeyAndIndex(t *testing.T) {
-	img := []byte("pixels")
-	b64 := base64.StdEncoding.EncodeToString(img)
+func TestBuildURLResponse_PreservesMetadataFields(t *testing.T) {
+	b64 := base64.StdEncoding.EncodeToString([]byte("pixels"))
 	envelope := imageResponseEnvelope{
 		Created: 999,
 		Data: []imageResponseData{
@@ -171,11 +270,8 @@ func TestBuildURLResponse_URLsContainChatKeyAndIndex(t *testing.T) {
 		},
 	}
 	body, _ := json.Marshal(envelope)
-	chatKey := "chat-uuid-abc123"
-	req := httptest.NewRequest("POST", "/v1/proxy/images/generations", nil)
-	req.Host = "broker.example.com"
 
-	out, err := buildURLResponse(body, chatKey, 2, req)
+	out, err := buildURLResponse(body, "chat-uuid-abc123", 2, "https://broker.example.com")
 	if err != nil {
 		t.Fatalf("buildURLResponse: %v", err)
 	}
@@ -184,18 +280,9 @@ func TestBuildURLResponse_URLsContainChatKeyAndIndex(t *testing.T) {
 	if err := json.Unmarshal(out, &result); err != nil {
 		t.Fatalf("unmarshal result: %v", err)
 	}
-	if len(result.Data) != 2 {
-		t.Fatalf("len(data) = %d, want 2", len(result.Data))
-	}
 	for i, d := range result.Data {
 		if d.B64JSON != "" {
 			t.Errorf("data[%d].b64_json should be empty after URL rewrite, got %q", i, d.B64JSON)
-		}
-		if !strings.Contains(d.URL, chatKey) {
-			t.Errorf("data[%d].url %q should contain chatKey %q", i, d.URL, chatKey)
-		}
-		if !strings.HasSuffix(d.URL, "/"+strconv.Itoa(i)) {
-			t.Errorf("data[%d].url %q should end with index /%d", i, d.URL, i)
 		}
 	}
 	if result.Data[0].RevisedPrompt != "a fluffy cat" {
@@ -206,28 +293,79 @@ func TestBuildURLResponse_URLsContainChatKeyAndIndex(t *testing.T) {
 	}
 }
 
-func TestBuildURLResponse_HTTPScheme(t *testing.T) {
-	img := base64.StdEncoding.EncodeToString([]byte("px"))
-	body, _ := json.Marshal(imageResponseEnvelope{
-		Data: []imageResponseData{{B64JSON: img}},
-	})
-	req := httptest.NewRequest("POST", "/v1/proxy/images/generations", nil)
-	req.Host = "localhost:8080"
-	// req.TLS is nil → expect http://
-
-	out, err := buildURLResponse(body, "key", 1, req)
-	if err != nil {
-		t.Fatalf("buildURLResponse: %v", err)
-	}
-	var result imageResponseEnvelope
-	json.Unmarshal(out, &result)
-	if !strings.HasPrefix(result.Data[0].URL, "http://") {
-		t.Errorf("expected http:// scheme, got %q", result.Data[0].URL)
+func TestBuildURLResponse_InvalidJSON(t *testing.T) {
+	if _, err := buildURLResponse([]byte("{bad}"), "key", 1, "https://broker.example.com"); err == nil {
+		t.Error("expected error for invalid JSON, got nil")
 	}
 }
 
-func TestBuildURLResponse_InvalidJSON(t *testing.T) {
-	if _, err := buildURLResponse([]byte("{bad}"), "key", 1, httptest.NewRequest("POST", "/", nil)); err == nil {
-		t.Error("expected error for invalid JSON, got nil")
+// TestBuildURLResponse_UsesServingURL pins the scheme/host/path source:
+// broker-served image URLs are derived from service.servingUrl (the public URL
+// the provider registered on-chain), not from the incoming request. This is
+// what makes the rewrite correct behind a TLS-terminating ingress that doesn't
+// forward X-Forwarded-Proto.
+func TestBuildURLResponse_UsesServingURL(t *testing.T) {
+	body, _ := json.Marshal(imageResponseEnvelope{
+		Data: []imageResponseData{{B64JSON: base64.StdEncoding.EncodeToString([]byte("px"))}},
+	})
+
+	tests := []struct {
+		name       string
+		servingURL string
+		want       string
+	}{
+		{
+			name:       "https public URL",
+			servingURL: "https://compute-network-dev-99.integratenetwork.work",
+			want:       "https://compute-network-dev-99.integratenetwork.work/v1/proxy/images/k/0",
+		},
+		{
+			name:       "http local URL with port",
+			servingURL: "http://localhost:3080",
+			want:       "http://localhost:3080/v1/proxy/images/k/0",
+		},
+		{
+			name:       "trailing slash is normalised (no double /)",
+			servingURL: "https://broker.example.com/",
+			want:       "https://broker.example.com/v1/proxy/images/k/0",
+		},
+		{
+			name:       "path prefix is preserved",
+			servingURL: "https://edge.example.com/provider-42",
+			want:       "https://edge.example.com/provider-42/v1/proxy/images/k/0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := buildURLResponse(body, "k", 1, tt.servingURL)
+			if err != nil {
+				t.Fatalf("buildURLResponse: %v", err)
+			}
+			var result imageResponseEnvelope
+			if err := json.Unmarshal(out, &result); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if result.Data[0].URL != tt.want {
+				t.Errorf("URL = %q, want %q", result.Data[0].URL, tt.want)
+			}
+		})
+	}
+}
+
+// TestBuildURLResponse_RejectsInvalidServingURL ensures the caller falls back
+// to b64 (its only error path) when servingUrl is missing or malformed, rather
+// than emitting a broken URL.
+func TestBuildURLResponse_RejectsInvalidServingURL(t *testing.T) {
+	body, _ := json.Marshal(imageResponseEnvelope{
+		Data: []imageResponseData{{B64JSON: base64.StdEncoding.EncodeToString([]byte("px"))}},
+	})
+
+	for _, servingURL := range []string{"", "not-a-url", "//no-scheme.example.com", "https://"} {
+		t.Run("servingURL="+servingURL, func(t *testing.T) {
+			if _, err := buildURLResponse(body, "k", 1, servingURL); err == nil {
+				t.Errorf("expected error for servingUrl %q, got nil", servingURL)
+			}
+		})
 	}
 }

--- a/api/inference/internal/ctrl/text_to_image_test.go
+++ b/api/inference/internal/ctrl/text_to_image_test.go
@@ -215,10 +215,12 @@ func TestRewriteMultipartResponseFormat_RewritesURLToB64(t *testing.T) {
 }
 
 // TestRewriteMultipartResponseFormat_FieldAbsent_InjectsB64 pins the absent-
-// field leak fix: OpenAI's default for /v1/images/edits is "url", so a client
-// that omits response_format would cause the provider to return LAN-private
-// URLs. The rewriter must inject response_format=b64_json and report the
-// original format as "url" so the handler still runs the URL-rewrite path.
+// field leak fix and the broker's chosen default: when the client omits the
+// field, the broker MUST force b64_json upstream (otherwise the provider
+// returns LAN-private URLs), AND it reports originalFormat="" so the handler
+// passes the b64 body through. Diverges from OpenAI's per-endpoint default
+// (which is "url" for /v1/images/edits), by design — matches the JSON path's
+// behaviour so clients see consistent defaults regardless of transport.
 func TestRewriteMultipartResponseFormat_FieldAbsent_InjectsB64(t *testing.T) {
 	body := []byte(
 		"--b\r\nContent-Disposition: form-data; name=\"prompt\"\r\n\r\nhello\r\n" +
@@ -229,8 +231,8 @@ func TestRewriteMultipartResponseFormat_FieldAbsent_InjectsB64(t *testing.T) {
 	if err != nil {
 		t.Fatalf("rewriteMultipartResponseFormat: %v", err)
 	}
-	if orig != "url" {
-		t.Errorf("original format = %q, want url (OpenAI default for absent field)", orig)
+	if orig != "" {
+		t.Errorf("original format = %q, want \"\" (broker default is b64 across JSON + multipart)", orig)
 	}
 	if !strings.Contains(string(modified), "name=\"response_format\"\r\n\r\nb64_json") {
 		t.Errorf("injected response_format part missing:\n%s", modified)
@@ -419,6 +421,26 @@ func TestBuildURLResponse_PreservesMetadataFields(t *testing.T) {
 func TestBuildURLResponse_InvalidJSON(t *testing.T) {
 	if _, err := buildURLResponse([]byte("{bad}"), "key", 1, "https://broker.example.com"); err == nil {
 		t.Error("expected error for invalid JSON, got nil")
+	}
+}
+
+// TestBuildURLResponse_RejectsEnvelopeCountMismatch pins the guard against
+// emitting a mixed b64/url envelope: if the provider's data array has more
+// (or fewer) entries than the images we actually stored, the function MUST
+// refuse rather than leave tail entries in b64 form. Caller downgrades on
+// error, which is the safer failure mode.
+func TestBuildURLResponse_RejectsEnvelopeCountMismatch(t *testing.T) {
+	b64 := base64.StdEncoding.EncodeToString([]byte("px"))
+	// Envelope advertises THREE images but the caller only stored TWO.
+	body, _ := json.Marshal(imageResponseEnvelope{
+		Data: []imageResponseData{
+			{B64JSON: b64},
+			{B64JSON: b64},
+			{B64JSON: b64},
+		},
+	})
+	if _, err := buildURLResponse(body, "k", 2, "https://broker.example.com"); err == nil {
+		t.Error("expected error when envelope length != stored image count, got nil")
 	}
 }
 

--- a/api/inference/internal/ctrl/text_to_image_test.go
+++ b/api/inference/internal/ctrl/text_to_image_test.go
@@ -84,6 +84,48 @@ func TestExtractB64Images_InvalidJSON(t *testing.T) {
 	}
 }
 
+// TestExtractB64Images_RejectsOversizedImage pins the per-image byte cap.
+// Without it, a compromised provider could return a single multi-hundred-MB
+// b64_json blob: the upstream body would be buffered by io.ReadAll, decoded
+// into memory by extractB64Images, and then written to disk — amplifying one
+// request into a multi-hundred-MB allocation. The encoded-length pre-check
+// fires BEFORE base64 decode so we never allocate the decode buffer for
+// oversized inputs.
+func TestExtractB64Images_RejectsOversizedImage(t *testing.T) {
+	// Build a b64 string longer than the encoded cap. The actual contents
+	// don't matter — the size check runs before decode.
+	overSized := strings.Repeat("A", base64.StdEncoding.EncodedLen(maxB64ImageBytes)+4)
+	body, _ := json.Marshal(imageResponseEnvelope{
+		Data: []imageResponseData{{B64JSON: overSized}},
+	})
+
+	_, err := extractB64Images(body, 1)
+	if err == nil {
+		t.Fatal("expected error for oversized b64_json blob, got nil")
+	}
+	if !strings.Contains(err.Error(), "exceeds per-image cap") {
+		t.Errorf("error should mention the per-image cap; got: %v", err)
+	}
+}
+
+// TestExtractB64Images_AcceptsAtCap confirms the cap is inclusive of normal-
+// sized images. A small image well under the threshold must round-trip
+// successfully — the size check should not regress the happy path.
+func TestExtractB64Images_AcceptsAtCap(t *testing.T) {
+	img := []byte("small-image-bytes-well-under-cap")
+	body, _ := json.Marshal(imageResponseEnvelope{
+		Data: []imageResponseData{{B64JSON: base64.StdEncoding.EncodeToString(img)}},
+	})
+
+	images, err := extractB64Images(body, 1)
+	if err != nil {
+		t.Fatalf("extractB64Images: %v", err)
+	}
+	if len(images) != 1 || string(images[0]) != string(img) {
+		t.Errorf("round-trip mismatch: got %q", images[0])
+	}
+}
+
 // TestExtractB64Images_RejectsMoreThanRequested pins the provider-OOM guard:
 // a compromised provider returning 50 images when the client asked for 1 is
 // a billing bug AND a memory risk (all 50 b64 blobs would be decoded). The

--- a/api/inference/internal/ctrl/text_to_image_test.go
+++ b/api/inference/internal/ctrl/text_to_image_test.go
@@ -108,10 +108,10 @@ func TestExtractB64Images_RejectsOversizedImage(t *testing.T) {
 	}
 }
 
-// TestExtractB64Images_AcceptsAtCap confirms the cap is inclusive of normal-
-// sized images. A small image well under the threshold must round-trip
-// successfully — the size check should not regress the happy path.
-func TestExtractB64Images_AcceptsAtCap(t *testing.T) {
+// TestExtractB64Images_AcceptsBelowCap confirms the size check does not
+// regress the happy path: a normal-sized image well under maxB64ImageBytes
+// must round-trip successfully.
+func TestExtractB64Images_AcceptsBelowCap(t *testing.T) {
 	img := []byte("small-image-bytes-well-under-cap")
 	body, _ := json.Marshal(imageResponseEnvelope{
 		Data: []imageResponseData{{B64JSON: base64.StdEncoding.EncodeToString(img)}},

--- a/api/inference/internal/ctrl/text_to_image_test.go
+++ b/api/inference/internal/ctrl/text_to_image_test.go
@@ -27,7 +27,7 @@ func TestExtractB64Images_HappyPath(t *testing.T) {
 	}
 	body, _ := json.Marshal(envelope)
 
-	images, err := extractB64Images(body)
+	images, err := extractB64Images(body, 2)
 	if err != nil {
 		t.Fatalf("extractB64Images: %v", err)
 	}
@@ -47,7 +47,7 @@ func TestExtractB64Images_SingleImage(t *testing.T) {
 	body, _ := json.Marshal(imageResponseEnvelope{
 		Data: []imageResponseData{{B64JSON: base64.StdEncoding.EncodeToString(img)}},
 	})
-	images, err := extractB64Images(body)
+	images, err := extractB64Images(body, 1)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -60,27 +60,53 @@ func TestExtractB64Images_URLOnly_ReturnsError(t *testing.T) {
 	body, _ := json.Marshal(imageResponseEnvelope{
 		Data: []imageResponseData{{URL: "http://provider/img.png"}},
 	})
-	if _, err := extractB64Images(body); err == nil {
+	if _, err := extractB64Images(body, 1); err == nil {
 		t.Error("expected error for URL-only response, got nil")
 	}
 }
 
 func TestExtractB64Images_EmptyData(t *testing.T) {
-	if _, err := extractB64Images([]byte(`{"created":1,"data":[]}`)); err == nil {
+	if _, err := extractB64Images([]byte(`{"created":1,"data":[]}`), 1); err == nil {
 		t.Error("expected error for empty data array")
 	}
 }
 
 func TestExtractB64Images_BadBase64(t *testing.T) {
 	body := []byte(`{"created":1,"data":[{"b64_json":"!!!not-valid-base64!!!"}]}`)
-	if _, err := extractB64Images(body); err == nil {
+	if _, err := extractB64Images(body, 1); err == nil {
 		t.Error("expected error for invalid base64")
 	}
 }
 
 func TestExtractB64Images_InvalidJSON(t *testing.T) {
-	if _, err := extractB64Images([]byte("{not json}")); err == nil {
+	if _, err := extractB64Images([]byte("{not json}"), 1); err == nil {
 		t.Error("expected error for invalid JSON")
+	}
+}
+
+// TestExtractB64Images_RejectsMoreThanRequested pins the provider-OOM guard:
+// a compromised provider returning 50 images when the client asked for 1 is
+// a billing bug AND a memory risk (all 50 b64 blobs would be decoded). The
+// extractor must refuse before decoding anything past the cap.
+func TestExtractB64Images_RejectsMoreThanRequested(t *testing.T) {
+	img := base64.StdEncoding.EncodeToString([]byte("px"))
+	many := make([]imageResponseData, 50)
+	for i := range many {
+		many[i] = imageResponseData{B64JSON: img}
+	}
+	body, _ := json.Marshal(imageResponseEnvelope{Data: many})
+
+	// Client asked for 1 (maxImages=1); provider returned 50 → error.
+	if _, err := extractB64Images(body, 1); err == nil {
+		t.Error("expected error when envelope exceeds maxImages, got nil")
+	}
+	// Same body with a permissive cap (test-only usage) decodes fine.
+	if _, err := extractB64Images(body, 100); err != nil {
+		t.Errorf("permissive cap must not reject: %v", err)
+	}
+	// maxImages <= 0 disables the cap (tests only).
+	if _, err := extractB64Images(body, 0); err != nil {
+		t.Errorf("maxImages=0 should disable the cap, got: %v", err)
 	}
 }
 

--- a/api/inference/internal/ctrl/text_to_image_test.go
+++ b/api/inference/internal/ctrl/text_to_image_test.go
@@ -1,0 +1,233 @@
+package ctrl
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// ==========================================================================
+// extractB64Images
+// ==========================================================================
+
+func TestExtractB64Images_HappyPath(t *testing.T) {
+	img0 := []byte("fake-png-bytes-zero")
+	img1 := []byte("fake-png-bytes-one")
+	envelope := imageResponseEnvelope{
+		Created: 1000,
+		Data: []imageResponseData{
+			{B64JSON: base64.StdEncoding.EncodeToString(img0)},
+			{B64JSON: base64.StdEncoding.EncodeToString(img1)},
+		},
+	}
+	body, _ := json.Marshal(envelope)
+
+	images, err := extractB64Images(body)
+	if err != nil {
+		t.Fatalf("extractB64Images: %v", err)
+	}
+	if len(images) != 2 {
+		t.Fatalf("len(images) = %d, want 2", len(images))
+	}
+	if string(images[0]) != string(img0) {
+		t.Errorf("image[0] = %q, want %q", images[0], img0)
+	}
+	if string(images[1]) != string(img1) {
+		t.Errorf("image[1] = %q, want %q", images[1], img1)
+	}
+}
+
+func TestExtractB64Images_SingleImage(t *testing.T) {
+	img := []byte("single-image-data")
+	body, _ := json.Marshal(imageResponseEnvelope{
+		Data: []imageResponseData{{B64JSON: base64.StdEncoding.EncodeToString(img)}},
+	})
+	images, err := extractB64Images(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(images) != 1 {
+		t.Fatalf("len(images) = %d, want 1", len(images))
+	}
+}
+
+func TestExtractB64Images_URLOnly_ReturnsError(t *testing.T) {
+	body, _ := json.Marshal(imageResponseEnvelope{
+		Data: []imageResponseData{{URL: "http://provider/img.png"}},
+	})
+	if _, err := extractB64Images(body); err == nil {
+		t.Error("expected error for URL-only response, got nil")
+	}
+}
+
+func TestExtractB64Images_EmptyData(t *testing.T) {
+	if _, err := extractB64Images([]byte(`{"created":1,"data":[]}`)); err == nil {
+		t.Error("expected error for empty data array")
+	}
+}
+
+func TestExtractB64Images_BadBase64(t *testing.T) {
+	body := []byte(`{"created":1,"data":[{"b64_json":"!!!not-valid-base64!!!"}]}`)
+	if _, err := extractB64Images(body); err == nil {
+		t.Error("expected error for invalid base64")
+	}
+}
+
+func TestExtractB64Images_InvalidJSON(t *testing.T) {
+	if _, err := extractB64Images([]byte("{not json}")); err == nil {
+		t.Error("expected error for invalid JSON")
+	}
+}
+
+// ==========================================================================
+// forceB64ResponseFormat
+// ==========================================================================
+
+func TestForceB64ResponseFormat_RewritesURLToB64(t *testing.T) {
+	body := []byte(`{"prompt":"a cat","response_format":"url","n":2}`)
+
+	orig, modified, err := forceB64ResponseFormat(body)
+	if err != nil {
+		t.Fatalf("forceB64ResponseFormat: %v", err)
+	}
+	if orig != "url" {
+		t.Errorf("original format = %q, want url", orig)
+	}
+
+	var m map[string]interface{}
+	if err := json.Unmarshal(modified, &m); err != nil {
+		t.Fatalf("unmarshal modified body: %v", err)
+	}
+	if m["response_format"] != "b64_json" {
+		t.Errorf("response_format = %v, want b64_json", m["response_format"])
+	}
+	// Other fields must be preserved.
+	if m["prompt"] != "a cat" {
+		t.Errorf("prompt field should be preserved, got %v", m["prompt"])
+	}
+}
+
+func TestForceB64ResponseFormat_AddsFieldWhenAbsent(t *testing.T) {
+	body := []byte(`{"prompt":"a dog","n":1}`)
+
+	orig, modified, err := forceB64ResponseFormat(body)
+	if err != nil {
+		t.Fatalf("forceB64ResponseFormat: %v", err)
+	}
+	if orig != "" {
+		t.Errorf("original format = %q, want empty", orig)
+	}
+
+	var m map[string]interface{}
+	json.Unmarshal(modified, &m)
+	if m["response_format"] != "b64_json" {
+		t.Errorf("response_format should be added as b64_json, got %v", m["response_format"])
+	}
+}
+
+func TestForceB64ResponseFormat_AlreadyB64_NoChange(t *testing.T) {
+	body := []byte(`{"prompt":"x","response_format":"b64_json"}`)
+	orig, modified, err := forceB64ResponseFormat(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if orig != "b64_json" {
+		t.Errorf("orig = %q, want b64_json", orig)
+	}
+	var m map[string]interface{}
+	json.Unmarshal(modified, &m)
+	if m["response_format"] != "b64_json" {
+		t.Errorf("response_format = %v, want b64_json", m["response_format"])
+	}
+}
+
+func TestForceB64ResponseFormat_NonJSON_ReturnsError(t *testing.T) {
+	multipart := []byte("--boundary\r\nContent-Disposition: form-data; name=\"prompt\"\r\n\r\nhello\r\n--boundary--")
+	_, got, err := forceB64ResponseFormat(multipart)
+	if err == nil {
+		t.Error("expected error for non-JSON body, got nil")
+	}
+	// Original body returned unchanged on error.
+	if string(got) != string(multipart) {
+		t.Errorf("expected original multipart body returned on error")
+	}
+}
+
+// ==========================================================================
+// buildURLResponse
+// ==========================================================================
+
+func TestBuildURLResponse_URLsContainChatKeyAndIndex(t *testing.T) {
+	img := []byte("pixels")
+	b64 := base64.StdEncoding.EncodeToString(img)
+	envelope := imageResponseEnvelope{
+		Created: 999,
+		Data: []imageResponseData{
+			{B64JSON: b64, RevisedPrompt: "a fluffy cat"},
+			{B64JSON: b64},
+		},
+	}
+	body, _ := json.Marshal(envelope)
+	chatKey := "chat-uuid-abc123"
+	req := httptest.NewRequest("POST", "/v1/proxy/images/generations", nil)
+	req.Host = "broker.example.com"
+
+	out, err := buildURLResponse(body, chatKey, 2, req)
+	if err != nil {
+		t.Fatalf("buildURLResponse: %v", err)
+	}
+
+	var result imageResponseEnvelope
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if len(result.Data) != 2 {
+		t.Fatalf("len(data) = %d, want 2", len(result.Data))
+	}
+	for i, d := range result.Data {
+		if d.B64JSON != "" {
+			t.Errorf("data[%d].b64_json should be empty after URL rewrite, got %q", i, d.B64JSON)
+		}
+		if !strings.Contains(d.URL, chatKey) {
+			t.Errorf("data[%d].url %q should contain chatKey %q", i, d.URL, chatKey)
+		}
+		if !strings.HasSuffix(d.URL, "/"+strconv.Itoa(i)) {
+			t.Errorf("data[%d].url %q should end with index /%d", i, d.URL, i)
+		}
+	}
+	if result.Data[0].RevisedPrompt != "a fluffy cat" {
+		t.Errorf("revised_prompt should be preserved, got %q", result.Data[0].RevisedPrompt)
+	}
+	if result.Created != 999 {
+		t.Errorf("created should be preserved, got %d", result.Created)
+	}
+}
+
+func TestBuildURLResponse_HTTPScheme(t *testing.T) {
+	img := base64.StdEncoding.EncodeToString([]byte("px"))
+	body, _ := json.Marshal(imageResponseEnvelope{
+		Data: []imageResponseData{{B64JSON: img}},
+	})
+	req := httptest.NewRequest("POST", "/v1/proxy/images/generations", nil)
+	req.Host = "localhost:8080"
+	// req.TLS is nil → expect http://
+
+	out, err := buildURLResponse(body, "key", 1, req)
+	if err != nil {
+		t.Fatalf("buildURLResponse: %v", err)
+	}
+	var result imageResponseEnvelope
+	json.Unmarshal(out, &result)
+	if !strings.HasPrefix(result.Data[0].URL, "http://") {
+		t.Errorf("expected http:// scheme, got %q", result.Data[0].URL)
+	}
+}
+
+func TestBuildURLResponse_InvalidJSON(t *testing.T) {
+	if _, err := buildURLResponse([]byte("{bad}"), "key", 1, httptest.NewRequest("POST", "/", nil)); err == nil {
+		t.Error("expected error for invalid JSON, got nil")
+	}
+}

--- a/api/inference/internal/ctrl/text_to_image_test.go
+++ b/api/inference/internal/ctrl/text_to_image_test.go
@@ -154,6 +154,28 @@ func TestForceB64ResponseFormat_NonJSON_ReturnsError(t *testing.T) {
 	}
 }
 
+// TestForceB64ResponseFormat_PreservesLargeIntegers pins the UseNumber fix: a
+// seed > 2^53 would be silently coerced to float64 and emitted in exponential
+// notation if we decoded without json.Number. The signed body is pre-rewrite
+// so this doesn't affect TEE proofs today, but a provider that echoes numeric
+// parameters would see corrupted seeds.
+func TestForceB64ResponseFormat_PreservesLargeIntegers(t *testing.T) {
+	// 2^53 + 1 is the smallest positive integer that float64 cannot represent exactly.
+	const bigSeed = `9007199254740993`
+	body := []byte(`{"prompt":"cat","seed":` + bigSeed + `,"response_format":"url"}`)
+
+	_, modified, err := forceB64ResponseFormat(body)
+	if err != nil {
+		t.Fatalf("forceB64ResponseFormat: %v", err)
+	}
+	if !strings.Contains(string(modified), bigSeed) {
+		t.Errorf("large integer seed not preserved; got body: %s", modified)
+	}
+	if strings.Contains(string(modified), "9.007") || strings.Contains(string(modified), "e+") {
+		t.Errorf("seed was coerced to float64 exponential form: %s", modified)
+	}
+}
+
 // ==========================================================================
 // rewriteMultipartResponseFormat
 // ==========================================================================

--- a/api/inference/internal/ctrl/text_to_image_test.go
+++ b/api/inference/internal/ctrl/text_to_image_test.go
@@ -1,8 +1,12 @@
 package ctrl
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/json"
+	"io"
+	"mime"
+	"mime/multipart"
 	"strings"
 	"testing"
 )
@@ -127,7 +131,10 @@ func TestForceB64ResponseFormat_AddsFieldWhenAbsent(t *testing.T) {
 }
 
 func TestForceB64ResponseFormat_AlreadyB64_NoChange(t *testing.T) {
-	body := []byte(`{"prompt":"x","response_format":"b64_json"}`)
+	// Use a key-ordering the Go map remarshaller would definitely change
+	// (`z_last` after `a_first`, with response_format deliberately in the
+	// middle) so if the fast path regresses we'd see a different byte order.
+	body := []byte(`{"a_first":1,"response_format":"b64_json","z_last":"tail"}`)
 	orig, modified, err := forceB64ResponseFormat(body)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -135,10 +142,9 @@ func TestForceB64ResponseFormat_AlreadyB64_NoChange(t *testing.T) {
 	if orig != "b64_json" {
 		t.Errorf("orig = %q, want b64_json", orig)
 	}
-	var m map[string]interface{}
-	json.Unmarshal(modified, &m)
-	if m["response_format"] != "b64_json" {
-		t.Errorf("response_format = %v, want b64_json", m["response_format"])
+	// Fast path must return the input bytes verbatim (no remarshal).
+	if string(modified) != string(body) {
+		t.Errorf("fast path must return body byte-for-byte.\n got:  %s\nwant: %s", modified, body)
 	}
 }
 
@@ -180,6 +186,8 @@ func TestForceB64ResponseFormat_PreservesLargeIntegers(t *testing.T) {
 // rewriteMultipartResponseFormat
 // ==========================================================================
 
+const multipartCT = `multipart/form-data; boundary=b`
+
 func TestRewriteMultipartResponseFormat_RewritesURLToB64(t *testing.T) {
 	body := []byte(
 		"--b\r\nContent-Disposition: form-data; name=\"prompt\"\r\n\r\nhello\r\n" +
@@ -187,7 +195,7 @@ func TestRewriteMultipartResponseFormat_RewritesURLToB64(t *testing.T) {
 			"--b--\r\n",
 	)
 
-	orig, modified, err := rewriteMultipartResponseFormat(body)
+	orig, modified, err := rewriteMultipartResponseFormat(body, multipartCT)
 	if err != nil {
 		t.Fatalf("rewriteMultipartResponseFormat: %v", err)
 	}
@@ -206,21 +214,47 @@ func TestRewriteMultipartResponseFormat_RewritesURLToB64(t *testing.T) {
 	}
 }
 
-func TestRewriteMultipartResponseFormat_FieldAbsent_NoOp(t *testing.T) {
+// TestRewriteMultipartResponseFormat_FieldAbsent_InjectsB64 pins the absent-
+// field leak fix: OpenAI's default for /v1/images/edits is "url", so a client
+// that omits response_format would cause the provider to return LAN-private
+// URLs. The rewriter must inject response_format=b64_json and report the
+// original format as "url" so the handler still runs the URL-rewrite path.
+func TestRewriteMultipartResponseFormat_FieldAbsent_InjectsB64(t *testing.T) {
 	body := []byte(
 		"--b\r\nContent-Disposition: form-data; name=\"prompt\"\r\n\r\nhello\r\n" +
 			"--b--\r\n",
 	)
 
-	orig, modified, err := rewriteMultipartResponseFormat(body)
+	orig, modified, err := rewriteMultipartResponseFormat(body, multipartCT)
 	if err != nil {
 		t.Fatalf("rewriteMultipartResponseFormat: %v", err)
 	}
-	if orig != "" {
-		t.Errorf("original format = %q, want empty", orig)
+	if orig != "url" {
+		t.Errorf("original format = %q, want url (OpenAI default for absent field)", orig)
 	}
-	if string(modified) != string(body) {
-		t.Error("body should be unchanged when response_format is absent")
+	if !strings.Contains(string(modified), "name=\"response_format\"\r\n\r\nb64_json") {
+		t.Errorf("injected response_format part missing:\n%s", modified)
+	}
+	// Prompt part must still be present.
+	if !strings.Contains(string(modified), "name=\"prompt\"\r\n\r\nhello") {
+		t.Error("modified body should preserve the prompt part")
+	}
+	// Closing boundary must still terminate the body.
+	if !strings.HasSuffix(string(modified), "--b--\r\n") {
+		t.Errorf("modified body must end with closing boundary, got suffix: %q", string(modified)[len(modified)-20:])
+	}
+	// The new part must be placed BEFORE the closing delimiter (not after).
+	closeIdx := strings.Index(string(modified), "\r\n--b--\r\n")
+	injectIdx := strings.Index(string(modified), "name=\"response_format\"")
+	if injectIdx < 0 || injectIdx >= closeIdx {
+		t.Errorf("injected part must sit before closing boundary: injectIdx=%d closeIdx=%d", injectIdx, closeIdx)
+	}
+}
+
+func TestRewriteMultipartResponseFormat_FieldAbsent_RejectsMissingBoundary(t *testing.T) {
+	body := []byte("--b\r\nContent-Disposition: form-data; name=\"prompt\"\r\n\r\nhi\r\n--b--\r\n")
+	if _, _, err := rewriteMultipartResponseFormat(body, "multipart/form-data"); err == nil {
+		t.Error("expected error when content-type has no boundary")
 	}
 }
 
@@ -229,7 +263,7 @@ func TestRewriteMultipartResponseFormat_AlreadyB64_NoChange(t *testing.T) {
 		"--b\r\nContent-Disposition: form-data; name=\"response_format\"\r\n\r\nb64_json\r\n" +
 			"--b--\r\n",
 	)
-	orig, modified, err := rewriteMultipartResponseFormat(body)
+	orig, modified, err := rewriteMultipartResponseFormat(body, multipartCT)
 	if err != nil {
 		t.Fatalf("rewriteMultipartResponseFormat: %v", err)
 	}
@@ -241,6 +275,73 @@ func TestRewriteMultipartResponseFormat_AlreadyB64_NoChange(t *testing.T) {
 	}
 }
 
+// TestRewriteMultipartResponseFormat_AdversarialFilePayload pins the fix to
+// the byte-scanner vulnerability: a file part whose body contains the literal
+// string `name="response_format"` plus a fake boundary terminator used to
+// anchor the old bytes.Index scanner on the wrong location, corrupting the
+// uploaded file bytes. The mime/multipart.Reader respects boundaries, so the
+// adversarial substring inside a file part is ignored entirely.
+func TestRewriteMultipartResponseFormat_AdversarialFilePayload(t *testing.T) {
+	// File body deliberately contains the marker the old byte scanner searched
+	// for AND a \r\n-- sequence it used as the value-end anchor. The suffix
+	// "--XYZ" is NOT the real boundary "b", so a real multipart reader keeps
+	// these bytes inside the file part; the old byte scanner would treat them
+	// as a form-field terminator and splice "adversarial" as the value.
+	adversarial := []byte(
+		"PNG-HEADER" +
+			"name=\"response_format\"\r\n\r\nadversarial\r\n--XYZ " +
+			"more-bytes-after",
+	)
+	// File FIRST so its adversarial bytes come before the legitimate
+	// response_format field. The old byte scanner did bytes.Index over the
+	// whole body and would match the name="response_format" substring INSIDE
+	// this file part, then splice "adversarial" as the value — corrupting
+	// the file on readback.
+	var body []byte
+	body = append(body, []byte("--b\r\nContent-Disposition: form-data; name=\"image\"; filename=\"x.bin\"\r\nContent-Type: application/octet-stream\r\n\r\n")...)
+	body = append(body, adversarial...)
+	body = append(body, []byte("\r\n--b\r\nContent-Disposition: form-data; name=\"prompt\"\r\n\r\nhello\r\n")...)
+	body = append(body, []byte("--b\r\nContent-Disposition: form-data; name=\"response_format\"\r\n\r\nurl\r\n")...)
+	body = append(body, []byte("--b--\r\n")...)
+
+	orig, modified, err := rewriteMultipartResponseFormat(body, multipartCT)
+	if err != nil {
+		t.Fatalf("rewriteMultipartResponseFormat: %v", err)
+	}
+	if orig != "url" {
+		t.Errorf("original format = %q, want url", orig)
+	}
+
+	// Decode the output and confirm: the response_format part was rewritten to
+	// b64_json, AND the adversarial file bytes survived verbatim.
+	_, params, _ := mime.ParseMediaType(multipartCT)
+	reader := multipart.NewReader(bytes.NewReader(modified), params["boundary"])
+	seenResponseFormat := false
+	seenImageVerbatim := false
+	for {
+		part, err := reader.NextPart()
+		if err != nil {
+			break
+		}
+		partBody, _ := io.ReadAll(part)
+		switch part.FormName() {
+		case "response_format":
+			seenResponseFormat = true
+			if string(partBody) != "b64_json" {
+				t.Errorf("response_format part = %q, want b64_json", partBody)
+			}
+		case "image":
+			seenImageVerbatim = bytes.Equal(partBody, adversarial)
+		}
+	}
+	if !seenResponseFormat {
+		t.Error("response_format part missing from rewritten body")
+	}
+	if !seenImageVerbatim {
+		t.Error("adversarial file bytes were corrupted — the byte scanner bug regressed")
+	}
+}
+
 func TestRewriteMultipartResponseFormat_PreservesBinaryBytes(t *testing.T) {
 	binary := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0xFF, 0x00, 0xFF}
 	var body []byte
@@ -249,7 +350,7 @@ func TestRewriteMultipartResponseFormat_PreservesBinaryBytes(t *testing.T) {
 	body = append(body, binary...)
 	body = append(body, []byte("\r\n--b--\r\n")...)
 
-	_, modified, err := rewriteMultipartResponseFormat(body)
+	_, modified, err := rewriteMultipartResponseFormat(body, multipartCT)
 	if err != nil {
 		t.Fatalf("rewriteMultipartResponseFormat: %v", err)
 	}

--- a/api/inference/internal/proxy/proxy.go
+++ b/api/inference/internal/proxy/proxy.go
@@ -40,6 +40,12 @@ type Proxy struct {
 	perUserRateLimiter        *middleware.PerUserRateLimiter
 	perUserTPMLimiter         *middleware.PerUserTPMLimiter
 	perUserIPMLimiter         *middleware.PerUserTPMLimiter
+	// imageServeLimiter throttles the unauthenticated /v1/proxy/images/{key}/{i}
+	// endpoint per-client-IP. The endpoint bypasses session auth (UUID-as-token
+	// model), so a bandwidth-amplification bound is the only defence against a
+	// caller hammering a single chatKey. Reuses PerUserRateLimiter with IP as
+	// the key — see handleImageServeRoute.
+	imageServeLimiter *middleware.PerUserRateLimiter
 }
 
 func New(ctrl *ctrl.Ctrl, engine *gin.Engine, allowOrigins []string, enableMonitor bool, concurrencyConfig config.ConcurrencyLimitConfig, logger log.Logger) *Proxy {
@@ -110,6 +116,14 @@ func New(ctrl *ctrl.Ctrl, engine *gin.Engine, allowOrigins []string, enableMonit
 		p.perUserIPMLimiter = middleware.NewPerUserTPMLimiter(concurrencyConfig.PerUserIPM, ipmBurst)
 		logger.Infof("Per-user image limit: %d IPM, burst=%d", concurrencyConfig.PerUserIPM, ipmBurst)
 	}
+
+	// Per-IP limit for the unauthenticated image-serve route. Chosen loose so
+	// legitimate browser tabs re-fetching a few images do not trip: 120 RPM
+	// with a 30-request burst. Bandwidth-amplification is bounded at roughly
+	// 120 * image_size per IP per minute; tighten via config if ever needed.
+	// Keyed by client IP; the IP field lives outside the per-user keyspace so
+	// it never starves user-scoped limits.
+	p.imageServeLimiter = middleware.NewPerUserRateLimiter(120, 30)
 
 	logger.Infof("Concurrency limits: global=%d, per-user=%d",
 		concurrencyConfig.MaxGlobalConcurrent, concurrencyConfig.MaxPerUserConcurrent)
@@ -603,6 +617,16 @@ func (p *Proxy) handleImageServeRoute(ctx *gin.Context, targetPath string) bool 
 	if ctx.Request.Method != http.MethodGet && ctx.Request.Method != http.MethodHead {
 		ctx.Header("Allow", "GET, HEAD")
 		ctx.JSON(http.StatusMethodNotAllowed, gin.H{"error": "method not allowed"})
+		return true
+	}
+	// Per-IP rate limit. The route has no session auth — without a throttle a
+	// single caller with one UUID could hammer the endpoint to amplify
+	// bandwidth. ClientIP honours X-Forwarded-For only when gin's trusted
+	// proxies list accepts the direct peer; otherwise it falls back to the
+	// socket's remote address, which is the right thing for a direct client.
+	if p.imageServeLimiter != nil && !p.imageServeLimiter.Allow(ctx.ClientIP()) {
+		ctx.Header("Retry-After", "1")
+		ctx.JSON(http.StatusTooManyRequests, gin.H{"error": "rate limit exceeded on image serve endpoint"})
 		return true
 	}
 	// Parse /images/{chatKey}/{index}; must have exactly two path segments.

--- a/api/inference/internal/proxy/proxy.go
+++ b/api/inference/internal/proxy/proxy.go
@@ -579,13 +579,31 @@ func (p *Proxy) proxyHTTPRequest(ctx *gin.Context) {
 }
 
 // handleImageServeRoute serves broker-stored image bytes at
-// /images/{chatKey}/{index}.  The chatKey is a UUID issued in ZG-Res-Key, so
-// only the requester who received it can derive the URL.  No session auth is
+// /images/{chatKey}/{index}. The chatKey is a UUID issued in ZG-Res-Key, so
+// only the requester who received it can derive the URL. No session auth is
 // required (the UUID itself is the access token), matching OpenAI's CDN URL
-// behaviour.  Returns true if the request was handled (including error cases).
+// behaviour.
+//
+// This path runs BEFORE FreePrefixes evaluation and has no billing or rate-
+// limit middleware attached — by design, a browser must be able to GET these
+// URLs without bearer auth. The security argument is that the chatKey is an
+// unguessable UUID; anyone with it can refetch repeatedly. If abuse becomes a
+// concern (repeated fetches of the same chatKey amplifying bandwidth), add a
+// per-IP or per-chatKey rate limiter at this callsite — don't rely on the
+// upstream RPM/TPM limiter, which runs on a different path.
+//
+// Returns true if the request was handled (including error cases).
 func (p *Proxy) handleImageServeRoute(ctx *gin.Context, targetPath string) bool {
 	if !strings.HasPrefix(strings.ToLower(targetPath), "/images/") {
 		return false
+	}
+	// GET (and HEAD for byte-range probes) only. A POST/PUT/DELETE here would
+	// have been silently 200-and-served before; reject it explicitly so that a
+	// future route collision at the same path doesn't mask a real handler.
+	if ctx.Request.Method != http.MethodGet && ctx.Request.Method != http.MethodHead {
+		ctx.Header("Allow", "GET, HEAD")
+		ctx.JSON(http.StatusMethodNotAllowed, gin.H{"error": "method not allowed"})
+		return true
 	}
 	// Parse /images/{chatKey}/{index}; must have exactly two path segments.
 	rest := strings.TrimPrefix(targetPath, "/images/")

--- a/api/inference/internal/proxy/proxy.go
+++ b/api/inference/internal/proxy/proxy.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"strconv"
 	"strings"
@@ -621,10 +622,18 @@ func (p *Proxy) handleImageServeRoute(ctx *gin.Context, targetPath string) bool 
 	}
 	// Per-IP rate limit. The route has no session auth — without a throttle a
 	// single caller with one UUID could hammer the endpoint to amplify
-	// bandwidth. ClientIP honours X-Forwarded-For only when gin's trusted
-	// proxies list accepts the direct peer; otherwise it falls back to the
-	// socket's remote address, which is the right thing for a direct client.
-	if p.imageServeLimiter != nil && !p.imageServeLimiter.Allow(ctx.ClientIP()) {
+	// bandwidth. Key off the socket's RemoteAddr, NOT ctx.ClientIP(): gin's
+	// default trusted-proxy list is permissive, so ClientIP honours a
+	// spoofed X-Forwarded-For from any direct client unless the deployment
+	// explicitly narrows TrustedProxies. RemoteAddr is the direct TCP peer
+	// and cannot be spoofed at the HTTP layer. If the broker runs behind a
+	// TLS-terminating ingress, all traffic appears to come from the ingress
+	// IP — acceptable (the ingress is the abuse-control point anyway).
+	peer := ctx.Request.RemoteAddr
+	if host, _, splitErr := net.SplitHostPort(peer); splitErr == nil {
+		peer = host
+	}
+	if p.imageServeLimiter != nil && !p.imageServeLimiter.Allow(peer) {
 		ctx.Header("Retry-After", "1")
 		ctx.JSON(http.StatusTooManyRequests, gin.H{"error": "rate limit exceeded on image serve endpoint"})
 		return true

--- a/api/inference/internal/proxy/proxy.go
+++ b/api/inference/internal/proxy/proxy.go
@@ -677,6 +677,28 @@ func (p *Proxy) handleImageServeRoute(ctx *gin.Context, targetPath string) bool 
 	}
 
 	ct := p.ctrl.DetectImageContentType(img)
+	// chatKey is an unguessable UUID and the {chatKey,index} → bytes mapping is
+	// immutable for the entry's lifetime, so the response is safely cacheable
+	// up to the store's TTL. "private" prevents shared caches from holding it
+	// (the UUID is the access token, so a shared cache would leak across
+	// users); "immutable" tells modern browsers to skip revalidation on
+	// reload. Falling back to no Cache-Control when TTL is unknown is safer
+	// than guessing a value that outlives the on-disk file.
+	if ttl := p.ctrl.ImageCacheTTL(); ttl > 0 {
+		maxAge := int(ttl.Seconds())
+		ctx.Header("Cache-Control", fmt.Sprintf("private, max-age=%d, immutable", maxAge))
+	}
+	// HEAD short-circuit: net/http already drops the body bytes for HEAD, but
+	// ctx.Data still allocates the response buffer and writes through. Set
+	// the headers explicitly and skip the body to avoid that copy on byte-
+	// range probes / preflight HEADs. Content-Length must match what a GET
+	// would return so range clients can size their request correctly.
+	if ctx.Request.Method == http.MethodHead {
+		ctx.Header("Content-Type", ct)
+		ctx.Header("Content-Length", strconv.Itoa(len(img)))
+		ctx.Status(http.StatusOK)
+		return true
+	}
 	ctx.Data(http.StatusOK, ct, img)
 	return true
 }

--- a/api/inference/internal/proxy/proxy.go
+++ b/api/inference/internal/proxy/proxy.go
@@ -539,7 +539,7 @@ func (p *Proxy) proxyHTTPRequest(ctx *gin.Context) {
 		req.OutputCount = imageNum
 		expectedInputFee = "0"
 	case "image-editing":
-		inputFee, imageNum, err := p.ctrl.GetImageEditingInputFeeAndImageNum(reqBody)
+		inputFee, imageNum, err := p.ctrl.GetImageEditingInputFeeAndImageNum(reqBody, ctx.Request.Header.Get("Content-Type"))
 		if err != nil {
 			// Invalid request body is a user-caused error
 			ctx.Set("ignoreError", true)

--- a/api/inference/internal/proxy/proxy.go
+++ b/api/inference/internal/proxy/proxy.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -205,6 +206,10 @@ func (p *Proxy) proxyHTTPRequest(ctx *gin.Context) {
 		// handleSignatureRoute returns true if it handled the request from broker cache
 		// returns false if it should be forwarded to backend (targetSeparated=true)
 		if p.handleSignatureRoute(ctx, targetPath) {
+			return
+		}
+
+		if p.handleImageServeRoute(ctx, targetPath) {
 			return
 		}
 
@@ -461,6 +466,39 @@ func (p *Proxy) proxyHTTPRequest(ctx *gin.Context) {
 	if err := p.ctrl.ProcessHTTPRequest(ctx, svcType, httpReq, req, service.OutputPrice, true); err != nil {
 		p.logger.Errorf("process http request failed: %v", err)
 	}
+}
+
+// handleImageServeRoute serves broker-stored image bytes at
+// /images/{chatKey}/{index}.  The chatKey is a UUID issued in ZG-Res-Key, so
+// only the requester who received it can derive the URL.  No session auth is
+// required (the UUID itself is the access token), matching OpenAI's CDN URL
+// behaviour.  Returns true if the request was handled (including error cases).
+func (p *Proxy) handleImageServeRoute(ctx *gin.Context, targetPath string) bool {
+	if !strings.HasPrefix(strings.ToLower(targetPath), "/images/") {
+		return false
+	}
+	// Parse /images/{chatKey}/{index}; must have exactly two path segments.
+	rest := strings.TrimPrefix(targetPath, "/images/")
+	parts := strings.SplitN(rest, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return false
+	}
+	chatKey := parts[0]
+	index, err := strconv.Atoi(parts[1])
+	if err != nil || index < 0 {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid image index"})
+		return true
+	}
+
+	img, err := p.ctrl.GetImage(chatKey, index)
+	if err != nil {
+		ctx.JSON(http.StatusNotFound, gin.H{"error": "image not found or expired"})
+		return true
+	}
+
+	ct := p.ctrl.DetectImageContentType(img)
+	ctx.Data(http.StatusOK, ct, img)
+	return true
 }
 
 func (p *Proxy) handleSignatureRoute(ctx *gin.Context, targetRoute string) bool {

--- a/api/inference/internal/proxy/proxy.go
+++ b/api/inference/internal/proxy/proxy.go
@@ -612,6 +612,16 @@ func (p *Proxy) handleImageServeRoute(ctx *gin.Context, targetPath string) bool 
 	if !strings.HasPrefix(strings.ToLower(targetPath), "/images/") {
 		return false
 	}
+	// Parse /images/{chatKey}/{index}; must have exactly two path segments.
+	// Validate BEFORE consuming a rate-limit token: otherwise a caller looping
+	// on GET /images/xyz (no index) would drain the per-IP bucket without ever
+	// reaching the store, then fall through to the next handler. Shape-fail
+	// means "this wasn't for me" → return false so the next matcher tries.
+	rest := strings.TrimPrefix(targetPath, "/images/")
+	parts := strings.SplitN(rest, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return false
+	}
 	// GET (and HEAD for byte-range probes) only. A POST/PUT/DELETE here would
 	// have been silently 200-and-served before; reject it explicitly so that a
 	// future route collision at the same path doesn't mask a real handler.
@@ -637,12 +647,6 @@ func (p *Proxy) handleImageServeRoute(ctx *gin.Context, targetPath string) bool 
 		ctx.Header("Retry-After", "1")
 		ctx.JSON(http.StatusTooManyRequests, gin.H{"error": "rate limit exceeded on image serve endpoint"})
 		return true
-	}
-	// Parse /images/{chatKey}/{index}; must have exactly two path segments.
-	rest := strings.TrimPrefix(targetPath, "/images/")
-	parts := strings.SplitN(rest, "/", 2)
-	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-		return false
 	}
 	chatKey := parts[0]
 	index, err := strconv.Atoi(parts[1])

--- a/api/inference/internal/proxy/proxy_test.go
+++ b/api/inference/internal/proxy/proxy_test.go
@@ -468,3 +468,84 @@ func TestHandleImageServeRoute_IndexOutOfRange_Returns404(t *testing.T) {
 		t.Errorf("status = %d, want 404", w.Code)
 	}
 }
+
+// TestHandleImageServeRoute_SetsCacheControl pins the cache header. The
+// {chatKey,index} → bytes mapping is immutable for the entry's lifetime; the
+// header lets browsers skip revalidation on reload, but it MUST be "private"
+// because the UUID is the access token and a shared cache would leak across
+// users.
+func TestHandleImageServeRoute_SetsCacheControl(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	c := &ctrl.Ctrl{}
+	if err := c.SetupImageStoreForTest(t.TempDir()); err != nil {
+		t.Fatalf("SetupImageStoreForTest: %v", err)
+	}
+	chatKey := "cache-test"
+	pngImg := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0, 0, 0, 1}
+	if err := c.StoreTestImage(chatKey, [][]byte{pngImg}); err != nil {
+		t.Fatalf("StoreTestImage: %v", err)
+	}
+
+	p := newTestProxy(t, c)
+	path := "/images/" + chatKey + "/0"
+	ctx, w := newGinCtxForPath(t, path)
+
+	if !p.handleImageServeRoute(ctx, path) {
+		t.Fatal("expected route to be handled")
+	}
+	cc := w.Header().Get("Cache-Control")
+	if cc == "" {
+		t.Fatal("Cache-Control header missing")
+	}
+	if !strings.Contains(cc, "private") {
+		t.Errorf("Cache-Control = %q, want it to include 'private'", cc)
+	}
+	if !strings.Contains(cc, "immutable") {
+		t.Errorf("Cache-Control = %q, want it to include 'immutable'", cc)
+	}
+	if !strings.Contains(cc, "max-age=") {
+		t.Errorf("Cache-Control = %q, want a max-age directive", cc)
+	}
+}
+
+// TestHandleImageServeRoute_HEADReturnsNoBody pins the HEAD short-circuit:
+// Content-Type/Content-Length must reflect the GET response so byte-range
+// clients can size their request, but no body bytes should be written.
+func TestHandleImageServeRoute_HEADReturnsNoBody(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	c := &ctrl.Ctrl{}
+	if err := c.SetupImageStoreForTest(t.TempDir()); err != nil {
+		t.Fatalf("SetupImageStoreForTest: %v", err)
+	}
+	chatKey := "head-test"
+	pngImg := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0, 0, 0, 1}
+	if err := c.StoreTestImage(chatKey, [][]byte{pngImg}); err != nil {
+		t.Fatalf("StoreTestImage: %v", err)
+	}
+
+	p := newTestProxy(t, c)
+	path := "/images/" + chatKey + "/0"
+
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Request = httptest.NewRequest("HEAD", constant.ServicePrefix+path, nil)
+	ctx.Params = gin.Params{{Key: "any", Value: path}}
+
+	if !p.handleImageServeRoute(ctx, path) {
+		t.Fatal("expected HEAD to be handled")
+	}
+	if w.Code != http.StatusOK {
+		t.Errorf("HEAD status = %d, want 200", w.Code)
+	}
+	if w.Body.Len() != 0 {
+		t.Errorf("HEAD response body length = %d, want 0", w.Body.Len())
+	}
+	if cl := w.Header().Get("Content-Length"); cl == "" {
+		t.Error("expected Content-Length header on HEAD response")
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "image/") {
+		t.Errorf("Content-Type = %q, want image/*", ct)
+	}
+}

--- a/api/inference/internal/proxy/proxy_test.go
+++ b/api/inference/internal/proxy/proxy_test.go
@@ -11,6 +11,7 @@ import (
 	logrus "github.com/sirupsen/logrus"
 
 	"github.com/0glabs/0g-serving-broker/common/log"
+	"github.com/0glabs/0g-serving-broker/common/middleware"
 	"github.com/0glabs/0g-serving-broker/inference/config"
 	constant "github.com/0glabs/0g-serving-broker/inference/const"
 	"github.com/0glabs/0g-serving-broker/inference/internal/ctrl"
@@ -260,6 +261,58 @@ func TestHandleImageServeRoute_NoMatch_ShortPath(t *testing.T) {
 	handled := p.handleImageServeRoute(ctx, "/images/only-one-segment")
 	if handled {
 		t.Error("path with no index segment should not be handled")
+	}
+}
+
+// TestHandleImageServeRoute_ShapeFailDoesNotConsumeRateLimit pins the
+// ordering fix: malformed paths under /images/ (e.g. missing the index
+// segment) must NOT consume a rate-limit token. Otherwise a caller looping
+// on GET /images/xyz could drain the per-IP bucket without ever reaching the
+// store, then fall through to the next matcher at zero cost to themselves.
+func TestHandleImageServeRoute_ShapeFailDoesNotConsumeRateLimit(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	c := &ctrl.Ctrl{}
+	if err := c.SetupImageStoreForTest(t.TempDir()); err != nil {
+		t.Fatalf("SetupImageStoreForTest: %v", err)
+	}
+	// Seed one valid image so the well-formed probe at the end succeeds.
+	if err := c.StoreTestImage("ordered", [][]byte{[]byte{0x89, 0x50, 0x4E, 0x47, 0, 0, 0, 1}}); err != nil {
+		t.Fatalf("StoreTestImage: %v", err)
+	}
+
+	p := newTestProxy(t, c)
+	// Budget of 1 per "minute" at 60 RPM, burst 1 — simulates a drained bucket
+	// if the shape-fail path consumed a token. Using PerUserRateLimiter so we
+	// depend on the production primitive, not a test fake.
+	p.imageServeLimiter = middleware.NewPerUserRateLimiter(60, 1)
+
+	// 3 shape-fail requests with the same RemoteAddr. Each SHOULD return false
+	// (unhandled) without touching the limiter.
+	for i := 0; i < 3; i++ {
+		w := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(w)
+		ctx.Request = httptest.NewRequest("GET", constant.ServicePrefix+"/images/only-one-segment", nil)
+		ctx.Request.RemoteAddr = "10.0.0.1:55555"
+		ctx.Params = gin.Params{{Key: "any", Value: "/images/only-one-segment"}}
+
+		if handled := p.handleImageServeRoute(ctx, "/images/only-one-segment"); handled {
+			t.Fatalf("iter %d: shape-fail should return false (unhandled), not consume a token", i)
+		}
+	}
+
+	// A well-formed request from the same IP should still have its burst.
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Request = httptest.NewRequest("GET", constant.ServicePrefix+"/images/ordered/0", nil)
+	ctx.Request.RemoteAddr = "10.0.0.1:55555"
+	ctx.Params = gin.Params{{Key: "any", Value: "/images/ordered/0"}}
+
+	if !p.handleImageServeRoute(ctx, "/images/ordered/0") {
+		t.Fatal("well-formed request after shape-fails should be handled")
+	}
+	if w.Code != http.StatusOK {
+		t.Errorf("well-formed after shape-fails: status = %d, want 200 (burst exhausted by shape-fails?)", w.Code)
 	}
 }
 

--- a/api/inference/internal/proxy/proxy_test.go
+++ b/api/inference/internal/proxy/proxy_test.go
@@ -274,6 +274,60 @@ func TestHandleImageServeRoute_NoMatch_NonImagePath(t *testing.T) {
 	}
 }
 
+// TestHandleImageServeRoute_RejectsNonGET pins the method guard. Before the
+// fix, any HTTP method (POST, PUT, DELETE, OPTIONS) at the same path would have
+// been silently served or silently handled as "not matched" depending on path
+// shape. Now anything other than GET/HEAD must return 405 so a future route
+// collision doesn't mask a real handler.
+func TestHandleImageServeRoute_RejectsNonGET(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	c := &ctrl.Ctrl{}
+	if err := c.SetupImageStoreForTest(t.TempDir()); err != nil {
+		t.Fatalf("SetupImageStoreForTest: %v", err)
+	}
+	chatKey := "method-test"
+	if err := c.StoreTestImage(chatKey, [][]byte{[]byte("img")}); err != nil {
+		t.Fatalf("StoreTestImage: %v", err)
+	}
+
+	p := newTestProxy(t, c)
+	path := "/images/" + chatKey + "/0"
+
+	for _, method := range []string{"POST", "PUT", "DELETE", "PATCH", "OPTIONS"} {
+		t.Run(method, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			ctx, _ := gin.CreateTestContext(w)
+			ctx.Request = httptest.NewRequest(method, constant.ServicePrefix+path, nil)
+			ctx.Params = gin.Params{{Key: "any", Value: path}}
+
+			if !p.handleImageServeRoute(ctx, path) {
+				t.Fatal("expected route to be handled (handler must reject the method, not return false)")
+			}
+			if w.Code != http.StatusMethodNotAllowed {
+				t.Errorf("status = %d, want 405", w.Code)
+			}
+			if allow := w.Header().Get("Allow"); allow == "" {
+				t.Error("expected Allow header on 405 response")
+			}
+		})
+	}
+
+	t.Run("HEAD-allowed", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(w)
+		ctx.Request = httptest.NewRequest("HEAD", constant.ServicePrefix+path, nil)
+		ctx.Params = gin.Params{{Key: "any", Value: path}}
+
+		if !p.handleImageServeRoute(ctx, path) {
+			t.Fatal("HEAD should be handled")
+		}
+		if w.Code != http.StatusOK {
+			t.Errorf("HEAD status = %d, want 200", w.Code)
+		}
+	})
+}
+
 func TestHandleImageServeRoute_InvalidIndex_Returns400(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	p := newTestProxy(t, &ctrl.Ctrl{})

--- a/api/inference/internal/proxy/proxy_test.go
+++ b/api/inference/internal/proxy/proxy_test.go
@@ -16,6 +16,23 @@ import (
 	"github.com/0glabs/0g-serving-broker/inference/internal/ctrl"
 )
 
+// newTestProxy builds the minimal Proxy needed for handleImageServeRoute tests.
+func newTestProxy(t *testing.T, c *ctrl.Ctrl) *Proxy {
+	t.Helper()
+	return &Proxy{ctrl: c, logger: noopLogger{}}
+}
+
+// newGinCtxForPath builds a gin.Context whose RequestURI matches path under ServicePrefix.
+func newGinCtxForPath(t *testing.T, path string) (*gin.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Request = httptest.NewRequest("GET", constant.ServicePrefix+path, nil)
+	// Populate the wildcard "any" param the same way gin does in production.
+	ctx.Params = gin.Params{{Key: "any", Value: path}}
+	return ctx, w
+}
+
 // ==========================================================================
 // Video route registration in TargetRoute
 // ==========================================================================
@@ -228,5 +245,119 @@ func TestCentralizedAttestationGuard_Logic(t *testing.T) {
 				t.Errorf("expected shouldBlock=%v, got %v", tt.shouldBlock, blocked)
 			}
 		})
+	}
+}
+
+// ==========================================================================
+// handleImageServeRoute
+// ==========================================================================
+
+func TestHandleImageServeRoute_NoMatch_ShortPath(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	p := newTestProxy(t, &ctrl.Ctrl{})
+
+	ctx, _ := newGinCtxForPath(t, "/images/only-one-segment")
+	handled := p.handleImageServeRoute(ctx, "/images/only-one-segment")
+	if handled {
+		t.Error("path with no index segment should not be handled")
+	}
+}
+
+func TestHandleImageServeRoute_NoMatch_NonImagePath(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	p := newTestProxy(t, &ctrl.Ctrl{})
+
+	ctx, _ := newGinCtxForPath(t, "/signature/some-key")
+	handled := p.handleImageServeRoute(ctx, "/signature/some-key")
+	if handled {
+		t.Error("non-image path should not be handled")
+	}
+}
+
+func TestHandleImageServeRoute_InvalidIndex_Returns400(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	p := newTestProxy(t, &ctrl.Ctrl{})
+
+	ctx, w := newGinCtxForPath(t, "/images/some-chat-key/notanumber")
+	handled := p.handleImageServeRoute(ctx, "/images/some-chat-key/notanumber")
+	if !handled {
+		t.Fatal("expected route to be handled")
+	}
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestHandleImageServeRoute_NotFound_Returns404(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	p := newTestProxy(t, &ctrl.Ctrl{})
+
+	ctx, w := newGinCtxForPath(t, "/images/unknown-uuid/0")
+	handled := p.handleImageServeRoute(ctx, "/images/unknown-uuid/0")
+	if !handled {
+		t.Fatal("expected route to be handled")
+	}
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestHandleImageServeRoute_ServesImage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	c := &ctrl.Ctrl{}
+	if err := c.SetupImageStoreForTest(t.TempDir()); err != nil {
+		t.Fatalf("SetupImageStoreForTest: %v", err)
+	}
+
+	chatKey := "serve-test-uuid"
+	// PNG-like bytes so content-type detection works.
+	pngImg := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0, 0, 0, 1}
+	if err := c.StoreTestImage(chatKey, [][]byte{pngImg}); err != nil {
+		t.Fatalf("StoreTestImage: %v", err)
+	}
+
+	p := newTestProxy(t, c)
+	path := "/images/" + chatKey + "/0"
+	ctx, w := newGinCtxForPath(t, path)
+
+	handled := p.handleImageServeRoute(ctx, path)
+	if !handled {
+		t.Fatal("expected route to be handled")
+	}
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	ct := w.Header().Get("Content-Type")
+	if !strings.HasPrefix(ct, "image/") {
+		t.Errorf("content-type = %q, want image/*", ct)
+	}
+	if w.Body.Bytes() == nil || len(w.Body.Bytes()) == 0 {
+		t.Error("expected non-empty image body")
+	}
+}
+
+func TestHandleImageServeRoute_IndexOutOfRange_Returns404(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	c := &ctrl.Ctrl{}
+	if err := c.SetupImageStoreForTest(t.TempDir()); err != nil {
+		t.Fatalf("SetupImageStoreForTest: %v", err)
+	}
+	chatKey := "range-test"
+	if err := c.StoreTestImage(chatKey, [][]byte{[]byte("img")}); err != nil {
+		t.Fatalf("StoreTestImage: %v", err)
+	}
+
+	p := newTestProxy(t, c)
+	path := "/images/" + chatKey + "/5" // only index 0 exists
+	ctx, w := newGinCtxForPath(t, path)
+
+	handled := p.handleImageServeRoute(ctx, path)
+	if !handled {
+		t.Fatal("expected route to be handled")
+	}
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
 	}
 }


### PR DESCRIPTION
## Summary

Implements `response_format="url"` for `/v1/images/generations` and `/v1/images/edits` on both the sync and async paths, so the OpenAI default works without users having to force `b64_json`. Also extracts TEE chat-signing infrastructure out of `chatbot.go` into a shared `signing.go` so it can be reused by the image and async flows.

### How it works
1. **Upstream normalization** — when the client sends `response_format=url` (JSON or multipart), the broker rewrites the forwarded body to `b64_json`. The provider always returns base64, so LAN-private provider URLs never reach the user.
2. **Broker-served URLs** — decoded image bytes are persisted to a local `imageStore` keyed by a broker-generated `chatKey` (sync) or `jobID` (async). The client-facing response replaces `data[].b64_json` with `{servingUrl}/v1/proxy/images/{key}/{i}`, served by a new route in `proxy.go`.
3. **TEE signature integrity** — signing covers decoded image bytes (`signImageResponse`), not the JSON envelope, so URL-format responses preserve the same verification guarantee as b64. The signed text is `sha256(originalClientReqBody):sha256(img0),sha256(img1),...`, binding the signature to actual image bytes rather than provider response JSON (which may contain inaccessible LAN URLs).
4. **Centralized-provider guard** — `signImageResponse` hard-fails if `Service.IsCentralized()` is true. Image flows on centralized providers need a routing-proof sibling that also binds the TLS fingerprint; the guard prevents the gap from being reached silently by config toggle.
5. **Public URL source** — URL base is derived from `service.servingUrl` (the on-chain public URL), not from `X-Forwarded-Proto` or `r.Host`. This avoids scheme/host drift behind TLS-terminating ingresses that don't forward those headers.
6. **Async parity** — `processAsyncJob` mirrors the sync pipeline: pre-dispatch body rewrite, post-response `extractB64Images` → store → `buildURLResponse`. `params.RequestBody` stays unmodified so TEE signing binds the client's original bytes.
7. **Image-store TTL** — bumped to `max(chatCacheExpiration, async.resultTTL)` at init, so async results can't reference already-evicted image files.

Falls back to passing b64 through when the client asks for `b64_json` or when any step fails (with a warn log).

### Signing refactor (drive-by)
`chatbot.go` shrinks by ~120 lines: `ChatPrefix`, `SigningAlgo`, `ChatSignature`, `signChatWithKey`, `signCentralizedRoutingProof`, and `chatCacheKey` move to the new `signing.go`. This is shared TEE-signing infrastructure (chatbot, video, speech-to-text, image flows) rather than chatbot-specific logic, and co-locating it with the new `signImageResponse` keeps the parity note between decentralized and centralized paths in one place. Pure move + new helper — no behavior change for existing chat signing.

## Files
- `api/inference/internal/ctrl/signing.go` — **new**. Hosts `ChatSignature`, `signChatWithKey`, `signCentralizedRoutingProof` (moved from `chatbot.go`) and the new `signImageResponse` with the centralized-provider guard.
- `api/inference/internal/ctrl/chatbot.go` — removes the signing helpers now living in `signing.go`.
- `api/inference/internal/ctrl/proxy.go` — `forceB64ResponseFormat` / `rewriteMultipartResponseFormat`, `clientReqBody` capture for signing, `GetImage` accessor.
- `api/inference/internal/ctrl/text_to_image.go`, `image_editing.go` — handler-side URL rewrite, image-byte signing via `signImageResponse`.
- `api/inference/internal/ctrl/async.go` — same pipeline in `processAsyncJob` + `extractContentType` helper.
- `api/inference/internal/ctrl/image_store.go` — **new**. Local file-backed store with TTL-driven eviction.
- `api/inference/internal/ctrl/ctrl.go` — image-store TTL widened to `max(chatCacheExpiration, async.resultTTL)`.
- `api/inference/internal/ctrl/testing_helpers.go` — `SetupImageStoreForTest` / `StoreTestImage` for proxy-layer tests.
- `api/inference/internal/proxy/proxy.go` — `handleImageServeRoute` for `/v1/proxy/images/{key}/{i}`.
- Tests: unit (`text_to_image_test.go`, `image_editing_test.go`, `async_test.go`, `image_store_test.go`, `proxy_test.go`, `chatbot_test.go` coverage for `signImageResponse`) + integration (`integration_test/text_to_image_test.go`, `image_editing_test.go`).

## Test plan
- [ ] `cd api && go build ./...`
- [ ] `cd api && go test ./inference/internal/...` — new unit tests for request rewrites, URL response building, serving-URL precedence, TTL max, async URL flow, and `signImageResponse` text/recoverability + centralized guard.
- [ ] `cd api && go test -tags integration ./inference/integration_test/ -run 'ResponseFormat' -timeout 600s` — end-to-end sync flows for JSON/multipart url and b64 pass-through.
- [ ] Manual (dev cluster): `node test-response-format-url.mjs --bearerToken "…"` — verifies `data[].url` points to broker, GET returns image bytes with `image/*` content-type.
- [ ] Manual: async submit with `response_format=url`, poll result, GET the returned URL.

Closes #424