### PR TITLE
Hardcode 0G symbols in pricefeed factory, remove config

### DIFF
--- a/api/inference/config/config.go
+++ b/api/inference/config/config.go
@@ -143,15 +143,11 @@ type PriceFeedConfig struct {
 	// Known identifiers: "coingecko", "binance".
 	// The aggregator returns the median of healthy sources; at least MinQuorum
 	// sources must respond successfully for an update to proceed.
+	//
+	// Each source's 0G trading symbol is hardcoded in the pricefeed factory
+	// (see pricefeed.BuildSources); the symbols aren't an operator choice
+	// because this broker only ever prices 0G.
 	Sources []string `yaml:"sources"`
-	// SourceSymbols gives each source its own "<base>-<quote>" identifier,
-	// because the two APIs disagree on the shape of the base:
-	//   binance:   "0g-usdt"            -> 0GUSDT
-	//   coingecko: "zero-gravity-usd"   -> ids=zero-gravity&vs_currencies=usd
-	// Every entry in Sources must have a non-empty symbol here, validated at
-	// startup.  Keys are case-insensitive and normalised to the lowercase
-	// source identifier.
-	SourceSymbols map[string]string `yaml:"sourceSymbols"`
 	// UpdateInterval is how often the processor fetches a fresh rate and
 	// refreshes the in-memory wei price cache.
 	UpdateInterval time.Duration `yaml:"updateInterval"`
@@ -454,35 +450,6 @@ func validatePriceFeedConfig(pf *PriceFeedConfig) error {
 		seen[name] = struct{}{}
 		pf.Sources[i] = name
 	}
-
-	// Normalise sourceSymbols keys to lowercase and require an entry for
-	// every source.  Each symbol must be in "<base>-<quote>" form (quote
-	// is split on the LAST hyphen to accommodate hyphenated CoinGecko IDs).
-	normalised := make(map[string]string, len(pf.SourceSymbols))
-	for k, v := range pf.SourceSymbols {
-		key := strings.ToLower(strings.TrimSpace(k))
-		sym := strings.TrimSpace(v)
-		if key == "" {
-			return fmt.Errorf("invalid config: priceFeed.sourceSymbols has an empty key")
-		}
-		if _, dup := normalised[key]; dup {
-			return fmt.Errorf("invalid config: priceFeed.sourceSymbols has duplicate key %q (case-insensitive)", key)
-		}
-		if sym == "" {
-			return fmt.Errorf("invalid config: priceFeed.sourceSymbols[%q] is empty", key)
-		}
-		idx := strings.LastIndex(sym, "-")
-		if idx <= 0 || idx == len(sym)-1 {
-			return fmt.Errorf("invalid config: priceFeed.sourceSymbols[%q]=%q must be in '<base>-<quote>' form", key, sym)
-		}
-		normalised[key] = sym
-	}
-	for _, name := range pf.Sources {
-		if _, ok := normalised[name]; !ok {
-			return fmt.Errorf("invalid config: priceFeed.sourceSymbols is missing an entry for source %q", name)
-		}
-	}
-	pf.SourceSymbols = normalised
 
 	if pf.UpdateInterval <= 0 {
 		pf.UpdateInterval = time.Hour

--- a/api/inference/config/config.go
+++ b/api/inference/config/config.go
@@ -153,9 +153,9 @@ type PriceFeedConfig struct {
 	UpdateInterval time.Duration `yaml:"updateInterval"`
 	// StalenessThreshold rejects new requests (fail-closed) if the last
 	// successful cache refresh is older than this.  Must be >= UpdateInterval.
-	// Defaults to 3h when unset — long enough to ride out a multi-hour
-	// feed outage through intra-tick retries, short enough that sustained
-	// outages surface as errors before clients notice bad pricing.
+	// Defaults to 3 × UpdateInterval when unset — three consecutive tick
+	// failures (each of which runs its own retry loop first) before readers
+	// start erroring, which scales naturally with the refresh cadence.
 	StalenessThreshold time.Duration `yaml:"stalenessThreshold"`
 	// MinOnChainUpdateBps is the drift threshold (in basis points, 1/10000)
 	// between the newly-derived wei price and the currently-registered
@@ -458,12 +458,12 @@ func validatePriceFeedConfig(pf *PriceFeedConfig) error {
 		pf.UpdateInterval = time.Hour
 	}
 	if pf.StalenessThreshold <= 0 {
-		// Absolute 3-hour default — long enough to ride out a CoinGecko /
-		// Binance outage through multiple tick retries, short enough that
-		// a sustained feed problem fails closed before users notice badly
-		// stale pricing.  Operators running with updateInterval > 3h need
-		// to set stalenessThreshold explicitly.
-		pf.StalenessThreshold = 3 * time.Hour
+		// 3× updateInterval: the first failed tick uses retries to absorb
+		// transient issues, the second and third ticks give the feed two
+		// more chances to recover before readers start failing closed.
+		// Scales with the operator's chosen interval so shorter/longer
+		// cadences don't need a separate staleness tune.
+		pf.StalenessThreshold = 3 * pf.UpdateInterval
 	}
 	if pf.StalenessThreshold < pf.UpdateInterval {
 		return fmt.Errorf("invalid config: priceFeed.stalenessThreshold (%s) must be >= priceFeed.updateInterval (%s)", pf.StalenessThreshold, pf.UpdateInterval)

--- a/api/inference/config/config.go
+++ b/api/inference/config/config.go
@@ -151,8 +151,11 @@ type PriceFeedConfig struct {
 	// UpdateInterval is how often the processor fetches a fresh rate and
 	// refreshes the in-memory wei price cache.
 	UpdateInterval time.Duration `yaml:"updateInterval"`
-	// StalenessThreshold rejects new requests (fail-closed) if the last successful
-	// cache refresh is older than this. Must be >= UpdateInterval.
+	// StalenessThreshold rejects new requests (fail-closed) if the last
+	// successful cache refresh is older than this.  Must be >= UpdateInterval.
+	// Defaults to 3h when unset — long enough to ride out a multi-hour
+	// feed outage through intra-tick retries, short enough that sustained
+	// outages surface as errors before clients notice bad pricing.
 	StalenessThreshold time.Duration `yaml:"stalenessThreshold"`
 	// MinOnChainUpdateBps is the drift threshold (in basis points, 1/10000)
 	// between the newly-derived wei price and the currently-registered
@@ -455,7 +458,12 @@ func validatePriceFeedConfig(pf *PriceFeedConfig) error {
 		pf.UpdateInterval = time.Hour
 	}
 	if pf.StalenessThreshold <= 0 {
-		pf.StalenessThreshold = 2 * pf.UpdateInterval
+		// Absolute 3-hour default — long enough to ride out a CoinGecko /
+		// Binance outage through multiple tick retries, short enough that
+		// a sustained feed problem fails closed before users notice badly
+		// stale pricing.  Operators running with updateInterval > 3h need
+		// to set stalenessThreshold explicitly.
+		pf.StalenessThreshold = 3 * time.Hour
 	}
 	if pf.StalenessThreshold < pf.UpdateInterval {
 		return fmt.Errorf("invalid config: priceFeed.stalenessThreshold (%s) must be >= priceFeed.updateInterval (%s)", pf.StalenessThreshold, pf.UpdateInterval)

--- a/api/inference/config/config.go
+++ b/api/inference/config/config.go
@@ -113,15 +113,17 @@ type Service struct {
 
 	// PriceDenomination selects how input/output prices are expressed:
 	//   "NATIVE" (default): InputPrice/OutputPrice are wei amounts, written to chain as-is.
-	//   "USD":              InputPriceUSD/OutputPriceUSD are USD decimal strings.
+	//   "USD":              InputPriceUSDPerMillionTokens/OutputPriceUSDPerMillionTokens are USD decimal strings.
 	//                       The PriceUpdateProcessor converts them to wei using a live rate.
 	PriceDenomination string `yaml:"priceDenomination"`
-	// InputPriceUSD is the input-side price in USD per token (decimal string).
+	// InputPriceUSDPerMillionTokens is the input-side price in USD per 1M
+	// tokens, as a decimal string (e.g. "0.50" = $0.50 per 1M input tokens,
+	// matching the convention used by OpenAI/Anthropic pricing tables).
 	// Required iff PriceDenomination == "USD".
-	InputPriceUSD string `yaml:"inputPriceUSD"`
-	// OutputPriceUSD is the output-side price in USD per token (decimal string).
-	// Required iff PriceDenomination == "USD".
-	OutputPriceUSD string `yaml:"outputPriceUSD"`
+	InputPriceUSDPerMillionTokens string `yaml:"inputPriceUSDPerMillionTokens"`
+	// OutputPriceUSDPerMillionTokens is the output-side price in USD per 1M
+	// tokens, decimal string.  Required iff PriceDenomination == "USD".
+	OutputPriceUSDPerMillionTokens string `yaml:"outputPriceUSDPerMillionTokens"`
 }
 
 // IsCentralized returns true if this service routes to a centralized API provider.
@@ -566,17 +568,17 @@ func loadConfig(config *Config) error {
 	config.Service.PriceDenomination = strings.ToUpper(config.Service.PriceDenomination)
 	switch config.Service.PriceDenomination {
 	case constant.PriceDenominationNative:
-		if config.Service.InputPriceUSD != "" || config.Service.OutputPriceUSD != "" {
-			return fmt.Errorf("invalid config: service.inputPriceUSD / service.outputPriceUSD must be empty when priceDenomination is '%s'", constant.PriceDenominationNative)
+		if config.Service.InputPriceUSDPerMillionTokens != "" || config.Service.OutputPriceUSDPerMillionTokens != "" {
+			return fmt.Errorf("invalid config: service.inputPriceUSDPerMillionTokens / service.outputPriceUSDPerMillionTokens must be empty when priceDenomination is '%s'", constant.PriceDenominationNative)
 		}
 	case constant.PriceDenominationUSD:
-		if config.Service.InputPriceUSD == "" || config.Service.OutputPriceUSD == "" {
-			return fmt.Errorf("invalid config: service.inputPriceUSD and service.outputPriceUSD are required when priceDenomination is '%s'", constant.PriceDenominationUSD)
+		if config.Service.InputPriceUSDPerMillionTokens == "" || config.Service.OutputPriceUSDPerMillionTokens == "" {
+			return fmt.Errorf("invalid config: service.inputPriceUSDPerMillionTokens and service.outputPriceUSDPerMillionTokens are required when priceDenomination is '%s'", constant.PriceDenominationUSD)
 		}
-		if err := validateUSDPriceString("service.inputPriceUSD", config.Service.InputPriceUSD); err != nil {
+		if err := validateUSDPriceString("service.inputPriceUSDPerMillionTokens", config.Service.InputPriceUSDPerMillionTokens); err != nil {
 			return err
 		}
-		if err := validateUSDPriceString("service.outputPriceUSD", config.Service.OutputPriceUSD); err != nil {
+		if err := validateUSDPriceString("service.outputPriceUSDPerMillionTokens", config.Service.OutputPriceUSDPerMillionTokens); err != nil {
 			return err
 		}
 		if config.Service.InputPrice != "" || config.Service.OutputPrice != "" {

--- a/api/inference/config/config_test.go
+++ b/api/inference/config/config_test.go
@@ -290,8 +290,9 @@ priceFeed:
 }
 
 func TestLoadConfig_USDStalenessThresholdDefault(t *testing.T) {
-	// With stalenessThreshold unset, the config loader should apply the
-	// 3-hour absolute default (not a multiple of updateInterval).
+	// With stalenessThreshold unset, the config loader applies 3×
+	// UpdateInterval — so the staleness window scales naturally with
+	// whatever refresh cadence the operator chose.
 	configPath := writeTestConfig(t, `
 service:
   servingUrl: "http://example.com"
@@ -312,9 +313,9 @@ priceFeed:
 	if err := loadConfig(cfg); err != nil {
 		t.Fatalf("loadConfig failed: %v", err)
 	}
-	want := 3 * time.Hour
+	want := 90 * time.Minute // 3 × 30m
 	if cfg.PriceFeed.StalenessThreshold != want {
-		t.Errorf("StalenessThreshold default = %s, want %s", cfg.PriceFeed.StalenessThreshold, want)
+		t.Errorf("StalenessThreshold default = %s, want %s (3× updateInterval)", cfg.PriceFeed.StalenessThreshold, want)
 	}
 }
 

--- a/api/inference/config/config_test.go
+++ b/api/inference/config/config_test.go
@@ -265,8 +265,8 @@ service:
   model: "gpt-4"
   verifiability: "TeeML"
   priceDenomination: "USD"
-  inputPriceUSD: "0.50"
-  outputPriceUSD: "1.50"
+  inputPriceUSDPerMillionTokens: "0.50"
+  outputPriceUSDPerMillionTokens: "1.50"
 priceFeed:
   sources: ["coingecko", "binance"]
   updateInterval: "1h"
@@ -301,8 +301,8 @@ service:
   model: "gpt-4"
   verifiability: "TeeML"
   priceDenomination: "USD"
-  inputPriceUSD: "0.50"
-  outputPriceUSD: "1.50"
+  inputPriceUSDPerMillionTokens: "0.50"
+  outputPriceUSDPerMillionTokens: "1.50"
 priceFeed:
   sources: ["coingecko"]
   updateInterval: "30m"
@@ -335,8 +335,8 @@ priceFeed:
 
 	cfg := &Config{}
 	err := loadConfig(cfg)
-	if err == nil || !strings.Contains(err.Error(), "inputPriceUSD") {
-		t.Errorf("expected error about missing inputPriceUSD, got %v", err)
+	if err == nil || !strings.Contains(err.Error(), "inputPriceUSDPerMillionTokens") {
+		t.Errorf("expected error about missing inputPriceUSDPerMillionTokens, got %v", err)
 	}
 }
 
@@ -350,8 +350,8 @@ service:
   verifiability: "TeeML"
   priceDenomination: "USD"
   inputPrice: "1000"
-  inputPriceUSD: "0.50"
-  outputPriceUSD: "1.50"
+  inputPriceUSDPerMillionTokens: "0.50"
+  outputPriceUSDPerMillionTokens: "1.50"
 priceFeed:
   sources: ["coingecko"]
 `)
@@ -385,18 +385,18 @@ service:
   type: "chatbot"
   model: "gpt-4"
   verifiability: "TeeML"
-  inputPriceUSD: "0.50"
+  inputPriceUSDPerMillionTokens: "0.50"
 `)
 	t.Setenv("CONFIG_FILE", configPath)
 
 	cfg := &Config{}
 	err := loadConfig(cfg)
 	if err == nil {
-		t.Fatal("expected error for USD inputPriceUSD under NATIVE denomination")
+		t.Fatal("expected error for USD inputPriceUSDPerMillionTokens under NATIVE denomination")
 	}
 	msg := err.Error()
-	if !strings.Contains(msg, "service.inputPriceUSD") && !strings.Contains(msg, "service.outputPriceUSD") {
-		t.Errorf("expected error naming service.inputPriceUSD / service.outputPriceUSD, got %q", msg)
+	if !strings.Contains(msg, "service.inputPriceUSDPerMillionTokens") && !strings.Contains(msg, "service.outputPriceUSDPerMillionTokens") {
+		t.Errorf("expected error naming service.inputPriceUSDPerMillionTokens / service.outputPriceUSDPerMillionTokens, got %q", msg)
 	}
 	if !strings.Contains(msg, "NATIVE") {
 		t.Errorf("expected error to reference NATIVE denomination, got %q", msg)
@@ -412,8 +412,8 @@ service:
   model: "gpt-4"
   verifiability: "TeeML"
   priceDenomination: "eur"
-  inputPriceUSD: "0.50"
-  outputPriceUSD: "1.50"
+  inputPriceUSDPerMillionTokens: "0.50"
+  outputPriceUSDPerMillionTokens: "1.50"
 `)
 	t.Setenv("CONFIG_FILE", configPath)
 
@@ -433,8 +433,8 @@ service:
   model: "gpt-4"
   verifiability: "TeeML"
   priceDenomination: "USD"
-  inputPriceUSD: "0,50"
-  outputPriceUSD: "1.50"
+  inputPriceUSDPerMillionTokens: "0,50"
+  outputPriceUSDPerMillionTokens: "1.50"
 priceFeed:
   sources: ["coingecko"]
 `)
@@ -442,8 +442,8 @@ priceFeed:
 
 	cfg := &Config{}
 	err := loadConfig(cfg)
-	if err == nil || !strings.Contains(err.Error(), "inputPriceUSD") {
-		t.Errorf("expected error about malformed inputPriceUSD, got %v", err)
+	if err == nil || !strings.Contains(err.Error(), "inputPriceUSDPerMillionTokens") {
+		t.Errorf("expected error about malformed inputPriceUSDPerMillionTokens, got %v", err)
 	}
 }
 
@@ -456,8 +456,8 @@ service:
   model: "gpt-4"
   verifiability: "TeeML"
   priceDenomination: "USD"
-  inputPriceUSD: "0.50"
-  outputPriceUSD: "-1.50"
+  inputPriceUSDPerMillionTokens: "0.50"
+  outputPriceUSDPerMillionTokens: "-1.50"
 priceFeed:
   sources: ["coingecko"]
 `)
@@ -466,7 +466,7 @@ priceFeed:
 	cfg := &Config{}
 	err := loadConfig(cfg)
 	if err == nil || !strings.Contains(err.Error(), "non-negative") {
-		t.Errorf("expected error about negative outputPriceUSD, got %v", err)
+		t.Errorf("expected error about negative outputPriceUSDPerMillionTokens, got %v", err)
 	}
 }
 
@@ -479,8 +479,8 @@ service:
   model: "gpt-4"
   verifiability: "TeeML"
   priceDenomination: "USD"
-  inputPriceUSD: "0.50"
-  outputPriceUSD: "1.50"
+  inputPriceUSDPerMillionTokens: "0.50"
+  outputPriceUSDPerMillionTokens: "1.50"
 `)
 	t.Setenv("CONFIG_FILE", configPath)
 

--- a/api/inference/config/config_test.go
+++ b/api/inference/config/config_test.go
@@ -268,9 +268,6 @@ service:
   outputPriceUSD: "1.50"
 priceFeed:
   sources: ["coingecko", "binance"]
-  sourceSymbols:
-    coingecko: "zero-gravity-usd"
-    binance: "0g-usdt"
   updateInterval: "1h"
   stalenessThreshold: "2h"
 `)
@@ -288,62 +285,6 @@ priceFeed:
 	}
 	if cfg.PriceFeed.MinOnChainUpdateBps != 500 {
 		t.Errorf("MinOnChainUpdateBps default = %d, want 500", cfg.PriceFeed.MinOnChainUpdateBps)
-	}
-	if got := cfg.PriceFeed.SourceSymbols["coingecko"]; got != "zero-gravity-usd" {
-		t.Errorf("SourceSymbols[coingecko] = %q, want zero-gravity-usd", got)
-	}
-	if got := cfg.PriceFeed.SourceSymbols["binance"]; got != "0g-usdt" {
-		t.Errorf("SourceSymbols[binance] = %q, want 0g-usdt", got)
-	}
-}
-
-func TestLoadConfig_USDMissingSourceSymbol(t *testing.T) {
-	configPath := writeTestConfig(t, `
-service:
-  servingUrl: "http://example.com"
-  targetUrl: "http://backend:8000"
-  type: "chatbot"
-  model: "gpt-4"
-  verifiability: "TeeML"
-  priceDenomination: "USD"
-  inputPriceUSD: "0.50"
-  outputPriceUSD: "1.50"
-priceFeed:
-  sources: ["coingecko", "binance"]
-  sourceSymbols:
-    coingecko: "zero-gravity-usd"
-`)
-	t.Setenv("CONFIG_FILE", configPath)
-
-	cfg := &Config{}
-	err := loadConfig(cfg)
-	if err == nil || !strings.Contains(err.Error(), `missing an entry for source "binance"`) {
-		t.Errorf("expected error about missing sourceSymbols entry for binance, got %v", err)
-	}
-}
-
-func TestLoadConfig_USDMalformedSourceSymbol(t *testing.T) {
-	configPath := writeTestConfig(t, `
-service:
-  servingUrl: "http://example.com"
-  targetUrl: "http://backend:8000"
-  type: "chatbot"
-  model: "gpt-4"
-  verifiability: "TeeML"
-  priceDenomination: "USD"
-  inputPriceUSD: "0.50"
-  outputPriceUSD: "1.50"
-priceFeed:
-  sources: ["coingecko"]
-  sourceSymbols:
-    coingecko: "noseparator"
-`)
-	t.Setenv("CONFIG_FILE", configPath)
-
-	cfg := &Config{}
-	err := loadConfig(cfg)
-	if err == nil || !strings.Contains(err.Error(), "<base>-<quote>") {
-		t.Errorf("expected error about malformed sourceSymbols entry, got %v", err)
 	}
 }
 

--- a/api/inference/config/config_test.go
+++ b/api/inference/config/config_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func validModelInfo() *ModelInfo {
@@ -285,6 +286,35 @@ priceFeed:
 	}
 	if cfg.PriceFeed.MinOnChainUpdateBps != 500 {
 		t.Errorf("MinOnChainUpdateBps default = %d, want 500", cfg.PriceFeed.MinOnChainUpdateBps)
+	}
+}
+
+func TestLoadConfig_USDStalenessThresholdDefault(t *testing.T) {
+	// With stalenessThreshold unset, the config loader should apply the
+	// 3-hour absolute default (not a multiple of updateInterval).
+	configPath := writeTestConfig(t, `
+service:
+  servingUrl: "http://example.com"
+  targetUrl: "http://backend:8000"
+  type: "chatbot"
+  model: "gpt-4"
+  verifiability: "TeeML"
+  priceDenomination: "USD"
+  inputPriceUSD: "0.50"
+  outputPriceUSD: "1.50"
+priceFeed:
+  sources: ["coingecko"]
+  updateInterval: "30m"
+`)
+	t.Setenv("CONFIG_FILE", configPath)
+
+	cfg := &Config{}
+	if err := loadConfig(cfg); err != nil {
+		t.Fatalf("loadConfig failed: %v", err)
+	}
+	want := 3 * time.Hour
+	if cfg.PriceFeed.StalenessThreshold != want {
+		t.Errorf("StalenessThreshold default = %s, want %s", cfg.PriceFeed.StalenessThreshold, want)
 	}
 }
 

--- a/api/inference/const/const.go
+++ b/api/inference/const/const.go
@@ -31,7 +31,7 @@ const (
 // Price denomination modes for provider-configured service prices.
 // NATIVE: inputPrice/outputPrice are configured directly in wei (0G) and written
 //         to chain as-is; existing behavior.
-// USD:    inputPriceUSD/outputPriceUSD are configured in USD and converted to
+// USD:    inputPriceUSDPerMillionTokens/outputPriceUSDPerMillionTokens are configured in USD and converted to
 //         wei by the PriceUpdateProcessor using a live 0G/USDT rate.
 const (
 	PriceDenominationNative = "NATIVE"

--- a/api/inference/internal/ctrl/ctrl.go
+++ b/api/inference/internal/ctrl/ctrl.go
@@ -258,6 +258,22 @@ func (c *Ctrl) GetPriceCache() *pricefeed.Cache {
 	return c.priceCache
 }
 
+// GetPriceFeedSnapshot returns a snapshot of the in-memory wei-price +
+// rate cache together with the configured staleness threshold, plus a
+// boolean indicating whether the service is USD-denominated at all.
+//
+// Callers (e.g. the /v1/models handler) use this to surface the current
+// rate and staleness state to SDK clients without needing to reason about
+// USD-vs-NATIVE mode themselves: if isUSD=false the snapshot should be
+// ignored; if isUSD=true and snap.Populated is false the feed hasn't
+// bootstrapped yet.
+func (c *Ctrl) GetPriceFeedSnapshot() (snap pricefeed.Snapshot, stalenessThreshold time.Duration, isUSD bool) {
+	if !c.Service.IsUSDDenominated() || c.priceCache == nil {
+		return pricefeed.Snapshot{}, 0, false
+	}
+	return c.priceCache.Get(), c.priceFeed.StalenessThreshold, true
+}
+
 // InvalidateServiceCache clears the cached on-chain service record so the
 // next GetCachedService call re-reads from the contract.  Called by the
 // PriceUpdateProcessor after pushing a new price on-chain.

--- a/api/inference/internal/ctrl/service.go
+++ b/api/inference/internal/ctrl/service.go
@@ -77,8 +77,8 @@ func (c *Ctrl) GetCachedService(ctx context.Context) (model.Service, error) {
 		// Also carry the configured per-1M-tokens USD value through so the
 		// /v1/models handler can surface it.  Verbatim — conversion to
 		// per-token for display happens at the JSON boundary.
-		service.InputPriceUSD = c.Service.InputPriceUSD
-		service.OutputPriceUSD = c.Service.OutputPriceUSD
+		service.InputPriceUSDPerMillionTokens = c.Service.InputPriceUSDPerMillionTokens
+		service.OutputPriceUSDPerMillionTokens = c.Service.OutputPriceUSDPerMillionTokens
 	}
 	return service, nil
 }

--- a/api/inference/internal/ctrl/service.go
+++ b/api/inference/internal/ctrl/service.go
@@ -74,6 +74,11 @@ func (c *Ctrl) GetCachedService(ctx context.Context) (model.Service, error) {
 		}
 		service.InputPrice = snap.InputPriceWei.String()
 		service.OutputPrice = snap.OutputPriceWei.String()
+		// Also carry the configured per-1M-tokens USD value through so the
+		// /v1/models handler can surface it.  Verbatim — conversion to
+		// per-token for display happens at the JSON boundary.
+		service.InputPriceUSD = c.Service.InputPriceUSD
+		service.OutputPriceUSD = c.Service.OutputPriceUSD
 	}
 	return service, nil
 }

--- a/api/inference/internal/ctrl/service_test.go
+++ b/api/inference/internal/ctrl/service_test.go
@@ -33,8 +33,8 @@ func newUSDOverlayCtrl(t *testing.T, priceCache *pricefeed.Cache, staleness time
 		priceCache:   priceCache,
 		Service: config.Service{
 			PriceDenomination: constant.PriceDenominationUSD,
-			InputPriceUSD:     "0.50",
-			OutputPriceUSD:    "1.50",
+			InputPriceUSDPerMillionTokens:     "0.50",
+			OutputPriceUSDPerMillionTokens:    "1.50",
 		},
 		priceFeed: config.PriceFeedConfig{
 			StalenessThreshold: staleness,

--- a/api/inference/internal/ctrl/service_test.go
+++ b/api/inference/internal/ctrl/service_test.go
@@ -59,7 +59,7 @@ func TestGetCachedService_UnpopulatedCacheDistinctError(t *testing.T) {
 
 func TestGetCachedService_StaleCacheDistinctError(t *testing.T) {
 	pc := pricefeed.NewCache()
-	pc.Set(big.NewInt(100), big.NewInt(200), time.Now().Add(-2*time.Hour))
+	pc.Set(big.NewInt(100), big.NewInt(200), nil, time.Now().Add(-2*time.Hour))
 	c := newUSDOverlayCtrl(t, pc, 30*time.Minute)
 
 	_, err := c.GetCachedService(context.Background())
@@ -76,7 +76,7 @@ func TestGetCachedService_StaleCacheDistinctError(t *testing.T) {
 
 func TestGetCachedService_FreshCacheOverlaysPrices(t *testing.T) {
 	pc := pricefeed.NewCache()
-	pc.Set(big.NewInt(100), big.NewInt(200), time.Now())
+	pc.Set(big.NewInt(100), big.NewInt(200), nil, time.Now())
 	c := newUSDOverlayCtrl(t, pc, time.Hour)
 
 	svc, err := c.GetCachedService(context.Background())

--- a/api/inference/internal/event/price_update_processor.go
+++ b/api/inference/internal/event/price_update_processor.go
@@ -55,13 +55,13 @@ func NewPriceUpdateProcessor(
 	pfCfg config.PriceFeedConfig,
 	logger log.Logger,
 ) (*PriceUpdateProcessor, error) {
-	inputUSD, err := pricefeed.ParseUSDPerMillion(serviceCfg.InputPriceUSD)
+	inputUSD, err := pricefeed.ParseUSDPerMillion(serviceCfg.InputPriceUSDPerMillionTokens)
 	if err != nil {
-		return nil, fmt.Errorf("processor: parse inputPriceUSD: %w", err)
+		return nil, fmt.Errorf("processor: parse inputPriceUSDPerMillionTokens: %w", err)
 	}
-	outputUSD, err := pricefeed.ParseUSDPerMillion(serviceCfg.OutputPriceUSD)
+	outputUSD, err := pricefeed.ParseUSDPerMillion(serviceCfg.OutputPriceUSDPerMillionTokens)
 	if err != nil {
-		return nil, fmt.Errorf("processor: parse outputPriceUSD: %w", err)
+		return nil, fmt.Errorf("processor: parse outputPriceUSDPerMillionTokens: %w", err)
 	}
 	return &PriceUpdateProcessor{
 		cache:      cache,
@@ -156,11 +156,11 @@ func (p *PriceUpdateProcessor) Bootstrap(ctx context.Context) (inputWei, outputW
 
 	inputWei, err = pricefeed.USDPerMillionToWeiPerToken(p.inputUSD, rate)
 	if err != nil {
-		return nil, nil, fmt.Errorf("bootstrap: convert inputPriceUSD: %w", err)
+		return nil, nil, fmt.Errorf("bootstrap: convert inputPriceUSDPerMillionTokens: %w", err)
 	}
 	outputWei, err = pricefeed.USDPerMillionToWeiPerToken(p.outputUSD, rate)
 	if err != nil {
-		return nil, nil, fmt.Errorf("bootstrap: convert outputPriceUSD: %w", err)
+		return nil, nil, fmt.Errorf("bootstrap: convert outputPriceUSDPerMillionTokens: %w", err)
 	}
 
 	p.cache.Set(inputWei, outputWei, rate, time.Now())
@@ -202,12 +202,12 @@ func (p *PriceUpdateProcessor) tick(ctx context.Context) {
 
 	inputWei, err := pricefeed.USDPerMillionToWeiPerToken(p.inputUSD, rate)
 	if err != nil {
-		p.logger.Errorf("pricefeed tick: convert inputPriceUSD: %v", err)
+		p.logger.Errorf("pricefeed tick: convert inputPriceUSDPerMillionTokens: %v", err)
 		return
 	}
 	outputWei, err := pricefeed.USDPerMillionToWeiPerToken(p.outputUSD, rate)
 	if err != nil {
-		p.logger.Errorf("pricefeed tick: convert outputPriceUSD: %v", err)
+		p.logger.Errorf("pricefeed tick: convert outputPriceUSDPerMillionTokens: %v", err)
 		return
 	}
 

--- a/api/inference/internal/event/price_update_processor.go
+++ b/api/inference/internal/event/price_update_processor.go
@@ -74,12 +74,12 @@ func NewPriceUpdateProcessor(
 	}, nil
 }
 
-// Bootstrap retry knobs — declared as package vars rather than consts so
-// tests can shrink them to avoid minute-long sleeps.  Under Kubernetes, a
-// transient public-API outage (CoinGecko 429, regional 451, intermittent
-// 5xx) coinciding with a broker restart would otherwise CrashLoopBackoff
-// the pod; we prefer to absorb short outages and only fail once the outage
-// looks sustained.
+// Bootstrap and tick retry knobs — declared as package vars rather than
+// consts so tests can shrink them to avoid minute-long sleeps.  Under
+// Kubernetes, a transient public-API outage (CoinGecko 429, regional 451,
+// intermittent 5xx) coinciding with a broker restart would otherwise
+// CrashLoopBackoff the pod; we prefer to absorb short outages and only fail
+// once the outage looks sustained.
 var (
 	// bootstrapMaxAttempts bounds the boot-time rate-fetch retry loop.
 	bootstrapMaxAttempts = 6
@@ -89,7 +89,54 @@ var (
 	// bootstrapMaxBackoff caps the per-retry sleep so a long outage fails
 	// in bounded wall time rather than ballooning indefinitely.
 	bootstrapMaxBackoff = 30 * time.Second
+
+	// Runtime tick retries.  Scoped smaller than Bootstrap because the
+	// steady-state interval is long (hours) and we don't want retries to
+	// bleed into the next tick.  Three attempts with short backoff absorb
+	// the common flaky cases (brief 429, single 5xx) without delaying the
+	// loop significantly — worst-case total ~15-30s per failing tick.
+	tickMaxAttempts = 3
+	tickBaseBackoff = 5 * time.Second
+	tickMaxBackoff  = 30 * time.Second
 )
+
+// aggregateWithRetry wraps aggregator.Aggregate in an exponential-backoff
+// retry loop.  Shared between Bootstrap and tick so both paths behave
+// consistently under transient source failures.  label is used in log
+// messages to distinguish which caller is retrying.
+//
+// Returns the aggregated rate on the first success, or the last error after
+// maxAttempts.  Honours ctx cancellation during backoff sleeps.
+func (p *PriceUpdateProcessor) aggregateWithRetry(ctx context.Context, label string, maxAttempts int, baseBackoff, maxBackoff time.Duration) (*big.Rat, error) {
+	var lastErr error
+	backoff := baseBackoff
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		rate, _, err := p.aggregator.Aggregate(ctx)
+		if err == nil {
+			return rate, nil
+		}
+		lastErr = err
+		p.logger.Warnf("pricefeed %s: attempt %d/%d failed: %v", label, attempt, maxAttempts, err)
+		if attempt == maxAttempts {
+			break
+		}
+		// Use time.NewTimer + Stop so ctx cancellation doesn't leak a timer
+		// for up to maxBackoff.
+		timer := time.NewTimer(backoff)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return nil, fmt.Errorf("%s: context cancelled during retry: %w", label, ctx.Err())
+		case <-timer.C:
+		}
+		if backoff *= 2; backoff > maxBackoff {
+			backoff = maxBackoff
+		}
+	}
+	return nil, fmt.Errorf("%s: aggregate rate (after %d attempts): %w", label, maxAttempts, lastErr)
+}
 
 // Bootstrap performs a synchronous rate fetch and cache update with bounded
 // retries.  Called once at startup BEFORE any request billing, so both the
@@ -102,35 +149,9 @@ var (
 // regional block, transient 5xx — without making a sustained outage look
 // like a healthy start.
 func (p *PriceUpdateProcessor) Bootstrap(ctx context.Context) (inputWei, outputWei *big.Int, err error) {
-	var rate *big.Rat
-	var lastErr error
-	backoff := bootstrapBaseBackoff
-	for attempt := 1; attempt <= bootstrapMaxAttempts; attempt++ {
-		rate, _, lastErr = p.aggregator.Aggregate(ctx)
-		if lastErr == nil {
-			break
-		}
-		p.logger.Warnf("pricefeed bootstrap: attempt %d/%d failed: %v", attempt, bootstrapMaxAttempts, lastErr)
-		if attempt == bootstrapMaxAttempts {
-			break
-		}
-		// Use time.NewTimer + Stop so a ctx cancellation doesn't leak
-		// a timer for up to bootstrapMaxBackoff.
-		timer := time.NewTimer(backoff)
-		select {
-		case <-ctx.Done():
-			if !timer.Stop() {
-				<-timer.C
-			}
-			return nil, nil, fmt.Errorf("bootstrap: context cancelled during retry: %w", ctx.Err())
-		case <-timer.C:
-		}
-		if backoff *= 2; backoff > bootstrapMaxBackoff {
-			backoff = bootstrapMaxBackoff
-		}
-	}
-	if lastErr != nil {
-		return nil, nil, fmt.Errorf("bootstrap: aggregate initial rate (after %d attempts): %w", bootstrapMaxAttempts, lastErr)
+	rate, err := p.aggregateWithRetry(ctx, "bootstrap", bootstrapMaxAttempts, bootstrapBaseBackoff, bootstrapMaxBackoff)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	inputWei, err = pricefeed.USDPerMillionToWeiPerToken(p.inputUSD, rate)
@@ -168,13 +189,14 @@ func (p *PriceUpdateProcessor) Start(ctx context.Context) error {
 
 // tick runs one update cycle: aggregate → convert → update cache → maybe
 // push on-chain (via ctrl.SyncServicePrices, which performs drift gating
-// and mutex-guarded serialisation).  Any error is logged and the cache
-// from the previous tick is retained (readers enforce StalenessThreshold
-// independently).
+// and mutex-guarded serialisation).  Retries the aggregation up to
+// tickMaxAttempts to absorb transient feed failures; only on sustained
+// failure does the tick give up, log at error, and retain the last-good
+// cache (readers enforce StalenessThreshold independently).
 func (p *PriceUpdateProcessor) tick(ctx context.Context) {
-	rate, _, err := p.aggregator.Aggregate(ctx)
+	rate, err := p.aggregateWithRetry(ctx, "tick", tickMaxAttempts, tickBaseBackoff, tickMaxBackoff)
 	if err != nil {
-		p.logger.Warnf("pricefeed tick: aggregate failed (keeping last good cache): %v", err)
+		p.logger.Errorf("pricefeed tick: aggregate failed after retries (keeping last good cache): %v", err)
 		return
 	}
 

--- a/api/inference/internal/event/price_update_processor.go
+++ b/api/inference/internal/event/price_update_processor.go
@@ -142,7 +142,7 @@ func (p *PriceUpdateProcessor) Bootstrap(ctx context.Context) (inputWei, outputW
 		return nil, nil, fmt.Errorf("bootstrap: convert outputPriceUSD: %w", err)
 	}
 
-	p.cache.Set(inputWei, outputWei, time.Now())
+	p.cache.Set(inputWei, outputWei, rate, time.Now())
 	p.logger.Infof("pricefeed bootstrap: rate=%s USD/0G, inputPriceWei=%s, outputPriceWei=%s",
 		rate.FloatString(8), inputWei.String(), outputWei.String())
 	return inputWei, outputWei, nil
@@ -189,7 +189,7 @@ func (p *PriceUpdateProcessor) tick(ctx context.Context) {
 		return
 	}
 
-	p.cache.Set(inputWei, outputWei, time.Now())
+	p.cache.Set(inputWei, outputWei, rate, time.Now())
 	p.logger.Infof("pricefeed tick: rate=%s USD/0G, inputPriceWei=%s, outputPriceWei=%s",
 		rate.FloatString(8), inputWei.String(), outputWei.String())
 

--- a/api/inference/internal/event/price_update_processor_test.go
+++ b/api/inference/internal/event/price_update_processor_test.go
@@ -79,8 +79,11 @@ func defaultPFCfg() config.PriceFeedConfig {
 }
 
 func TestProcessor_Bootstrap_Success(t *testing.T) {
-	// Price: $0.50/1M tokens, rate: $0.003/0G.  Expected wei per token:
+	// Price: $0.50/1M tokens, rate: $0.003/0G.  Naive wei per token:
 	// floor((0.5 * 1e18) / (1_000_000 * 0.003)) = 166_666_666_666_666.
+	// After floor-quantising to 1e10 wei: 166_660_000_000_000.
+	// Output side: $1.50 / (1e6 * 0.003) * 1e18 = 500_000_000_000_000
+	// exactly, already a multiple of 1e10, so unchanged by quantisation.
 	srcs := []pricefeed.Source{pricefeedtest.NewMockSource("mock", mustRat("0.003"))}
 	p, cache := newTestProcessor(t, srcs, config.Service{
 		InputPriceUSD:  "0.50",
@@ -92,15 +95,13 @@ func TestProcessor_Bootstrap_Success(t *testing.T) {
 		t.Fatalf("bootstrap: %v", err)
 	}
 
-	wantInput, _ := new(big.Int).SetString("166666666666666", 10)
+	wantInput, _ := new(big.Int).SetString("166660000000000", 10)
 	if inputWei.Cmp(wantInput) != 0 {
 		t.Errorf("inputWei = %s, want %s", inputWei.String(), wantInput.String())
 	}
-	// Output price is 3× input price, so output wei is 3× input wei (modulo floor).
-	wantOutput := new(big.Int).Mul(wantInput, big.NewInt(3))
-	diff := new(big.Int).Sub(outputWei, wantOutput)
-	if diff.CmpAbs(big.NewInt(3)) > 0 {
-		t.Errorf("outputWei = %s, want ~%s (3× input)", outputWei.String(), wantOutput.String())
+	wantOutput, _ := new(big.Int).SetString("500000000000000", 10)
+	if outputWei.Cmp(wantOutput) != 0 {
+		t.Errorf("outputWei = %s, want %s", outputWei.String(), wantOutput.String())
 	}
 
 	snap := cache.Get()

--- a/api/inference/internal/event/price_update_processor_test.go
+++ b/api/inference/internal/event/price_update_processor_test.go
@@ -69,7 +69,6 @@ func newTestProcessor(t *testing.T, sources []pricefeed.Source, svcCfg config.Se
 func defaultPFCfg() config.PriceFeedConfig {
 	return config.PriceFeedConfig{
 		Sources:             []string{"mock"},
-		SourceSymbols:       map[string]string{"mock": "0g-usdt"},
 		UpdateInterval:      time.Hour,
 		StalenessThreshold:  2 * time.Hour,
 		MinOnChainUpdateBps: 500,

--- a/api/inference/internal/event/price_update_processor_test.go
+++ b/api/inference/internal/event/price_update_processor_test.go
@@ -86,8 +86,8 @@ func TestProcessor_Bootstrap_Success(t *testing.T) {
 	// exactly, already a multiple of 1e10, so unchanged by quantisation.
 	srcs := []pricefeed.Source{pricefeedtest.NewMockSource("mock", mustRat("0.003"))}
 	p, cache := newTestProcessor(t, srcs, config.Service{
-		InputPriceUSD:  "0.50",
-		OutputPriceUSD: "1.50",
+		InputPriceUSDPerMillionTokens:  "0.50",
+		OutputPriceUSDPerMillionTokens: "1.50",
 	}, defaultPFCfg())
 
 	inputWei, outputWei, err := p.Bootstrap(context.Background())
@@ -127,8 +127,8 @@ func TestProcessor_Bootstrap_AggregatorFails(t *testing.T) {
 	failing := pricefeedtest.NewMockSource("mock", nil)
 	failing.SetError(errors.New("boom"))
 	p, cache := newTestProcessor(t, []pricefeed.Source{failing}, config.Service{
-		InputPriceUSD:  "0.50",
-		OutputPriceUSD: "1.50",
+		InputPriceUSDPerMillionTokens:  "0.50",
+		OutputPriceUSDPerMillionTokens: "1.50",
 	}, defaultPFCfg())
 
 	_, _, err := p.Bootstrap(context.Background())
@@ -161,8 +161,8 @@ func TestProcessor_Bootstrap_SucceedsAfterTransientFailure(t *testing.T) {
 	flaky.SetFailFirst(2) // 1st and 2nd FetchRate fail; 3rd returns the rate.
 
 	p, cache := newTestProcessor(t, []pricefeed.Source{flaky}, config.Service{
-		InputPriceUSD:  "0.50",
-		OutputPriceUSD: "1.50",
+		InputPriceUSDPerMillionTokens:  "0.50",
+		OutputPriceUSDPerMillionTokens: "1.50",
 	}, defaultPFCfg())
 
 	if _, _, err := p.Bootstrap(context.Background()); err != nil {
@@ -193,8 +193,8 @@ func TestProcessor_Tick_RetriesOnTransientFailure(t *testing.T) {
 	flaky.SetFailFirst(2) // 1st and 2nd fail; 3rd returns rate.
 
 	p, cache := newTestProcessor(t, []pricefeed.Source{flaky}, config.Service{
-		InputPriceUSD:  "0.50",
-		OutputPriceUSD: "1.50",
+		InputPriceUSDPerMillionTokens:  "0.50",
+		OutputPriceUSDPerMillionTokens: "1.50",
 	}, defaultPFCfg())
 
 	p.tick(context.Background())
@@ -222,8 +222,8 @@ func TestProcessor_Tick_KeepsLastGoodCacheOnSustainedFailure(t *testing.T) {
 	failing := pricefeedtest.NewMockSource("mock", nil)
 	failing.SetError(errors.New("boom"))
 	p, cache := newTestProcessor(t, []pricefeed.Source{failing}, config.Service{
-		InputPriceUSD:  "0.50",
-		OutputPriceUSD: "1.50",
+		InputPriceUSDPerMillionTokens:  "0.50",
+		OutputPriceUSDPerMillionTokens: "1.50",
 	}, defaultPFCfg())
 
 	// Prime the cache with a known good value so we can verify it's
@@ -248,10 +248,10 @@ func TestNewPriceUpdateProcessor_InvalidUSDPrice(t *testing.T) {
 	cache := pricefeed.NewCache()
 	agg := pricefeed.NewAggregator(nil, 1, 500, time.Second, nopLogger{})
 	_, err := NewPriceUpdateProcessor(cache, agg, nil, config.Service{
-		InputPriceUSD:  "not-a-number",
-		OutputPriceUSD: "1.50",
+		InputPriceUSDPerMillionTokens:  "not-a-number",
+		OutputPriceUSDPerMillionTokens: "1.50",
 	}, defaultPFCfg(), nopLogger{})
 	if err == nil {
-		t.Error("expected constructor to reject invalid inputPriceUSD")
+		t.Error("expected constructor to reject invalid inputPriceUSDPerMillionTokens")
 	}
 }

--- a/api/inference/internal/event/price_update_processor_test.go
+++ b/api/inference/internal/event/price_update_processor_test.go
@@ -176,6 +176,71 @@ func TestProcessor_Bootstrap_SucceedsAfterTransientFailure(t *testing.T) {
 	}
 }
 
+func TestProcessor_Tick_RetriesOnTransientFailure(t *testing.T) {
+	// Tick should absorb short-lived failures (fail → retry → succeed) and
+	// populate the cache rather than waiting a full updateInterval for the
+	// next scheduled tick.  Mirrors the Bootstrap transient-failure test
+	// but through the tick path.
+	oldAttempts, oldBase, oldMax := tickMaxAttempts, tickBaseBackoff, tickMaxBackoff
+	tickMaxAttempts = 3
+	tickBaseBackoff = time.Millisecond
+	tickMaxBackoff = 5 * time.Millisecond
+	t.Cleanup(func() {
+		tickMaxAttempts, tickBaseBackoff, tickMaxBackoff = oldAttempts, oldBase, oldMax
+	})
+
+	flaky := pricefeedtest.NewMockSource("mock", mustRat("0.003"))
+	flaky.SetFailFirst(2) // 1st and 2nd fail; 3rd returns rate.
+
+	p, cache := newTestProcessor(t, []pricefeed.Source{flaky}, config.Service{
+		InputPriceUSD:  "0.50",
+		OutputPriceUSD: "1.50",
+	}, defaultPFCfg())
+
+	p.tick(context.Background())
+
+	if !cache.Get().Populated {
+		t.Error("cache should be populated after tick recovered via retry")
+	}
+	if got := flaky.Calls(); got != 3 {
+		t.Errorf("expected 3 FetchRate calls (2 fail + 1 success), got %d", got)
+	}
+}
+
+func TestProcessor_Tick_KeepsLastGoodCacheOnSustainedFailure(t *testing.T) {
+	// When every retry attempt fails, the tick must NOT touch the cache —
+	// stale readers fail closed via StalenessThreshold, not via cache
+	// corruption.
+	oldAttempts, oldBase, oldMax := tickMaxAttempts, tickBaseBackoff, tickMaxBackoff
+	tickMaxAttempts = 3
+	tickBaseBackoff = time.Millisecond
+	tickMaxBackoff = 5 * time.Millisecond
+	t.Cleanup(func() {
+		tickMaxAttempts, tickBaseBackoff, tickMaxBackoff = oldAttempts, oldBase, oldMax
+	})
+
+	failing := pricefeedtest.NewMockSource("mock", nil)
+	failing.SetError(errors.New("boom"))
+	p, cache := newTestProcessor(t, []pricefeed.Source{failing}, config.Service{
+		InputPriceUSD:  "0.50",
+		OutputPriceUSD: "1.50",
+	}, defaultPFCfg())
+
+	// Prime the cache with a known good value so we can verify it's
+	// retained untouched after the failing tick.
+	cache.Set(big.NewInt(111), big.NewInt(222), mustRat("0.001"), time.Now())
+
+	p.tick(context.Background())
+
+	if got := failing.Calls(); got != 3 {
+		t.Errorf("expected 3 FetchRate calls (all retries), got %d", got)
+	}
+	snap := cache.Get()
+	if snap.InputPriceWei.Cmp(big.NewInt(111)) != 0 || snap.OutputPriceWei.Cmp(big.NewInt(222)) != 0 {
+		t.Errorf("cache was overwritten on failing tick: input=%s output=%s", snap.InputPriceWei, snap.OutputPriceWei)
+	}
+}
+
 func TestNewPriceUpdateProcessor_InvalidUSDPrice(t *testing.T) {
 	// Parse-once moves the USD validation up to the constructor, so a bad
 	// price is caught before the server even starts ticking — no "error

--- a/api/inference/internal/handler/handler.go
+++ b/api/inference/internal/handler/handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"golang.org/x/time/rate"
@@ -13,6 +14,7 @@ import (
 	"github.com/0glabs/0g-serving-broker/common/middleware"
 	"github.com/0glabs/0g-serving-broker/inference/config"
 	"github.com/0glabs/0g-serving-broker/inference/internal/ctrl"
+	"github.com/0glabs/0g-serving-broker/inference/internal/pricefeed"
 	"github.com/0glabs/0g-serving-broker/inference/internal/proxy"
 	"github.com/0glabs/0g-serving-broker/inference/model"
 )
@@ -35,6 +37,7 @@ type modelsCtrl interface {
 	GetTieredPricingConfig() config.TieredPricingConfig
 	GetCacheTokenBillingConfig() config.CacheTokenBillingConfig
 	GetConcurrencyLimitConfig() config.ConcurrencyLimitConfig
+	GetPriceFeedSnapshot() (snap pricefeed.Snapshot, stalenessThreshold time.Duration, isUSD bool)
 }
 
 type Handler struct {

--- a/api/inference/internal/handler/models.go
+++ b/api/inference/internal/handler/models.go
@@ -211,9 +211,9 @@ func (h *Handler) GetModels(ctx *gin.Context) {
 	// the configured per-1M-tokens value) plus the live rate-feed state.
 	// Both blocks are omitted entirely in NATIVE mode.
 	var priceFeedOut *PriceFeedState
-	if svc.InputPriceUSD != "" && svc.OutputPriceUSD != "" {
-		if prompt, err := pricefeed.USDPerMillionStringToPerToken(svc.InputPriceUSD); err == nil {
-			if completion, err := pricefeed.USDPerMillionStringToPerToken(svc.OutputPriceUSD); err == nil {
+	if svc.InputPriceUSDPerMillionTokens != "" && svc.OutputPriceUSDPerMillionTokens != "" {
+		if prompt, err := pricefeed.USDPerMillionStringToPerToken(svc.InputPriceUSDPerMillionTokens); err == nil {
+			if completion, err := pricefeed.USDPerMillionStringToPerToken(svc.OutputPriceUSDPerMillionTokens); err == nil {
 				obj.PricingUSD = &ModelPricingUSD{Prompt: prompt, Completion: completion}
 			}
 		}

--- a/api/inference/internal/handler/models.go
+++ b/api/inference/internal/handler/models.go
@@ -3,11 +3,13 @@ package handler
 import (
 	"encoding/json"
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
 
 	"github.com/0glabs/0g-serving-broker/inference/config"
 	constant "github.com/0glabs/0g-serving-broker/inference/const"
+	"github.com/0glabs/0g-serving-broker/inference/internal/pricefeed"
 )
 
 // ModelObject represents a single model in the OpenAI-compatible /v1/models response.
@@ -26,6 +28,7 @@ type ModelObject struct {
 	SupportedFormats    []string                  `json:"supported_formats,omitempty"`
 	DefaultParameters   map[string]interface{}    `json:"default_parameters,omitempty"`
 	Pricing             *ModelPricing             `json:"pricing,omitempty"`
+	PricingUSD          *ModelPricingUSD          `json:"pricingUSD,omitempty"`
 	Verifiability       string                    `json:"verifiability,omitempty"`
 	TeeAttested         bool                      `json:"tee_attested"`
 	TeeType             string                    `json:"tee_type,omitempty"`
@@ -66,10 +69,29 @@ type ModelPricing struct {
 	CacheTokenBilling *ModelCacheTokenBilling `json:"cache_token_billing,omitempty"`
 }
 
+// ModelPricingUSD holds per-token USD pricing as trimmed decimal strings.
+// Present only when the provider is USD-denominated; omitted in NATIVE mode.
+// Values are derived from the configured USD-per-1M-tokens by exact big.Rat
+// division — no float precision loss.
+type ModelPricingUSD struct {
+	Prompt     string `json:"prompt"`
+	Completion string `json:"completion"`
+}
+
+// PriceFeedState surfaces the live 0G/USD rate and its freshness.  Present
+// only when the provider is USD-denominated and the price cache has been
+// populated at least once.
+type PriceFeedState struct {
+	RateUSDPerOG string    `json:"rateUSDPerOG"`
+	UpdatedAt    time.Time `json:"updatedAt"`
+	IsStale      bool      `json:"isStale"`
+}
+
 // ModelListResponse is the OpenAI-compatible response for GET /v1/models.
 type ModelListResponse struct {
-	Object string        `json:"object"`
-	Data   []ModelObject `json:"data"`
+	Object    string          `json:"object"`
+	Data      []ModelObject   `json:"data"`
+	PriceFeed *PriceFeedState `json:"priceFeed,omitempty"`
 }
 
 // GetModels returns the list of models served by this broker.
@@ -185,9 +207,29 @@ func (h *Handler) GetModels(ctx *gin.Context) {
 		obj.ProviderIdentity = cfg.ProviderIdentity
 	}
 
+	// USD-denominated providers: surface per-token USD pricing (derived from
+	// the configured per-1M-tokens value) plus the live rate-feed state.
+	// Both blocks are omitted entirely in NATIVE mode.
+	var priceFeedOut *PriceFeedState
+	if svc.InputPriceUSD != "" && svc.OutputPriceUSD != "" {
+		if prompt, err := pricefeed.USDPerMillionStringToPerToken(svc.InputPriceUSD); err == nil {
+			if completion, err := pricefeed.USDPerMillionStringToPerToken(svc.OutputPriceUSD); err == nil {
+				obj.PricingUSD = &ModelPricingUSD{Prompt: prompt, Completion: completion}
+			}
+		}
+	}
+	if snap, threshold, isUSD := h.modelsCtrl.GetPriceFeedSnapshot(); isUSD && snap.Populated && snap.RateUSDPerOG != nil {
+		priceFeedOut = &PriceFeedState{
+			RateUSDPerOG: snap.RateUSDPerOG.FloatString(8),
+			UpdatedAt:    snap.LastUpdate,
+			IsStale:      snap.IsStale(threshold, time.Now()),
+		}
+	}
+
 	ctx.JSON(http.StatusOK, ModelListResponse{
-		Object: "list",
-		Data:   []ModelObject{obj},
+		Object:    "list",
+		Data:      []ModelObject{obj},
+		PriceFeed: priceFeedOut,
 	})
 }
 

--- a/api/inference/internal/handler/models_test.go
+++ b/api/inference/internal/handler/models_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"math/big"
 	"net/http"
 	"testing"
 	"time"
 
 	"github.com/0glabs/0g-serving-broker/inference/config"
+	"github.com/0glabs/0g-serving-broker/inference/internal/pricefeed"
 	"github.com/0glabs/0g-serving-broker/inference/model"
 )
 
@@ -21,6 +23,9 @@ type mockModelsCtrl struct {
 	tieredPricingConfig     config.TieredPricingConfig
 	cacheTokenBillingConfig config.CacheTokenBillingConfig
 	concurrencyLimitConfig  config.ConcurrencyLimitConfig
+	priceFeedSnapshot       pricefeed.Snapshot
+	priceFeedThreshold      time.Duration
+	priceFeedIsUSD          bool
 }
 
 func (m *mockModelsCtrl) GetCachedService(_ context.Context) (model.Service, error) {
@@ -41,6 +46,10 @@ func (m *mockModelsCtrl) GetCacheTokenBillingConfig() config.CacheTokenBillingCo
 
 func (m *mockModelsCtrl) GetConcurrencyLimitConfig() config.ConcurrencyLimitConfig {
 	return m.concurrencyLimitConfig
+}
+
+func (m *mockModelsCtrl) GetPriceFeedSnapshot() (pricefeed.Snapshot, time.Duration, bool) {
+	return m.priceFeedSnapshot, m.priceFeedThreshold, m.priceFeedIsUSD
 }
 
 func newModelsTestHandler(mock *mockModelsCtrl) *Handler {
@@ -473,6 +482,187 @@ func TestGetModels_DecentralizedOmitsProviderFields(t *testing.T) {
 	}
 	if _, exists := modelMap["provider_identity"]; exists {
 		t.Error("provider_identity should be omitted from JSON for decentralized providers")
+	}
+}
+
+func TestGetModels_USDPricingAndFeedState(t *testing.T) {
+	// USD mode: service carries per-1M USD strings, and priceCache has a
+	// fresh rate.  Response should include pricingUSD (per-token, derived
+	// from per-million by /1e6) and the top-level priceFeed block.
+	rate, _ := new(big.Rat).SetString("0.00321")
+	updatedAt := time.Now().Add(-5 * time.Second)
+	mock := &mockModelsCtrl{
+		service: model.Service{
+			ModelType:      "test-model",
+			Type:           "chatbot",
+			InputPrice:     "166660000000000",
+			OutputPrice:    "500000000000000",
+			InputPriceUSD:  "0.50",
+			OutputPriceUSD: "1.50",
+		},
+		serviceConfig: config.Service{},
+		priceFeedIsUSD: true,
+		priceFeedSnapshot: pricefeed.Snapshot{
+			InputPriceWei:  big.NewInt(166660000000000),
+			OutputPriceWei: big.NewInt(500000000000000),
+			RateUSDPerOG:   rate,
+			LastUpdate:     updatedAt,
+			Populated:      true,
+		},
+		priceFeedThreshold: 5 * time.Minute,
+	}
+
+	h := newModelsTestHandler(mock)
+	w := performRequest(h.GetModels, "GET", "/v1/models", "", nil)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	var resp ModelListResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse response: %v", err)
+	}
+	if len(resp.Data) != 1 {
+		t.Fatalf("expected 1 model, got %d", len(resp.Data))
+	}
+	m := resp.Data[0]
+
+	// pricingUSD: per-token, derived from $0.50/M and $1.50/M config.
+	if m.PricingUSD == nil {
+		t.Fatal("expected pricingUSD to be present in USD mode")
+	}
+	if m.PricingUSD.Prompt != "0.0000005" {
+		t.Errorf("pricingUSD.prompt = %q, want 0.0000005", m.PricingUSD.Prompt)
+	}
+	if m.PricingUSD.Completion != "0.0000015" {
+		t.Errorf("pricingUSD.completion = %q, want 0.0000015", m.PricingUSD.Completion)
+	}
+
+	// priceFeed: rate decimal-formatted, isStale=false, updatedAt echoed.
+	if resp.PriceFeed == nil {
+		t.Fatal("expected top-level priceFeed block in USD mode with populated cache")
+	}
+	if resp.PriceFeed.RateUSDPerOG != "0.00321000" {
+		t.Errorf("rateUSDPerOG = %q, want 0.00321000 (FloatString(8))", resp.PriceFeed.RateUSDPerOG)
+	}
+	if resp.PriceFeed.IsStale {
+		t.Error("isStale = true, want false for 5s-old cache + 5m threshold")
+	}
+	if !resp.PriceFeed.UpdatedAt.Equal(updatedAt) {
+		t.Errorf("updatedAt = %v, want %v", resp.PriceFeed.UpdatedAt, updatedAt)
+	}
+}
+
+func TestGetModels_NativeModeOmitsUSDBlocks(t *testing.T) {
+	// NATIVE mode: no InputPriceUSD on the service, priceFeedIsUSD=false.
+	// Response must have no pricingUSD on models and no priceFeed at top
+	// level — the raw JSON must not even contain those keys.
+	mock := &mockModelsCtrl{
+		service: model.Service{
+			ModelType:   "test-model",
+			Type:        "chatbot",
+			InputPrice:  "100",
+			OutputPrice: "200",
+		},
+		serviceConfig:  config.Service{},
+		priceFeedIsUSD: false,
+	}
+
+	h := newModelsTestHandler(mock)
+	w := performRequest(h.GetModels, "GET", "/v1/models", "", nil)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	// Raw-JSON check: keys must be absent (not just null/empty).
+	var raw map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("parse raw: %v", err)
+	}
+	if _, exists := raw["priceFeed"]; exists {
+		t.Error("priceFeed key should be absent in NATIVE mode")
+	}
+	data, _ := raw["data"].([]interface{})
+	if len(data) == 0 {
+		t.Fatal("data empty")
+	}
+	m, _ := data[0].(map[string]interface{})
+	if _, exists := m["pricingUSD"]; exists {
+		t.Error("pricingUSD key should be absent in NATIVE mode")
+	}
+}
+
+func TestGetModels_USDModeCachePopulatedButStale(t *testing.T) {
+	// USD mode with cache older than threshold — isStale must be true.
+	rate, _ := new(big.Rat).SetString("0.003")
+	mock := &mockModelsCtrl{
+		service: model.Service{
+			ModelType:      "test-model",
+			Type:           "chatbot",
+			InputPrice:     "1",
+			OutputPrice:    "1",
+			InputPriceUSD:  "0.50",
+			OutputPriceUSD: "1.50",
+		},
+		serviceConfig: config.Service{},
+		priceFeedIsUSD: true,
+		priceFeedSnapshot: pricefeed.Snapshot{
+			InputPriceWei:  big.NewInt(1),
+			OutputPriceWei: big.NewInt(1),
+			RateUSDPerOG:   rate,
+			LastUpdate:     time.Now().Add(-10 * time.Minute),
+			Populated:      true,
+		},
+		priceFeedThreshold: time.Minute,
+	}
+
+	h := newModelsTestHandler(mock)
+	w := performRequest(h.GetModels, "GET", "/v1/models", "", nil)
+	var resp ModelListResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if resp.PriceFeed == nil {
+		t.Fatal("expected priceFeed block for populated cache (even when stale)")
+	}
+	if !resp.PriceFeed.IsStale {
+		t.Error("isStale = false, want true for 10min-old cache + 1min threshold")
+	}
+}
+
+func TestGetModels_USDModeUnpopulatedCacheOmitsPriceFeed(t *testing.T) {
+	// USD mode but cache not yet populated (pre-bootstrap).  The pricingUSD
+	// block derived from config still appears; the top-level priceFeed is
+	// omitted since there's no meaningful rate to report.
+	mock := &mockModelsCtrl{
+		service: model.Service{
+			ModelType:      "test-model",
+			Type:           "chatbot",
+			InputPrice:     "1",
+			OutputPrice:    "1",
+			InputPriceUSD:  "0.50",
+			OutputPriceUSD: "1.50",
+		},
+		serviceConfig:     config.Service{},
+		priceFeedIsUSD:    true,
+		priceFeedSnapshot: pricefeed.Snapshot{Populated: false},
+	}
+	h := newModelsTestHandler(mock)
+	w := performRequest(h.GetModels, "GET", "/v1/models", "", nil)
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if _, exists := raw["priceFeed"]; exists {
+		t.Error("priceFeed should be absent when cache unpopulated")
+	}
+	var resp ModelListResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.Data[0].PricingUSD == nil {
+		t.Error("pricingUSD should still be present (derived from config, not cache)")
 	}
 }
 

--- a/api/inference/internal/handler/models_test.go
+++ b/api/inference/internal/handler/models_test.go
@@ -497,8 +497,8 @@ func TestGetModels_USDPricingAndFeedState(t *testing.T) {
 			Type:           "chatbot",
 			InputPrice:     "166660000000000",
 			OutputPrice:    "500000000000000",
-			InputPriceUSD:  "0.50",
-			OutputPriceUSD: "1.50",
+			InputPriceUSDPerMillionTokens:  "0.50",
+			OutputPriceUSDPerMillionTokens: "1.50",
 		},
 		serviceConfig: config.Service{},
 		priceFeedIsUSD: true,
@@ -555,7 +555,7 @@ func TestGetModels_USDPricingAndFeedState(t *testing.T) {
 }
 
 func TestGetModels_NativeModeOmitsUSDBlocks(t *testing.T) {
-	// NATIVE mode: no InputPriceUSD on the service, priceFeedIsUSD=false.
+	// NATIVE mode: no InputPriceUSDPerMillionTokens on the service, priceFeedIsUSD=false.
 	// Response must have no pricingUSD on models and no priceFeed at top
 	// level — the raw JSON must not even contain those keys.
 	mock := &mockModelsCtrl{
@@ -603,8 +603,8 @@ func TestGetModels_USDModeCachePopulatedButStale(t *testing.T) {
 			Type:           "chatbot",
 			InputPrice:     "1",
 			OutputPrice:    "1",
-			InputPriceUSD:  "0.50",
-			OutputPriceUSD: "1.50",
+			InputPriceUSDPerMillionTokens:  "0.50",
+			OutputPriceUSDPerMillionTokens: "1.50",
 		},
 		serviceConfig: config.Service{},
 		priceFeedIsUSD: true,
@@ -642,8 +642,8 @@ func TestGetModels_USDModeUnpopulatedCacheOmitsPriceFeed(t *testing.T) {
 			Type:           "chatbot",
 			InputPrice:     "1",
 			OutputPrice:    "1",
-			InputPriceUSD:  "0.50",
-			OutputPriceUSD: "1.50",
+			InputPriceUSDPerMillionTokens:  "0.50",
+			OutputPriceUSDPerMillionTokens: "1.50",
 		},
 		serviceConfig:     config.Service{},
 		priceFeedIsUSD:    true,

--- a/api/inference/internal/pricefeed/cache.go
+++ b/api/inference/internal/pricefeed/cache.go
@@ -7,19 +7,21 @@ import (
 )
 
 // Cache holds the most recently computed wei prices for the USD-denominated
-// service.  Readers on the request-billing hot path call Get and must handle
-// the "not yet populated" and "stale" cases.  The PriceUpdateProcessor is the
-// sole writer; Set is called once per successful tick.
+// service, along with the rate they were derived from.  Readers on the
+// request-billing hot path call Get and must handle the "not yet populated"
+// and "stale" cases.  The PriceUpdateProcessor is the sole writer; Set is
+// called once per successful tick.
 //
-// The rate itself is deliberately not stored — it's a transient value
-// internal to each update tick.  Only the wei prices derived from it are
-// exposed.  Storing the rate would imply it's authoritative, when in reality
-// the authoritative billing unit is always wei.
+// The stored rate is informational only — it's surfaced in the /v1/models
+// response so SDK clients can display the rate, but the authoritative
+// billing unit is always wei.  Fee calculation never reads the rate back
+// from the cache.
 type Cache struct {
 	mu sync.RWMutex
 
 	inputPriceWei  *big.Int
 	outputPriceWei *big.Int
+	rateUSDPerOG   *big.Rat
 	lastUpdate     time.Time
 }
 
@@ -30,11 +32,13 @@ func NewCache() *Cache {
 }
 
 // Snapshot is a read-only view of the cache at a point in time.  The big.Int
-// values are fresh copies so callers may mutate them without affecting the
-// cache.  Populated is false iff the cache has never been written.
+// and big.Rat values are fresh copies so callers may mutate them without
+// affecting the cache.  Populated is false iff the cache has never been
+// written.
 type Snapshot struct {
 	InputPriceWei  *big.Int
 	OutputPriceWei *big.Int
+	RateUSDPerOG   *big.Rat
 	LastUpdate     time.Time
 	Populated      bool
 }
@@ -48,21 +52,31 @@ func (c *Cache) Get() Snapshot {
 	if c.inputPriceWei == nil || c.outputPriceWei == nil {
 		return Snapshot{}
 	}
-	return Snapshot{
+	snap := Snapshot{
 		InputPriceWei:  new(big.Int).Set(c.inputPriceWei),
 		OutputPriceWei: new(big.Int).Set(c.outputPriceWei),
 		LastUpdate:     c.lastUpdate,
 		Populated:      true,
 	}
+	if c.rateUSDPerOG != nil {
+		snap.RateUSDPerOG = new(big.Rat).Set(c.rateUSDPerOG)
+	}
+	return snap
 }
 
-// Set replaces the cached prices and stamps the update time.  Intended for the
-// processor only; fee-computation code must not call this.
-func (c *Cache) Set(inputWei, outputWei *big.Int, at time.Time) {
+// Set replaces the cached prices, rate, and update time.  Intended for the
+// processor only; fee-computation code must not call this.  rate may be nil
+// for callers that don't track it (e.g. tests); readers must handle that.
+func (c *Cache) Set(inputWei, outputWei *big.Int, rate *big.Rat, at time.Time) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.inputPriceWei = new(big.Int).Set(inputWei)
 	c.outputPriceWei = new(big.Int).Set(outputWei)
+	if rate != nil {
+		c.rateUSDPerOG = new(big.Rat).Set(rate)
+	} else {
+		c.rateUSDPerOG = nil
+	}
 	c.lastUpdate = at
 }
 

--- a/api/inference/internal/pricefeed/cache_test.go
+++ b/api/inference/internal/pricefeed/cache_test.go
@@ -20,7 +20,7 @@ func TestCache_GetEmpty(t *testing.T) {
 func TestCache_SetAndGet(t *testing.T) {
 	c := NewCache()
 	at := time.Now()
-	c.Set(big.NewInt(100), big.NewInt(200), at)
+	c.Set(big.NewInt(100), big.NewInt(200), nil, at)
 
 	snap := c.Get()
 	if !snap.Populated {
@@ -39,7 +39,7 @@ func TestCache_SetAndGet(t *testing.T) {
 
 func TestCache_SnapshotIsIndependentCopy(t *testing.T) {
 	c := NewCache()
-	c.Set(big.NewInt(100), big.NewInt(200), time.Now())
+	c.Set(big.NewInt(100), big.NewInt(200), nil, time.Now())
 	s1 := c.Get()
 	s1.InputPriceWei.SetInt64(999)
 
@@ -49,10 +49,41 @@ func TestCache_SnapshotIsIndependentCopy(t *testing.T) {
 	}
 }
 
+func TestCache_RateRoundTrip(t *testing.T) {
+	c := NewCache()
+	rate, _ := new(big.Rat).SetString("0.003210")
+	c.Set(big.NewInt(100), big.NewInt(200), rate, time.Now())
+
+	snap := c.Get()
+	if snap.RateUSDPerOG == nil {
+		t.Fatal("RateUSDPerOG nil after Set with non-nil rate")
+	}
+	if snap.RateUSDPerOG.Cmp(rate) != 0 {
+		t.Errorf("rate = %s, want %s", snap.RateUSDPerOG.FloatString(6), rate.FloatString(6))
+	}
+
+	// Snapshot must be an independent copy: mutating it does not affect
+	// the next Get().
+	snap.RateUSDPerOG.SetFloat64(999)
+	again := c.Get()
+	if again.RateUSDPerOG.Cmp(rate) != 0 {
+		t.Errorf("mutating snapshot corrupted cache rate: got %s", again.RateUSDPerOG.FloatString(6))
+	}
+}
+
+func TestCache_NilRateSetsNilSnapshot(t *testing.T) {
+	c := NewCache()
+	c.Set(big.NewInt(1), big.NewInt(2), nil, time.Now())
+	snap := c.Get()
+	if snap.RateUSDPerOG != nil {
+		t.Errorf("RateUSDPerOG = %v, want nil when Set passed nil rate", snap.RateUSDPerOG)
+	}
+}
+
 func TestSnapshot_IsStale(t *testing.T) {
 	c := NewCache()
 	now := time.Now()
-	c.Set(big.NewInt(1), big.NewInt(2), now.Add(-2*time.Minute))
+	c.Set(big.NewInt(1), big.NewInt(2), nil, now.Add(-2*time.Minute))
 	snap := c.Get()
 
 	if snap.IsStale(5*time.Minute, now) {

--- a/api/inference/internal/pricefeed/convert.go
+++ b/api/inference/internal/pricefeed/convert.go
@@ -81,6 +81,45 @@ func USDPerMillionToWeiPerToken(priceUSDPerMillion, rateUSDPerOG *big.Rat) (*big
 	return wei, nil
 }
 
+// USDPerMillionStringToPerToken parses a USD-per-1M-tokens decimal string
+// (e.g. "0.50"), divides exactly by 1_000_000, and returns the per-token
+// price as a decimal string with trailing zeros trimmed (e.g. "0.0000005").
+// Uses big.Rat throughout so there is no float precision loss.
+//
+// The formatting precision (18 decimals before trimming) matches wei-unit
+// resolution — any sensible configured price has fewer significant digits
+// than that, so the trimmed output is the shortest exact representation.
+//
+// Empty, negative, or unparseable input returns an error; the caller is
+// expected to have already validated the config value upstream.
+func USDPerMillionStringToPerToken(s string) (string, error) {
+	perMillion, err := ParseUSDPerMillion(s)
+	if err != nil {
+		return "", err
+	}
+	perToken := new(big.Rat).Quo(perMillion, new(big.Rat).SetInt(tokensPerMillion))
+	// FloatString pads to the requested precision; strip the noise.
+	out := perToken.FloatString(18)
+	return trimTrailingZeros(out), nil
+}
+
+// trimTrailingZeros removes trailing zeros after a decimal point and, if
+// that leaves a bare decimal point, drops it too.  "0.500000" -> "0.5",
+// "1.000000" -> "1", "10" -> "10" (unchanged).
+func trimTrailingZeros(s string) string {
+	if !strings.ContainsRune(s, '.') {
+		return s
+	}
+	i := len(s)
+	for i > 0 && s[i-1] == '0' {
+		i--
+	}
+	if i > 0 && s[i-1] == '.' {
+		i--
+	}
+	return s[:i]
+}
+
 // DriftBps returns the absolute difference between `current` and `reference`,
 // expressed in basis points (1/10000) of `reference`.  When reference is zero
 // any non-zero change is treated as infinite drift (returns math.MaxInt).

--- a/api/inference/internal/pricefeed/convert.go
+++ b/api/inference/internal/pricefeed/convert.go
@@ -13,6 +13,15 @@ var weiPerOG = new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
 // tokensPerMillion is the denominator for "USD per 1M tokens" pricing.
 var tokensPerMillion = big.NewInt(1_000_000)
 
+// priceQuantumWei is the granularity we snap wei-per-token prices to.
+// 1e10 wei/token == 0.01 0G per million tokens — two decimal places in 0G/M
+// space.  Floor-quantising here buys stable, human-readable on-chain prices
+// across small rate wobbles and reduces SyncService churn, at the cost of
+// at most `priceQuantumWei * rate` USD/M of drift per tick (well below
+// MinOnChainUpdateBps).  Floor favours the user: the broker can never
+// accidentally charge more than the unquantised conversion would yield.
+var priceQuantumWei = big.NewInt(1e10)
+
 // ParseUSDPerMillion parses a USD-per-million-tokens decimal string into a
 // big.Rat.  Accepts plain decimal notation (e.g. "0.50", "1.234567").
 // Rejects negative numbers and empty strings.
@@ -32,14 +41,15 @@ func ParseUSDPerMillion(s string) (*big.Rat, error) {
 }
 
 // USDPerMillionToWeiPerToken converts a USD-per-1M-tokens price to a
-// wei-per-token price using the supplied USD-per-0G rate.
+// wei-per-token price using the supplied USD-per-0G rate, then floor-
+// quantises the result to priceQuantumWei.
 //
-//	weiPerToken = priceUSD / 1_000_000 / rateUSDPerOG * 1e18
+//	weiPerToken = floor( priceUSD / 1_000_000 / rateUSDPerOG * 1e18 ,  priceQuantumWei )
 //
 // All intermediate math uses big.Rat for exact arithmetic; the final
-// result is truncated to a non-negative big.Int (rounding down favours
-// the user by at most 1 wei per token).  Returns an error if rate is
-// zero or negative, which a healthy aggregator should never produce.
+// result is floor-truncated and then snapped down to the nearest
+// multiple of priceQuantumWei.  Returns an error if rate is zero or
+// negative, which a healthy aggregator should never produce.
 func USDPerMillionToWeiPerToken(priceUSDPerMillion, rateUSDPerOG *big.Rat) (*big.Int, error) {
 	if priceUSDPerMillion == nil {
 		return nil, fmt.Errorf("priceUSDPerMillion is nil")
@@ -65,6 +75,9 @@ func USDPerMillionToWeiPerToken(priceUSDPerMillion, rateUSDPerOG *big.Rat) (*big
 	if wei.Sign() < 0 {
 		wei.SetInt64(0)
 	}
+
+	// Floor-snap to priceQuantumWei: wei = (wei / Q) * Q.
+	wei.Quo(wei, priceQuantumWei).Mul(wei, priceQuantumWei)
 	return wei, nil
 }
 

--- a/api/inference/internal/pricefeed/convert_test.go
+++ b/api/inference/internal/pricefeed/convert_test.go
@@ -53,16 +53,49 @@ func TestUSDPerMillionToWeiPerToken(t *testing.T) {
 	//   per-token OG  = 5e-7 / 0.003           ≈ 1.6666… e-4
 	//   per-token wei = 1.6666… e-4 * 1e18     ≈ 1.6666… e14
 	// Exactly: (0.5 * 1e18) / (1_000_000 * 0.003) = 5e17 / 3000 = 166_666_666_666_666.666…
-	// Floor to int → 166_666_666_666_666.
+	// Floor to int   → 166_666_666_666_666.
+	// Floor to 1e10  → 166_660_000_000_000 (trailing digits below the
+	// quantum dropped).
 	price := mustRat(t, "0.50")
 	rate := mustRat(t, "0.003")
 	got, err := USDPerMillionToWeiPerToken(price, rate)
 	if err != nil {
 		t.Fatalf("USDPerMillionToWeiPerToken: %v", err)
 	}
-	want, _ := new(big.Int).SetString("166666666666666", 10)
+	want, _ := new(big.Int).SetString("166660000000000", 10)
 	if got.Cmp(want) != 0 {
 		t.Errorf("wei = %s, want %s", got.String(), want.String())
+	}
+}
+
+func TestUSDPerMillionToWeiPerToken_FloorQuantizes(t *testing.T) {
+	// Any wei-per-token output must be an exact multiple of priceQuantumWei
+	// (1e10).  Rate chosen deliberately to produce a value whose naive
+	// conversion has non-zero digits below the quantum.
+	price := mustRat(t, "0.50")
+	rate := mustRat(t, "0.003")
+	got, err := USDPerMillionToWeiPerToken(price, rate)
+	if err != nil {
+		t.Fatalf("USDPerMillionToWeiPerToken: %v", err)
+	}
+	remainder := new(big.Int).Mod(got, priceQuantumWei)
+	if remainder.Sign() != 0 {
+		t.Errorf("wei=%s not a multiple of %s (remainder=%s)", got.String(), priceQuantumWei.String(), remainder.String())
+	}
+
+	// Floor direction: quantised value must never exceed the exact value.
+	exact := new(big.Rat).Quo(price, new(big.Rat).SetInt(tokensPerMillion))
+	exact.Quo(exact, rate)
+	exact.Mul(exact, new(big.Rat).SetInt(weiPerOG))
+	gotRat := new(big.Rat).SetInt(got)
+	if gotRat.Cmp(exact) > 0 {
+		t.Errorf("quantised wei %s exceeds exact %s — floor violated", got.String(), exact.FloatString(6))
+	}
+	// Drift from exact must be strictly less than one quantum.
+	drift := new(big.Rat).Sub(exact, gotRat)
+	quantumRat := new(big.Rat).SetInt(priceQuantumWei)
+	if drift.Cmp(quantumRat) >= 0 {
+		t.Errorf("drift %s >= quantum %s — floor should leave <1 quantum of drift", drift.FloatString(2), quantumRat.FloatString(0))
 	}
 }
 

--- a/api/inference/internal/pricefeed/convert_test.go
+++ b/api/inference/internal/pricefeed/convert_test.go
@@ -135,6 +135,40 @@ func TestUSDPerMillionToWeiPerToken_InvalidRate(t *testing.T) {
 	}
 }
 
+func TestUSDPerMillionStringToPerToken(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"0.50", "0.0000005", false},
+		{"1.5", "0.0000015", false},
+		{"10", "0.00001", false},
+		{"0", "0", false},
+		{"1", "0.000001", false},
+		{"0.000001", "0.000000000001", false},
+		{"", "", true},
+		{"-1", "", true},
+		{"nope", "", true},
+	}
+	for _, c := range cases {
+		got, err := USDPerMillionStringToPerToken(c.in)
+		if c.wantErr {
+			if err == nil {
+				t.Errorf("USDPerMillionStringToPerToken(%q) want error, got %q", c.in, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("USDPerMillionStringToPerToken(%q) unexpected error: %v", c.in, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("USDPerMillionStringToPerToken(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
 func TestDriftBps(t *testing.T) {
 	cases := []struct {
 		current, reference int64

--- a/api/inference/internal/pricefeed/factory.go
+++ b/api/inference/internal/pricefeed/factory.go
@@ -3,20 +3,26 @@ package pricefeed
 import (
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/0glabs/0g-serving-broker/inference/config"
 )
 
+// 0G-specific symbol constants for each supported source.  These are facts
+// about where 0G trades, not operator choices — there's no sensible alternate
+// value for this broker (it prices 0G for on-chain settlement).  If 0G is
+// ever re-slugged on CoinGecko or relisted under a different pair on Binance,
+// update these in place.
+const (
+	coinGeckoCoinID     = "zero-gravity"
+	coinGeckoQuote      = "usd"
+	binanceSymbol       = "0GUSDT"
+)
+
 // BuildSources constructs Source implementations from a PriceFeedConfig.
-// Each source gets its own symbol from cfg.SourceSymbols[name], expected in
-// "<base>-<quote>" form (e.g. "0g-usdt" for Binance, "zero-gravity-usd" for
-// CoinGecko); each implementation adapts the pair to its own API convention.
+// Each supported source has its 0G symbol baked in; see the constants above.
 //
-// Returns an error if a requested source is unknown or missing its symbol.
-// Validation guarantees SourceSymbols covers every entry in Sources, so the
-// lookups here should not fail in practice.
+// Returns an error if a requested source name is unknown.
 func BuildSources(cfg config.PriceFeedConfig) ([]Source, error) {
 	httpClient := &http.Client{
 		Timeout: cfg.HTTPTimeout,
@@ -29,40 +35,14 @@ func BuildSources(cfg config.PriceFeedConfig) ([]Source, error) {
 
 	sources := make([]Source, 0, len(cfg.Sources))
 	for _, name := range cfg.Sources {
-		name = strings.ToLower(strings.TrimSpace(name))
-		symbol, ok := cfg.SourceSymbols[name]
-		if !ok || symbol == "" {
-			return nil, fmt.Errorf("pricefeed: no sourceSymbols entry for source %q", name)
-		}
-		base, quote, err := splitSymbol(symbol)
-		if err != nil {
-			return nil, err
-		}
-
 		switch name {
 		case "coingecko":
-			sources = append(sources, NewCoinGeckoSource(httpClient, "", base, quote, cfg.CoinGeckoAPIKey, cfg.UserAgent))
+			sources = append(sources, NewCoinGeckoSource(httpClient, "", coinGeckoCoinID, coinGeckoQuote, cfg.CoinGeckoAPIKey, cfg.UserAgent))
 		case "binance":
-			// Binance pairs are base+quote uppercased and concatenated (e.g. "0GUSDT").
-			pair := strings.ToUpper(base + quote)
-			sources = append(sources, NewBinanceSource(httpClient, "", pair, cfg.UserAgent))
+			sources = append(sources, NewBinanceSource(httpClient, "", binanceSymbol, cfg.UserAgent))
 		default:
 			return nil, fmt.Errorf("pricefeed: unknown source %q", name)
 		}
 	}
 	return sources, nil
-}
-
-// splitSymbol parses a "<base>-<quote>" symbol into its two halves, splitting
-// on the LAST hyphen.  CoinGecko coin IDs commonly contain hyphens
-// (e.g. "zero-gravity", "bitcoin-cash"), so splitting on the first hyphen
-// would mangle the base.  Assumes the quote currency never contains a hyphen
-// — true for every fiat/stablecoin ticker we care about (usd, usdt, usdc,
-// eur, btc, eth, ...).
-func splitSymbol(symbol string) (base, quote string, err error) {
-	idx := strings.LastIndex(symbol, "-")
-	if idx <= 0 || idx == len(symbol)-1 {
-		return "", "", fmt.Errorf("pricefeed: symbol %q must be in '<base>-<quote>' form", symbol)
-	}
-	return strings.ToLower(symbol[:idx]), strings.ToLower(symbol[idx+1:]), nil
 }

--- a/api/inference/model/service.go
+++ b/api/inference/model/service.go
@@ -13,13 +13,13 @@ type Service struct {
 	Verifiability         string                `gorm:"type:varchar(255);not null" json:"verifiability" binding:"required"`
 	InputPrice            string                `gorm:"type:varchar(255);not null" json:"inputPrice" binding:"required"`
 	OutputPrice           string                `gorm:"type:varchar(255);not null" json:"outputPrice" binding:"required"`
-	// InputPriceUSD / OutputPriceUSD are populated only when the provider is
+	// InputPriceUSDPerMillionTokens / OutputPriceUSDPerMillionTokens are populated only when the provider is
 	// USD-denominated.  They carry the configured per-1M-tokens USD value
 	// verbatim (e.g. "0.50"); the /v1/models handler converts to per-token
 	// for display.  gorm:"-" because these are not persisted — config is the
 	// source of truth.
-	InputPriceUSD         string                `gorm:"-" json:"inputPriceUSD,omitempty"`
-	OutputPriceUSD        string                `gorm:"-" json:"outputPriceUSD,omitempty"`
+	InputPriceUSDPerMillionTokens         string                `gorm:"-" json:"inputPriceUSDPerMillionTokens,omitempty"`
+	OutputPriceUSDPerMillionTokens        string                `gorm:"-" json:"outputPriceUSDPerMillionTokens,omitempty"`
 	DeletedAt             soft_delete.DeletedAt `gorm:"softDelete:nano;not null;default:0;index:deleted_name" json:"-" readonly:"true"`
 	TeeSignerAcknowledged bool                  `gorm:"not null;default:false" json:"teeSignerAcknowledged" binding:"required"`
 	AdditionalInfo        string                `gorm:"type:text" json:"additionalInfo,omitempty"`

--- a/api/inference/model/service.go
+++ b/api/inference/model/service.go
@@ -13,6 +13,13 @@ type Service struct {
 	Verifiability         string                `gorm:"type:varchar(255);not null" json:"verifiability" binding:"required"`
 	InputPrice            string                `gorm:"type:varchar(255);not null" json:"inputPrice" binding:"required"`
 	OutputPrice           string                `gorm:"type:varchar(255);not null" json:"outputPrice" binding:"required"`
+	// InputPriceUSD / OutputPriceUSD are populated only when the provider is
+	// USD-denominated.  They carry the configured per-1M-tokens USD value
+	// verbatim (e.g. "0.50"); the /v1/models handler converts to per-token
+	// for display.  gorm:"-" because these are not persisted — config is the
+	// source of truth.
+	InputPriceUSD         string                `gorm:"-" json:"inputPriceUSD,omitempty"`
+	OutputPriceUSD        string                `gorm:"-" json:"outputPriceUSD,omitempty"`
 	DeletedAt             soft_delete.DeletedAt `gorm:"softDelete:nano;not null;default:0;index:deleted_name" json:"-" readonly:"true"`
 	TeeSignerAcknowledged bool                  `gorm:"not null;default:false" json:"teeSignerAcknowledged" binding:"required"`
 	AdditionalInfo        string                `gorm:"type:text" json:"additionalInfo,omitempty"`


### PR DESCRIPTION
## Summary
Remove the `sourceSymbols` configuration field from the price feed config and hardcode the 0G trading symbols directly in the pricefeed factory. Since this broker only ever prices 0G (not a generic asset pricing service), the symbols are facts about where 0G trades rather than operator choices.

## Key Changes
- **Removed `SourceSymbols` field** from `PriceFeedConfig` struct in `config.go`
  - Eliminates the requirement for operators to specify `<base>-<quote>` symbol pairs in config
  - Removes all associated validation logic that checked for missing or malformed symbols

- **Added symbol constants** in `pricefeed/factory.go`:
  - `coinGeckoCoinID = "zero-gravity"` and `coinGeckoQuote = "usd"`
  - `binanceSymbol = "0GUSDT"`
  - Includes detailed comments explaining these are 0G-specific facts, not configurable values

- **Simplified `BuildSources()` function** in `pricefeed/factory.go`:
  - Removed symbol lookup and parsing logic
  - Removed `splitSymbol()` helper function (no longer needed)
  - Sources now directly use hardcoded constants instead of config-provided symbols

- **Updated tests**:
  - Removed test cases for missing/malformed `sourceSymbols` entries
  - Removed `sourceSymbols` from test config YAML
  - Removed assertions checking `SourceSymbols` map contents
  - Updated test processor setup to remove `SourceSymbols` initialization

## Implementation Details
The change reflects the reality that this broker has a fixed purpose: pricing 0G for on-chain settlement. The symbols are not operator-configurable because there's no sensible alternate value. If 0G's listing ever changes (e.g., re-slugged on CoinGecko or relisted on Binance), the constants can be updated in place rather than requiring config changes across deployments.

https://claude.ai/code/session_01HFRoGU24epjfXP5Zezovj5