### PR TITLE
fix(inference): demote chat_id_not_found signature miss from error to…

### DIFF
--- a/api/inference/internal/ctrl/proxy.go
+++ b/api/inference/internal/ctrl/proxy.go
@@ -199,12 +199,17 @@ func (c *Ctrl) ProcessHTTPRequest(ctx *gin.Context, svcType string, req *http.Re
 	}
 }
 
+// ErrChatIDNotFound is returned when a signature lookup misses the cache.
+// The miss is client-caused (stale chatID past the cache TTL, or never-issued ID),
+// so callers should treat it as a 4xx, not a broker-side error.
+var ErrChatIDNotFound = errors.New("Chat id not found or expired, chat_id_not_found")
+
 func (c *Ctrl) GetChatSignature(chatID string) (*ChatSignature, error) {
 	key := c.chatCacheKey(chatID)
 	c.logger.Debugf("get signature for chat: %v", chatID)
 	val, exist := c.svcCache.Get(key)
 	if !exist {
-		return nil, errors.New("Chat id not found or expired, chat_id_not_found")
+		return nil, ErrChatIDNotFound
 	}
 
 	chatSignature, ok := val.(ChatSignature)

--- a/api/inference/internal/proxy/proxy.go
+++ b/api/inference/internal/proxy/proxy.go
@@ -584,6 +584,9 @@ func (p *Proxy) handleSignatureRoute(ctx *gin.Context, targetRoute string) bool 
 	if !p.ctrl.Service.TargetSeparated || p.ctrl.Service.IsCentralized() {
 		sig, err := p.ctrl.GetChatSignature(chatID)
 		if err != nil {
+			if errors.Is(err, ctrl.ErrChatIDNotFound) {
+				ctx.Set("ignoreError", true)
+			}
 			p.handleBrokerError(ctx, err, "prepare HTTP request")
 			return true
 		}


### PR DESCRIPTION
… client error

Signature lookups for expired or unknown chatIDs are client-caused (stale retries past the 20m cache TTL) but were logged at ERROR level, dominating the broker error rate. Introduce ErrChatIDNotFound and set ignoreError on the miss so handleBrokerError skips error logging while still returning 400.