### PR TITLE
feat(inference): LoRA capability advertising, quota & admission control, TEE-deployable example (#468 #469 #470)

### DIFF
--- a/api/common/chain/ethereum.go
+++ b/api/common/chain/ethereum.go
@@ -13,6 +13,11 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 )
 
+// DefaultMinGasPrice is the floor for suggested gas prices (2 Gwei).
+// When eth_gasPrice returns a value below this, the floor is used instead
+// to avoid "gas price below minimum" rejections from the chain.
+var DefaultMinGasPrice = big.NewInt(2_000_000_000)
+
 // EthereumClient wraps the client and the BlockChain network to interact with an EVM based Blockchain
 type EthereumClient struct {
 	Client   *ethclient.Client
@@ -50,13 +55,19 @@ func (e *EthereumClient) TransactionCallMessage(
 		return nil, err
 	}
 	e.logger.Infof("Suggested Gas Price: %s", gasPrice.String())
+
+	if gasPrice.Cmp(DefaultMinGasPrice) < 0 {
+		e.logger.Infof("Suggested gas price below floor %s, using floor", DefaultMinGasPrice.String())
+		gasPrice = new(big.Int).Set(DefaultMinGasPrice)
+	}
+
 	if e.GasPrice != "" {
 		GasPriceConfig, ok := new(big.Int).SetString(e.GasPrice, 10)
 		if !ok {
 			return nil, fmt.Errorf("invalid gas price: %s", e.GasPrice)
 		}
 		e.logger.Infof("Config Gas Price: %s", GasPriceConfig.String())
-		if gasPrice != nil && GasPriceConfig.Cmp(gasPrice) == 1 {
+		if GasPriceConfig.Cmp(gasPrice) > 0 {
 			gasPrice = GasPriceConfig
 		}
 	}

--- a/api/fine-tuning/config/config.go
+++ b/api/fine-tuning/config/config.go
@@ -213,7 +213,7 @@ func GetConfig() *Config {
 			}{
 				FineTune: "root:123456@tcp(mysql:3306)/fineTune?parseTime=true",
 			},
-			GasPrice: "",
+			GasPrice: "3000000000",
 			Images: Images{
 				ExecutionMockImageName: "mock-fine-tuning:latest",
 				ExecutionImageName:     "execution-test-pytorch:v1",

--- a/api/fine-tuning/contract/contract.go
+++ b/api/fine-tuning/contract/contract.go
@@ -123,7 +123,11 @@ func (s *ServingContract) TransactWithValue(ctx context.Context, retryOpts *Retr
 
 		errStr := strings.ToLower(err.Error())
 
-		if strings.Contains(errStr, "mempool") || strings.Contains(errStr, "timeout") {
+		if strings.Contains(errStr, "gas price below minimum") {
+			newGasPrice := bumpGasPriceFromError(errStr, opts.GasPrice)
+			s.logger.Infof("Gas price below chain minimum, bumping from %v to %v", opts.GasPrice, newGasPrice)
+			opts.GasPrice = newGasPrice
+		} else if strings.Contains(errStr, "mempool") || strings.Contains(errStr, "timeout") {
 			if retryOpts.MaxGasPrice == nil {
 				return nil, fmt.Errorf("mempool full and no max gas price is set, failed to send transaction: %w", err)
 			} else {
@@ -341,4 +345,23 @@ func (c *Contract) GetBalance(ctx context.Context, account common.Address, block
 
 func (c *Contract) Close() {
 	c.Client.Client.Close()
+}
+
+// bumpGasPriceFromError parses the required minimum from a "gas price below
+// minimum" error and returns minimum * 1.1. Falls back to current * 2 if
+// parsing fails.
+func bumpGasPriceFromError(errStr string, current *big.Int) *big.Int {
+	const prefix = "minimum needed "
+	if idx := strings.Index(errStr, prefix); idx != -1 {
+		minStr := errStr[idx+len(prefix):]
+		if spaceIdx := strings.IndexAny(minStr, " ,\t\n"); spaceIdx != -1 {
+			minStr = minStr[:spaceIdx]
+		}
+		if minPrice, ok := new(big.Int).SetString(minStr, 10); ok {
+			bumped := new(big.Int).Mul(minPrice, big.NewInt(11))
+			bumped.Div(bumped, big.NewInt(10))
+			return bumped
+		}
+	}
+	return new(big.Int).Mul(current, big.NewInt(2))
 }

--- a/api/fine-tuning/docs/USER_GUIDE_FINETUNE_AND_SERVE.md
+++ b/api/fine-tuning/docs/USER_GUIDE_FINETUNE_AND_SERVE.md
@@ -21,7 +21,7 @@ Full workflow: fine-tune a model → download result → send inference requests
      ↓
   monitor (get-task / get-log)
      ↓
-  acknowledge-model  ──── on-chain event ────→  adapter auto-deployed
+  acknowledge-model (--deploy) ── deploys ──→  adapter ready on GPU
      ↓
   decrypt-model (optional, for self-hosting)
 ```
@@ -135,32 +135,49 @@ Wait for **Delivered** before proceeding.
 0g-compute-cli fine-tuning acknowledge-model \
   --provider <PROVIDER> \
   --task-id <TASK_ID> \
-  --data-path ./output/
+  --data-path ./output/ \
+  --model "Qwen2.5-0.5B-Instruct" \
+  --deploy
 ```
 
-Downloads encrypted model from 0G Storage and acknowledges on-chain.
+This command:
+1. Downloads the encrypted model from 0G Storage
+2. Acknowledges on-chain (triggers settlement)
+3. With `--deploy`: automatically deploys the LoRA adapter to the inference GPU
+
+> Without `--deploy`, you must manually run `fine-tuning deploy-adapter` before using the model for inference.
 
 ---
 
 ## Step 6: Decrypt Model (Optional)
 
-For local self-hosting:
+For local self-hosting. Wait for task status to reach **Finished** before decrypting (the decryption key is uploaded on-chain during settlement).
 
 ```bash
 0g-compute-cli fine-tuning decrypt-model \
   --provider <PROVIDER> \
   --task-id <TASK_ID> \
   --encrypted-model ./output/model_<TASK_ID>.bin \
-  --output ./decrypted_model/
+  --output ./decrypted_model/model.zip
 ```
 
-Output: ZIP with LoRA adapter files (`adapter_model.safetensors`, `adapter_config.json`).
+> `--output` must be a **file path** (not a directory).
+
+Output: ZIP containing LoRA adapter files (`adapter_model.safetensors`, `adapter_config.json`).
 
 ---
 
 ## Step 7: Use Fine-Tuned Model for Inference
 
-After acknowledging (Step 5), the provider's inference broker auto-deploys your LoRA adapter.
+If you used `--deploy` in Step 5, the LoRA adapter is already deployed. Otherwise, deploy it manually:
+
+```bash
+0g-compute-cli fine-tuning deploy-adapter \
+  --provider <PROVIDER> \
+  --model "Qwen2.5-0.5B-Instruct" \
+  --task-id <TASK_ID> \
+  --wait
+```
 
 ### 7.1 Prepare Inference Account
 
@@ -254,8 +271,9 @@ curl $PROVIDER_URL/v1/proxy/chat/completions \
 | `fine-tuning get-task --provider <addr> [--task <id>]` | Check task status |
 | `fine-tuning get-log --provider <addr> [--task <id>]` | View training logs |
 | `fine-tuning list-tasks --provider <addr>` | List all tasks |
-| `fine-tuning acknowledge-model` | Download and acknowledge model |
-| `fine-tuning decrypt-model` | Decrypt model for local use |
+| `fine-tuning acknowledge-model` | Download and acknowledge model (`--deploy` to auto-deploy adapter) |
+| `fine-tuning decrypt-model` | Decrypt model for local use (requires Finished status) |
+| `fine-tuning deploy-adapter` | Deploy LoRA adapter to inference GPU |
 | `fine-tuning cancel-task` | Cancel a running task |
 | `fine-tuning get-adapter-name` | Get LoRA adapter name for inference |
 | `fine-tuning chat` | Chat with fine-tuned model |
@@ -300,9 +318,11 @@ The provider is downloading the dataset and model. Large models (e.g., Qwen3-32B
 0g-compute-cli fine-tuning get-log --provider <PROVIDER> --task <TASK_ID>
 ```
 
-### "Model not found" when using chat
+### "Model not found" or 400 error when using chat
 
-The inference broker may not have deployed the adapter yet. This happens automatically after `acknowledge-model`, but may take up to 30 seconds. Wait and retry.
+The adapter has not been deployed to the inference GPU yet. Either:
+- Re-run `acknowledge-model` with `--deploy --model <MODEL>`, or
+- Run `fine-tuning deploy-adapter --provider <PROVIDER> --model <MODEL> --task-id <TASK_ID> --wait`
 
 ### "Service not acknowledge the tee signer"
 
@@ -345,10 +365,11 @@ Or revoke all and regenerate:
   --config-path ./config.json
 # => Task ID: abc123-def456
 
-# 3. Wait for completion, then download
+# 3. Wait for Delivered, then download + deploy
 0g-compute-cli fine-tuning get-task --provider 0x87a1...8ed4 --task abc123-def456
 0g-compute-cli fine-tuning acknowledge-model \
-  --provider 0x87a1...8ed4 --task-id abc123-def456 --data-path ./output/
+  --provider 0x87a1...8ed4 --task-id abc123-def456 --data-path ./output/ \
+  --model "Qwen2.5-0.5B-Instruct" --deploy
 
 # 4. Use for inference
 0g-compute-cli inference acknowledge-provider --provider 0x87a1...8ed4

--- a/api/inference/config/config.go
+++ b/api/inference/config/config.go
@@ -341,8 +341,8 @@ func GetConfig() *Config {
 			}{
 				ProviderAddr: ":8088",
 			},
-			GasPrice:    "",
-			MaxGasPrice: "",
+			GasPrice:    "3000000000",
+			MaxGasPrice: "10000000000",
 			Interval: struct {
 				AutoSettleBufferTime     int `yaml:"autoSettleBufferTime"`
 				ForceSettlementProcessor int `yaml:"forceSettlementProcessor"`

--- a/api/inference/config/config.go
+++ b/api/inference/config/config.go
@@ -172,7 +172,54 @@ type LoRAConfig struct {
 	StorageTurbo             bool   `yaml:"storageTurbo"`             // Use turbo indexer for 0G Storage
 	AutoDeploy               bool   `yaml:"autoDeploy"`               // If true, auto-deploy adapters to vLLM on acknowledge; if false, download only (user must call deploy API)
 	FineTuningProviderAddr   string `yaml:"fineTuningProviderAddr"`   // Override FT provider address for event filtering (default: inference provider address)
-	EciesPrivateKey string `yaml:"-"` // Override ECIES private key for adapter decryption (2-CVM setup). Set via env var LORA_ECIES_PRIVATE_KEY.
+	EciesPrivateKey          string `yaml:"-"`                        // Override ECIES private key for adapter decryption (2-CVM setup). Set via env var LORA_ECIES_PRIVATE_KEY.
+
+	// Quota and admission control (issue #470).
+	//
+	// Without these limits, every on-chain DeliverableAcknowledged event
+	// triggers an unconditional download → decrypt → deploy goroutine.
+	// A malicious user can drain disk and bandwidth with cheap chain calls,
+	// and even organic load can saturate the GPU pool. Defaults below are
+	// applied in GetConfig() if left as zero values.
+	Quota LoRAQuotaConfig `yaml:"quota"`
+}
+
+// LoRAQuotaConfig defines per-user/per-provider quotas and rate limits for
+// LoRA adapter registration and deployment. All fields are soft caps that
+// can be set to 0 to disable a particular check (operator opt-out).
+type LoRAQuotaConfig struct {
+	// MaxAdaptersPerUser caps how many LoRA adapters a single user address
+	// can have registered (in any non-failed state) on this broker. Excess
+	// registrations are rejected at admission time.
+	// Default: 5. Set to 0 to disable.
+	MaxAdaptersPerUser int `yaml:"maxAdaptersPerUser"`
+
+	// MaxAdaptersTotal caps total adapters this broker keeps on disk.
+	// When the cap is hit, the LRU eviction loop reclaims slots by
+	// archiving the oldest idle Active adapter.
+	// Default: 100. Set to 0 to disable.
+	MaxAdaptersTotal int `yaml:"maxAdaptersTotal"`
+
+	// MaxConcurrentDownloads caps concurrent 0G Storage downloads. Each
+	// download holds bandwidth + a goroutine; without a cap a burst of
+	// ack events spawns unbounded goroutines.
+	// Default: 3. Set to 0 to disable.
+	MaxConcurrentDownloads int `yaml:"maxConcurrentDownloads"`
+
+	// MaxAdapterDiskBytes caps total disk usage of stored adapters.
+	// Currently advisory: enforced by the eviction loop when total disk
+	// usage exceeds the cap. 0 disables. Default: 100 GB.
+	MaxAdapterDiskBytes int64 `yaml:"maxAdapterDiskBytes"`
+
+	// CapacityCheckIntervalMinutes drives how often the LRU eviction loop
+	// runs. Default: 5 minutes; 0 falls back to the default.
+	CapacityCheckIntervalMinutes int `yaml:"capacityCheckIntervalMinutes"`
+
+	// BlockedUsers is an operator kill-switch — addresses listed here
+	// have all new adapter registrations rejected. Existing adapters are
+	// not touched (use the admin evict endpoint for that). Comparison is
+	// case-insensitive.
+	BlockedUsers []string `yaml:"blockedUsers"`
 }
 
 type Config struct {
@@ -385,6 +432,13 @@ func GetConfig() *Config {
 		EnableColdStorage:        false,
 		PollBlockIntervalSeconds: 5,
 		StorageTurbo:             false,
+		Quota: LoRAQuotaConfig{
+			MaxAdaptersPerUser:           5,
+			MaxAdaptersTotal:             100,
+			MaxConcurrentDownloads:       3,
+			MaxAdapterDiskBytes:          100 * 1024 * 1024 * 1024, // 100 GiB
+			CapacityCheckIntervalMinutes: 5,
+		},
 	},
 		ChatCacheExpiration: time.Minute * 20,
 			NvGPU:               false,

--- a/api/inference/contract/contract.go
+++ b/api/inference/contract/contract.go
@@ -113,7 +113,10 @@ func (s *ServingContract) TransactWithValue(ctx context.Context, retryOpts *Retr
 
 		errStr := strings.ToLower(err.Error())
 
-		if strings.Contains(errStr, "mempool") || strings.Contains(errStr, "timeout") {
+		if strings.Contains(errStr, "gas price below minimum") {
+			newGasPrice := bumpGasPriceFromError(errStr, opts.GasPrice)
+			opts.GasPrice = newGasPrice
+		} else if strings.Contains(errStr, "mempool") || strings.Contains(errStr, "timeout") {
 			if retryOpts.MaxGasPrice == nil {
 				return nil, fmt.Errorf("mempool full and no max gas price is set, failed to send transaction: %w", err)
 			} else {
@@ -203,4 +206,23 @@ func (c *Contract) WaitForReceipt(ctx context.Context, txHash common.Hash, opts 
 
 func (c *Contract) Close() {
 	c.Client.Client.Close()
+}
+
+// bumpGasPriceFromError parses the required minimum from a "gas price below
+// minimum" error and returns minimum * 1.1. Falls back to current * 2 if
+// parsing fails.
+func bumpGasPriceFromError(errStr string, current *big.Int) *big.Int {
+	const prefix = "minimum needed "
+	if idx := strings.Index(errStr, prefix); idx != -1 {
+		minStr := errStr[idx+len(prefix):]
+		if spaceIdx := strings.IndexAny(minStr, " ,\t\n"); spaceIdx != -1 {
+			minStr = minStr[:spaceIdx]
+		}
+		if minPrice, ok := new(big.Int).SetString(minStr, 10); ok {
+			bumped := new(big.Int).Mul(minPrice, big.NewInt(11))
+			bumped.Div(bumped, big.NewInt(10))
+			return bumped
+		}
+	}
+	return new(big.Int).Mul(current, big.NewInt(2))
 }

--- a/api/inference/integration/provider-lora/README.md
+++ b/api/inference/integration/provider-lora/README.md
@@ -1,0 +1,125 @@
+# Inference broker + LoRA serving (TEE-deployable)
+
+Reference deployment for an inference broker that serves both base-model
+inference **and** fine-tune-derived LoRA adapters. Designed to run inside
+a Phala/dstack TEE without any host-side file pre-staging (issue #469),
+and to advertise its LoRA capability so off-chain routers can find it
+(issue #468), with quota & admission control protecting the GPU pool
+(issue #470).
+
+## What's different from `provider/`
+
+| Aspect | `provider/` example | `provider-lora/` (this folder) |
+|---|---|---|
+| Host bind-mounts | model dir, nginx.conf, init.sql | **only** `config.yaml` |
+| vLLM model source | host-mounted `/models/...` | HF auto-download into named volume |
+| sllm-wrapper | bind-mount `sllm-wrapper.py` | published image `ghcr.io/0gfoundation/0g-sllm-wrapper:latest` |
+| nginx | front-proxies the broker | dropped, broker listens on host port directly |
+| LoRA | not configured | `lora.enable: true` + `autoDeploy: true` |
+
+If you don't need LoRA, keep using `provider/`. If you do, prefer this
+example for any TEE deployment.
+
+## Topology
+
+```
+        ┌──────────────── inf-net ────────────────┐
+inbound │                                         │
+  ─────►│ inference-broker:3080  ── reads ───────►│ MySQL
+        │     │                                   │
+        │     ├─ /v1/chat/completions ───────────►│ sllm-wrapper:8343 ── /v1/* ──► vllm:8000 (Qwen base + LoRA)
+        │     ├─ /v1/lora/admin/evict (provider)  │
+        │     ├─ /v1/capabilities (public)        │
+        │     ├─ /v1/models (public)              │
+        │     └─ /v1/proxy/... (auth)             │
+        │                                         │
+        │ inference-event ── reads chain ────────►│ ethereum0g RPC
+        │     │                                   │
+        │     └─ on DeliverableAcknowledged ─────►│ inference-broker (admission check) ──► download ──► deploy
+        └─────────────────────────────────────────┘
+
+  Named volumes:
+    hf-cache        → vLLM HF model cache (auto-populated)
+    lora-modules    → adapter files (shared between vLLM, sllm-wrapper, broker)
+    mysql-data      → broker DB
+```
+
+The only file mounted from the host is `./config.yaml`, which dstack lets
+you deliver via `compose_template`.
+
+## First-run notes
+
+* **HF download time.** vLLM pulls the base model from Hugging Face on
+  first start into the `hf-cache` volume. For Qwen2.5-0.5B-Instruct
+  this is ~1 GB; for Qwen3-32B it's ~64 GB. Make sure the TEE has
+  enough disk and outbound connectivity, or set `HF_ENDPOINT` to a
+  reachable mirror.
+* **GPU memory.** `--gpu-memory-utilization 0.5` is conservative;
+  bump it for larger models. Qwen3-32B needs roughly 64 GB VRAM with
+  KV cache.
+* **vLLM healthcheck `start_period`.** Set to 600 s so the first HF
+  download doesn't trigger restart loops.
+* **LoRA module directory.** `lora-modules` is a named volume shared
+  between vLLM, sllm-wrapper, and the broker. The broker writes
+  decrypted adapter files there; sllm-wrapper points vLLM at the same
+  paths. Keep `LORA_HOST_PREFIX` and `LORA_CONTAINER_PREFIX` equal.
+
+## Capability discovery (issue #468)
+
+After registration this broker advertises LoRA capability in three places:
+
+1. **On-chain `additionalInfo`**:
+   `{"LoRAEnabled":true, "LoRABaseModel":"...", "LoRAAdapterPrefix":"ft-", ...}`
+2. **`GET /v1/models`**: the `supports_fine_tuned_adapters: true` field
+   on the base model entry.
+3. **`GET /v1/capabilities`**: a public, unauthenticated capability sheet.
+
+```sh
+curl -s https://<your-broker>/v1/capabilities | jq
+{
+  "base_model": "Qwen2.5-0.5B-Instruct",
+  "fine_tuning": {
+    "supports_fine_tuned_adapters": true,
+    "base_model": "Qwen/Qwen2.5-0.5B-Instruct",
+    "adapter_prefix": "ft-"
+  }
+}
+```
+
+## Quota & operator controls (issue #470)
+
+The `lora.quota` block in `config.yaml` enforces:
+
+| Quota | Default | What it stops |
+|---|---|---|
+| `maxAdaptersPerUser` | 5 | One user spamming many ack events |
+| `maxAdaptersTotal` | 100 | Broker-wide adapter count overflow |
+| `maxConcurrentDownloads` | 3 | Burst of acks → unbounded download goroutines |
+| `maxAdapterDiskBytes` | 100 GiB | Disk exhaustion |
+
+Capacity-based eviction (LRU) runs every `capacityCheckIntervalMinutes`
+and archives the oldest idle adapter when over quota. Files are removed
+from disk; the DB row is kept in `archived` state so the user can
+re-acknowledge to redownload.
+
+Operator kill-switch:
+
+```sh
+# Provider-key signed request (use the broker's CLI/SDK, not curl)
+POST /v1/lora/admin/evict
+{"adapterName": "ft-Qwen2-5-0-5B-Instruct-abc123", "purge": true}
+```
+
+`purge=false` archives only (DB row kept). `purge=true` removes the row.
+Add user addresses to `lora.quota.blockedUsers` to reject all future
+registrations from them.
+
+## Operations checklist
+
+* [ ] Replace `<Private_Key>` and `<Serving URL>` in `config.yaml`.
+* [ ] Choose your base model (HF id) and adjust `--gpu-memory-utilization`.
+* [ ] Verify `/v1/capabilities` returns `supports_fine_tuned_adapters: true`.
+* [ ] Confirm on-chain `additionalInfo` contains `"LoRAEnabled":true`
+      after the broker re-syncs the service.
+* [ ] Tune `lora.quota.*` for your hardware. Defaults assume a single
+      H100/H200 with `~80–143 GB` of HBM.

--- a/api/inference/integration/provider-lora/config.example.yaml
+++ b/api/inference/integration/provider-lora/config.example.yaml
@@ -1,0 +1,67 @@
+# Inference broker config for the TEE-friendly LoRA serving deployment
+# (issue #469). Pair with the sibling docker-compose.yml.
+#
+# Replace <Private_Key> and the ServingURL with your own values. The base
+# model and indexer URLs match the testnet defaults; adjust for mainnet.
+
+contractAddress: "0x41bD7Ac5c19000A974D5c192bcd5FB67b56C85c5"
+skipTEESignerCheck: false
+
+database:
+  provider: "root:123456@tcp(mysql:3306)/provider?parseTime=true"
+
+networks:
+  ethereum0g:
+    url: "https://evmrpc-testnet.0g.ai"
+    chainID: 16602
+    privateKeys:
+      - <Private_Key>
+
+service:
+  type: "chatbot"
+  model: "Qwen2.5-0.5B-Instruct"
+  servingUrl: <Serving URL>
+  targetUrl: "http://sllm-wrapper:8343/v1"
+  inputPrice: "10000000"
+  outputPrice: "10000000"
+  providerStake: "100000000000000000000"
+  verifiability: "TeeML"
+
+# LoRA serving (fine-tune-derived inference). When enable=true and
+# autoDeploy=true the broker advertises the capability on-chain in
+# additionalInfo.LoRAEnabled and at GET /v1/capabilities (issue #468).
+lora:
+  enable: true
+  autoDeploy: true
+  baseModel: "Qwen/Qwen2.5-0.5B-Instruct"
+  loraModulesDir: "/lora-modules"
+  sllmUrl: "http://sllm-wrapper:8343"
+  offloadAfterMinutes: 60
+  enableColdStorage: false
+  fineTuningContractAddress: "0x4e4158DF35CfdC0ac63264D3E112F5B8E9a5c569"
+  chainRpcUrl: "https://evmrpc-testnet.0g.ai"
+  pollBlockIntervalSeconds: 5
+  storageIndexerUrl: "https://indexer-storage-testnet-turbo.0g.ai"
+
+  # Quota & admission control (issue #470). Defaults shown.
+  quota:
+    maxAdaptersPerUser: 5
+    maxAdaptersTotal: 100
+    maxConcurrentDownloads: 3
+    maxAdapterDiskBytes: 107374182400  # 100 GiB
+    capacityCheckIntervalMinutes: 5
+    blockedUsers: []  # operator kill-switch (lower-cased addresses)
+
+event:
+  providerAddr: ":8089"
+
+interval:
+  autoSettleBufferTime: 60
+  forceSettlementProcessor: 600
+  settlementProcessor: 300
+
+logger:
+  format: "text"
+  level: "info"
+  path: ""
+  rotationCount: 7

--- a/api/inference/integration/provider-lora/docker-compose.yml
+++ b/api/inference/integration/provider-lora/docker-compose.yml
@@ -1,0 +1,166 @@
+# TEE-friendly inference broker + LoRA serving compose example.
+#
+# Issue #469: in Phala/dstack TEE CVMs the host operator can ONLY mount
+# the broker config file. Other host paths (model weights, helper scripts,
+# nginx config) cannot be pre-staged. This compose file therefore:
+#
+#   * Pulls the base model with vLLM at startup using an HF model id
+#     (or 0G Storage). No host bind-mount of /models/.
+#   * Uses the published sllm-wrapper image from ghcr.io. No bind-mount
+#     of sllm-wrapper.py.
+#   * Drops nginx; the broker listens directly on the published port.
+#
+# The only host bind-mount is the broker config file itself. Everything
+# else is either in the image or downloaded into a named volume on first
+# boot.
+#
+# Tested with: vllm/vllm-openai:v0.8.5.post1 + Qwen/Qwen2.5-0.5B-Instruct
+# (use a smaller HF model id when iterating, real production runs use
+# Qwen3-32B which needs ~64GB VRAM).
+
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: 0g-inference-broker-db
+    environment:
+      MYSQL_ROOT_PASSWORD: "123456"
+      MYSQL_DATABASE: provider
+    volumes:
+      - mysql-data:/var/lib/mysql
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping -h localhost"]
+      interval: 10s
+      retries: 10
+    networks:
+      - inf-net
+
+  # vLLM auto-downloads the base model from Hugging Face on first start
+  # into the hf-cache named volume. No host bind-mount of /models/.
+  # The first run requires HF reachability from inside the TEE; pin
+  # HF_ENDPOINT to a mirror if direct HF access is blocked.
+  vllm:
+    image: vllm/vllm-openai:v0.8.5.post1
+    container_name: 0g-vllm
+    ipc: host
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    volumes:
+      - hf-cache:/root/.cache/huggingface
+      - lora-modules:/lora-modules
+    environment:
+      - VLLM_ALLOW_RUNTIME_LORA_UPDATING=1
+      # Optional: HF_ENDPOINT=https://hf-mirror.com when blocked from HF
+    command: >
+      --model Qwen/Qwen2.5-0.5B-Instruct
+      --enable-lora
+      --max-lora-rank 64
+      --max-loras 8
+      --gpu-memory-utilization 0.5
+      --host 0.0.0.0
+      --port 8000
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 10
+      start_period: 600s
+    networks:
+      - inf-net
+
+  # SLLM-compatible wrapper, baked into a published image (issue #469).
+  # No bind-mount of the wrapper script.
+  sllm-wrapper:
+    image: ghcr.io/0gfoundation/0g-sllm-wrapper:latest
+    container_name: 0g-sllm-wrapper
+    environment:
+      - VLLM_BASE=http://vllm:8000
+      - LORA_HOST_PREFIX=/lora-modules/
+      - LORA_CONTAINER_PREFIX=/lora-modules/
+    restart: unless-stopped
+    depends_on:
+      vllm:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "python3 -c \"import urllib.request; urllib.request.urlopen('http://localhost:8343/health')\""]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    networks:
+      - inf-net
+
+  # Inference broker. Listens directly on the published port — no nginx
+  # proxy in front. The only mounts are the config file (single file,
+  # which the operator CAN inject in dstack) and the dstack socket.
+  inference-broker:
+    image: ghcr.io/0gfoundation/0g-serving-broker:latest
+    container_name: 0g-inference-broker
+    environment:
+      - PORT=3080
+      - CONFIG_FILE=/etc/config.yaml
+      - NETWORK=phala
+    ports:
+      - "3081:3080"
+    volumes:
+      - ./config.yaml:/etc/config.yaml:ro
+      - lora-modules:/lora-modules
+      - /var/run/dstack.sock:/var/run/dstack.sock
+    command: 0g-inference-server
+    restart: unless-stopped
+    depends_on:
+      mysql:
+        condition: service_healthy
+      sllm-wrapper:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:3080/v1/capabilities || true"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "100m"
+        max-file: "5"
+    networks:
+      - inf-net
+
+  inference-event:
+    image: ghcr.io/0gfoundation/0g-serving-broker:latest
+    container_name: 0g-inference-event
+    environment:
+      - CONFIG_FILE=/etc/config.yaml
+      - NETWORK=phala
+    volumes:
+      - ./config.yaml:/etc/config.yaml:ro
+      - /var/run/dstack.sock:/var/run/dstack.sock
+    command: 0g-inference-event
+    restart: unless-stopped
+    depends_on:
+      inference-broker:
+        condition: service_started
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "100m"
+        max-file: "5"
+    networks:
+      - inf-net
+
+volumes:
+  mysql-data:
+  hf-cache:
+  lora-modules:
+
+networks:
+  inf-net:
+    name: inf-net
+    driver: bridge

--- a/api/inference/integration/sllm-wrapper/Dockerfile
+++ b/api/inference/integration/sllm-wrapper/Dockerfile
@@ -1,0 +1,23 @@
+# SLLM-compatible API wrapper over vLLM.
+#
+# This image bakes sllm-wrapper.py so a TEE/dstack deployment does not
+# require a host bind-mount of the Python script (issue #469). Build &
+# publish as ghcr.io/0gfoundation/0g-sllm-wrapper:<tag> and reference it
+# from docker-compose without any volumes.
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY sllm-wrapper.py /app/sllm-wrapper.py
+
+ENV PORT=8343 \
+    VLLM_BASE=http://vllm:8000 \
+    LORA_HOST_PREFIX=/lora-modules/ \
+    LORA_CONTAINER_PREFIX=/lora-modules/
+
+EXPOSE 8343
+
+# stdlib-only — no pip install needed.
+HEALTHCHECK --interval=15s --timeout=5s --start-period=10s --retries=5 \
+    CMD python3 -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:'+__import__('os').environ.get('PORT','8343')+'/health')" || exit 1
+
+CMD ["python3", "/app/sllm-wrapper.py"]

--- a/api/inference/integration/sllm-wrapper/README.md
+++ b/api/inference/integration/sllm-wrapper/README.md
@@ -1,0 +1,50 @@
+# 0G SLLM Wrapper
+
+A small ServerlessLLM-compatible API shim over vLLM, used by the inference
+broker's LoRA serving path.
+
+The broker speaks a "ServerlessLLM" subset (deploy / chat / list / delete)
+to a target service. This wrapper translates that surface into native vLLM
+endpoints (`/v1/load_lora_adapter`, `/v1/chat/completions`, …) and resolves
+model-name aliases so a request for `/models/Qwen2.5-0.5B-Instruct` is
+forwarded as the canonical id vLLM exposes in `/v1/models`.
+
+## Why a separate image
+
+In Phala/dstack TEE deployments the host operator can mount the broker
+config file but **cannot** pre-stage other files on the host filesystem
+(see issue #469 and `api/fine-tuning/docs/DESIGN_SERVING_FINETUNED_MODELS.md`,
+"TEE 环境约束"). Earlier examples bind-mounted `sllm-wrapper.py`, which
+made them undeployable to a real TEE. This image bakes the script so the
+compose file only needs `image:` and (optionally) env vars.
+
+## Build / publish
+
+```sh
+cd api/inference/integration/sllm-wrapper
+docker build -t ghcr.io/0gfoundation/0g-sllm-wrapper:dev .
+docker push ghcr.io/0gfoundation/0g-sllm-wrapper:dev
+```
+
+## Usage
+
+```yaml
+services:
+  sllm-wrapper:
+    image: ghcr.io/0gfoundation/0g-sllm-wrapper:dev
+    environment:
+      - VLLM_BASE=http://vllm:8000
+      - LORA_HOST_PREFIX=/lora-modules/
+      - LORA_CONTAINER_PREFIX=/lora-modules/
+    healthcheck:
+      test: ["CMD-SHELL", "python3 -c \"import urllib.request; urllib.request.urlopen('http://localhost:8343/health')\""]
+```
+
+## Configuration
+
+| Var | Default | Notes |
+|---|---|---|
+| `PORT` | `8343` | Listen port |
+| `VLLM_BASE` | `http://vllm:8000` | vLLM HTTP base URL |
+| `LORA_HOST_PREFIX` | `/lora-modules/` | Path prefix the broker writes in deploy bodies |
+| `LORA_CONTAINER_PREFIX` | `/lora-modules/` | Path prefix vLLM expects (use the same value when the broker and vLLM share a named volume) |

--- a/api/inference/integration/sllm-wrapper/sllm-wrapper.py
+++ b/api/inference/integration/sllm-wrapper/sllm-wrapper.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""
+ServerlessLLM-compatible API wrapper over vLLM.
+
+Translates the SLLM API surface that the inference broker expects into vLLM
+native API calls. Pure Python stdlib — no pip packages required, so it can
+be baked into a tiny `python:3.11-slim`-based image and deployed inside a
+TEE without runtime bind-mounts (issue #469).
+
+Endpoints:
+  GET  /health                -> 200
+  POST /v1/models/deploy      -> POST vLLM /v1/load_lora_adapter
+  DELETE /v1/models/<name>    -> POST vLLM /v1/unload_lora_adapter
+  GET  /v1/models             -> GET  vLLM /v1/models
+  POST /v1/chat/completions   -> POST vLLM /v1/chat/completions
+                                  (with model name translation)
+
+Configuration (env vars):
+  VLLM_BASE             vLLM HTTP base URL.        Default: http://vllm:8000
+  LORA_HOST_PREFIX      Host path prefix used in   Default: /lora-modules/
+                        the broker's deploy body.
+  LORA_CONTAINER_PREFIX vLLM-side container path.  Default: /lora-modules/
+                        Set both prefixes to the
+                        same value when the broker
+                        and vLLM share a volume.
+  PORT                  Listen port.               Default: 8343
+"""
+
+import json
+import os
+import sys
+import logging
+import urllib.request
+import urllib.error
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [sllm-wrapper] %(message)s")
+log = logging.getLogger("sllm-wrapper")
+
+VLLM_BASE = os.environ.get("VLLM_BASE", "http://vllm:8000")
+HOST_LORA_PREFIX = os.environ.get("LORA_HOST_PREFIX", "/lora-modules/")
+CONTAINER_LORA_PREFIX = os.environ.get("LORA_CONTAINER_PREFIX", "/lora-modules/")
+
+_model_cache = {}
+_model_cache_ts = 0
+
+
+def translate_path(host_path):
+    """Translate host filesystem path to vLLM container path."""
+    if host_path.startswith(HOST_LORA_PREFIX):
+        translated = CONTAINER_LORA_PREFIX + host_path[len(HOST_LORA_PREFIX):]
+        log.info("Path translated: %s -> %s", host_path, translated)
+        return translated
+    return host_path
+
+
+def vllm_request(method, path, body=None, timeout=120):
+    url = VLLM_BASE + path
+    data = json.dumps(body).encode() if body else None
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.status, json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        try:
+            return e.code, json.loads(e.read())
+        except Exception:
+            return e.code, {"error": str(e)}
+    except Exception as e:
+        return 502, {"error": str(e)}
+
+
+def _refresh_model_cache():
+    import time
+    global _model_cache, _model_cache_ts
+    now = time.time()
+    if now - _model_cache_ts < 10:
+        return
+    code, resp = vllm_request("GET", "/v1/models")
+    if code == 200 and "data" in resp:
+        _model_cache = {}
+        for m in resp["data"]:
+            full_id = m["id"]
+            short_name = full_id.rsplit("/", 1)[-1]
+            _model_cache[short_name] = full_id
+            _model_cache[full_id] = full_id
+        _model_cache_ts = now
+        log.info("Model cache refreshed: %s", list(_model_cache.keys()))
+
+
+def resolve_model_name(name):
+    _refresh_model_cache()
+    if name in _model_cache:
+        return _model_cache[name]
+    return name
+
+
+class Handler(BaseHTTPRequestHandler):
+
+    def _json(self, code, body):
+        data = json.dumps(body).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def _read_body(self):
+        length = int(self.headers.get("Content-Length", 0))
+        if length == 0:
+            return {}
+        return json.loads(self.rfile.read(length))
+
+    def do_GET(self):
+        if self.path == "/health":
+            self._json(200, {"status": "ok"})
+        elif self.path == "/v1/models":
+            code, resp = vllm_request("GET", "/v1/models")
+            self._json(code, resp)
+        else:
+            self._json(404, {"error": "not found"})
+
+    def do_POST(self):
+        if self.path == "/v1/models/deploy":
+            self._handle_deploy()
+        elif self.path == "/v1/chat/completions":
+            self._handle_chat()
+        else:
+            self._json(404, {"error": "not found"})
+
+    def do_DELETE(self):
+        if self.path.startswith("/v1/models/"):
+            name = self.path[len("/v1/models/"):]
+            self._handle_delete(name)
+        else:
+            self._json(404, {"error": "not found"})
+
+    def _handle_deploy(self):
+        body = self._read_body()
+        adapters = body.get("lora_adapters", {})
+        results = []
+        for name, path in adapters.items():
+            container_path = translate_path(path)
+            code, resp = vllm_request("POST", "/v1/load_lora_adapter", {
+                "lora_name": name,
+                "lora_path": container_path,
+            })
+            log.info("deploy %s (input=%s, vllm_path=%s) -> vLLM %d: %s",
+                     name, path, container_path, code, resp)
+            global _model_cache_ts
+            _model_cache_ts = 0
+            results.append({
+                "name": name,
+                "status": "deployed" if code == 200 else "failed",
+                "detail": resp,
+            })
+        self._json(200, {"status": "deployed", "adapters": results})
+
+    def _handle_delete(self, name):
+        code, resp = vllm_request("POST", "/v1/unload_lora_adapter",
+                                  {"lora_name": name})
+        log.info("delete %s -> vLLM %d: %s", name, code, resp)
+        global _model_cache_ts
+        _model_cache_ts = 0
+        if code == 200:
+            self._json(200, {"status": "deleted", "model": name})
+        else:
+            self._json(code, resp)
+
+    def _handle_chat(self):
+        body = self._read_body()
+        if "model" in body:
+            original = body["model"]
+            resolved = resolve_model_name(original)
+            if original != resolved:
+                log.info("Model name translated: %s -> %s", original, resolved)
+                body["model"] = resolved
+        code, resp = vllm_request("POST", "/v1/chat/completions", body)
+        self._json(code, resp)
+
+    def log_message(self, fmt, *args):
+        pass
+
+
+if __name__ == "__main__":
+    port = int(os.environ.get("PORT", sys.argv[1] if len(sys.argv) > 1 else 8343))
+    server = HTTPServer(("0.0.0.0", port), Handler)
+    log.info("SLLM wrapper listening on :%d -> vLLM at %s", port, VLLM_BASE)
+    log.info("Path mapping: %s -> %s", HOST_LORA_PREFIX, CONTAINER_LORA_PREFIX)
+    server.serve_forever()

--- a/api/inference/internal/contract/provider_contract.go
+++ b/api/inference/internal/contract/provider_contract.go
@@ -32,6 +32,11 @@ type ProviderContract struct {
 	// Docker client for image info (optional)
 	dockerClient *client.Client
 	imageName    string
+
+	// loraConfig is captured at construction so the on-chain additionalInfo
+	// can advertise LoRA capability (issue #468) without threading the full
+	// config through every call site.
+	loraConfig config.LoRAConfig
 }
 
 func NewProviderContract(conf *config.Config, teeSignerAddress common.Address, logger log.Logger) (*ProviderContract, error) {
@@ -58,6 +63,7 @@ func NewProviderContract(conf *config.Config, teeSignerAddress common.Address, l
 		LockTime:         time.Duration(lockTime.Int64()) * time.Second,
 		TeeSignerAddress: teeSignerAddress,
 		logger:           logger,
+		loraConfig:       conf.LoRA,
 	}
 
 	// Initialize Docker client if controller is enabled and Docker is configured

--- a/api/inference/internal/contract/service.go
+++ b/api/inference/internal/contract/service.go
@@ -22,8 +22,13 @@ var ErrServiceNotFound = errors.New("service not found")
 // DefaultProviderStake is the default stake amount for first-time service registration (100 0G)
 var DefaultProviderStake = new(big.Int).Mul(big.NewInt(100), new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil))
 
-// buildAdditionalInfo creates the additionalInfo JSON string for a service
-func buildAdditionalInfo(service config.Service, imageName, imageDigest string) (string, error) {
+// buildAdditionalInfo creates the additionalInfo JSON string for a service.
+//
+// The output schema includes a stable subset of capability flags that
+// off-chain consumers (router, web aggregator) rely on. New keys must be
+// strictly additive — removing or renaming a key is a breaking change for
+// every downstream service that already parses additionalInfo.
+func buildAdditionalInfo(service config.Service, lora config.LoRAConfig, imageName, imageDigest string) (string, error) {
 	// Determine TEE verifier based on NETWORK environment variable
 	var teeVerifier string
 	switch os.Getenv("NETWORK") {
@@ -46,6 +51,18 @@ func buildAdditionalInfo(service config.Service, imageName, imageDigest string) 
 	// Set TargetTeeAddress if TargetSeparated is true
 	if service.TargetSeparated {
 		additionalInfo["TargetTeeAddress"] = service.TargetTeeAddress
+	}
+
+	// LoRA capability advertisement (issue #468). When this broker auto-deploys
+	// fine-tune-derived adapters, off-chain consumers need a way to discover
+	// it without authenticated calls. Only emit the flag when truly enabled,
+	// so existing brokers don't change their additionalInfo on upgrade.
+	if lora.Enable && lora.AutoDeploy {
+		additionalInfo["LoRAEnabled"] = true
+		if lora.BaseModel != "" {
+			additionalInfo["LoRABaseModel"] = lora.BaseModel
+		}
+		additionalInfo["LoRAAdapterPrefix"] = "ft-"
 	}
 
 	additionalInfoJSON, err := json.Marshal(additionalInfo)
@@ -188,7 +205,7 @@ func (c *ProviderContract) SyncService(ctx context.Context, new config.Service) 
 	imageName, imageDigest := c.GetImageInfo(ctx)
 
 	// Build additionalInfo for comparison
-	newAdditionalInfo, err := buildAdditionalInfo(new, imageName, imageDigest)
+	newAdditionalInfo, err := buildAdditionalInfo(new, c.loraConfig, imageName, imageDigest)
 	if err != nil {
 		c.logger.Errorf("[SyncService] Failed to build additional info - error=%v", err)
 		return err

--- a/api/inference/internal/ctrl/ctrl.go
+++ b/api/inference/internal/ctrl/ctrl.go
@@ -79,6 +79,11 @@ type Ctrl struct {
 
 	// LoRA manager for fine-tuned model serving (nil if LoRA not enabled)
 	loraManager *lora.Manager
+
+	// loraCfg captures the LoRA config snapshot at construction time so the
+	// capability advertising path (issue #468) can read it without holding
+	// references to the global Config singleton.
+	loraCfg config.LoRAConfig
 }
 
 func New(
@@ -145,6 +150,8 @@ func New(
 		},
 		// Initialize whitelist users map
 		whitelistUsers: make(map[string]struct{}),
+
+		loraCfg: cfg.LoRA,
 	}
 
 	// Initialize whitelist from config

--- a/api/inference/internal/ctrl/lora.go
+++ b/api/inference/internal/ctrl/lora.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/0glabs/0g-serving-broker/common/errors"
+	"github.com/0glabs/0g-serving-broker/inference/config"
 	"github.com/0glabs/0g-serving-broker/inference/internal/lora"
 	"github.com/0glabs/0g-serving-broker/inference/model"
 )
@@ -20,6 +21,37 @@ func (c *Ctrl) SetLoRAManager(m *lora.Manager) {
 // GetLoRAManager returns the LoRA manager (may be nil if not enabled).
 func (c *Ctrl) GetLoRAManager() *lora.Manager {
 	return c.loraManager
+}
+
+// SupportsFineTunedAdapters reports whether this broker advertises
+// fine-tune-derived (LoRA) inference. Used by the public capability
+// endpoint and /v1/models response (issue #468).
+//
+// True when LoRA serving is enabled AND auto-deployment from on-chain
+// events is on. Brokers that are technically wired but have autoDeploy
+// off intentionally do not advertise the capability, since they will not
+// pick up fine-tuning deliveries without operator action.
+func (c *Ctrl) SupportsFineTunedAdapters() bool {
+	if c.loraManager == nil {
+		return false
+	}
+	cfg := c.loraConfigSnapshot()
+	return cfg.Enable && cfg.AutoDeploy
+}
+
+// LoRABaseModel returns the configured base model name for LoRA serving,
+// or empty if LoRA is not enabled.
+func (c *Ctrl) LoRABaseModel() string {
+	if c.loraManager == nil {
+		return ""
+	}
+	return c.loraManager.GetBaseModel()
+}
+
+// loraConfigSnapshot returns the LoRA config captured at Ctrl construction.
+// Used by capability-advertising paths that must not touch the global config.
+func (c *Ctrl) loraConfigSnapshot() config.LoRAConfig {
+	return c.loraCfg
 }
 
 // CheckLoRAOwnership verifies that userAddress is the owner of the LoRA model.

--- a/api/inference/internal/db/lora.go
+++ b/api/inference/internal/db/lora.go
@@ -98,8 +98,17 @@ func (d *DB) ListIdleAdapters(idleThreshold time.Duration) ([]model.LoRAAdapter,
 }
 
 // CreateAdapterKey stores a provider-encrypted AES key pushed by the fine-tuning broker.
+// Uses upsert semantics: if a key for the same task already exists (e.g. from a
+// previous delivery attempt that partially succeeded), the storage hash and
+// encrypted key are updated rather than returning a duplicate-key error.
 func (d *DB) CreateAdapterKey(key *model.AdapterKey) error {
-	return d.db.Create(key).Error
+	return d.db.
+		Where("task_id = ?", key.TaskID).
+		Assign(model.AdapterKey{
+			StorageHash:    key.StorageHash,
+			ProviderEncKey: key.ProviderEncKey,
+		}).
+		FirstOrCreate(key).Error
 }
 
 // GetAdapterKeyByTaskID retrieves a pre-pushed adapter key by its task ID.

--- a/api/inference/internal/db/lora.go
+++ b/api/inference/internal/db/lora.go
@@ -97,6 +97,63 @@ func (d *DB) ListIdleAdapters(idleThreshold time.Duration) ([]model.LoRAAdapter,
 	return adapters, nil
 }
 
+// CountAdaptersByUser returns the number of adapters owned by a given user
+// that count toward the per-user quota (issue #470). Failed adapters do
+// not count, since they consumed no GPU and are typically purged.
+// Comparison is case-insensitive on the address.
+func (d *DB) CountAdaptersByUser(userAddress string) (int64, error) {
+	var n int64
+	err := d.db.Model(&model.LoRAAdapter{}).
+		Where("LOWER(user_address) = LOWER(?) AND state <> ?", userAddress, model.AdapterStateFailed).
+		Count(&n).Error
+	return n, err
+}
+
+// CountTotalAdapters returns total adapters (excluding Failed) across all users.
+func (d *DB) CountTotalAdapters() (int64, error) {
+	var n int64
+	err := d.db.Model(&model.LoRAAdapter{}).
+		Where("state <> ?", model.AdapterStateFailed).
+		Count(&n).Error
+	return n, err
+}
+
+// ListLRUEvictionCandidates returns adapters in {Active, Ready, Offloaded}
+// states ordered by last_access_at ascending (oldest first) — capacity-based
+// eviction targets (issue #470). Loading and Failed states are excluded so
+// in-progress work is not interrupted.
+func (d *DB) ListLRUEvictionCandidates(limit int) ([]model.LoRAAdapter, error) {
+	var adapters []model.LoRAAdapter
+	q := d.db.Where("state IN ?",
+		[]model.AdapterState{
+			model.AdapterStateActive,
+			model.AdapterStateReady,
+			model.AdapterStateOffloaded,
+		}).
+		Order("last_access_at ASC NULLS FIRST")
+	if limit > 0 {
+		q = q.Limit(limit)
+	}
+	if err := q.Find(&adapters).Error; err != nil {
+		// Fallback for SQL dialects that reject `NULLS FIRST` (MySQL):
+		// retry with COALESCE(last_access_at, 0).
+		q2 := d.db.Where("state IN ?",
+			[]model.AdapterState{
+				model.AdapterStateActive,
+				model.AdapterStateReady,
+				model.AdapterStateOffloaded,
+			}).
+			Order("COALESCE(last_access_at, '1970-01-01') ASC")
+		if limit > 0 {
+			q2 = q2.Limit(limit)
+		}
+		if err2 := q2.Find(&adapters).Error; err2 != nil {
+			return nil, err
+		}
+	}
+	return adapters, nil
+}
+
 // CreateAdapterKey stores a provider-encrypted AES key pushed by the fine-tuning broker.
 // Uses upsert semantics: if a key for the same task already exists (e.g. from a
 // previous delivery attempt that partially succeeded), the storage hash and

--- a/api/inference/internal/db/lora_test.go
+++ b/api/inference/internal/db/lora_test.go
@@ -264,4 +264,26 @@ func TestAdapterKeyCRUD(t *testing.T) {
 	if err == nil {
 		t.Error("expected error for nonexistent key")
 	}
+
+	// Upsert: calling CreateAdapterKey again with the same TaskID should update,
+	// not fail with a duplicate-key error.
+	updatedKey := &model.AdapterKey{
+		TaskID:         "task-key-001",
+		StorageHash:    "0xnewdeadbeef",
+		ProviderEncKey: "0xnewencryptedkey456",
+	}
+	if err := d.CreateAdapterKey(updatedKey); err != nil {
+		t.Fatalf("CreateAdapterKey (upsert): %v", err)
+	}
+
+	got2, err := d.GetAdapterKeyByTaskID("task-key-001")
+	if err != nil {
+		t.Fatalf("GetAdapterKeyByTaskID after upsert: %v", err)
+	}
+	if got2.StorageHash != "0xnewdeadbeef" {
+		t.Errorf("expected updated StorageHash=0xnewdeadbeef, got %s", got2.StorageHash)
+	}
+	if got2.ProviderEncKey != "0xnewencryptedkey456" {
+		t.Errorf("expected updated ProviderEncKey=0xnewencryptedkey456, got %s", got2.ProviderEncKey)
+	}
 }

--- a/api/inference/internal/handler/capabilities.go
+++ b/api/inference/internal/handler/capabilities.go
@@ -1,0 +1,57 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// CapabilitiesResponse describes broker-level capabilities for off-chain
+// aggregators (router, web UI). It is intentionally separate from the
+// per-model /v1/models response and is unauthenticated, so a router can
+// enumerate brokers and their feature flags without an account.
+//
+// Forward compatibility: clients MUST tolerate unknown fields. New
+// capabilities are added as additive boolean / object fields and existing
+// names are never repurposed.
+type CapabilitiesResponse struct {
+	BaseModel string `json:"base_model"`
+	// FineTuning describes whether this broker can serve fine-tune-derived
+	// (LoRA) adapters produced via the 0G fine-tuning flow (issue #468).
+	FineTuning FineTuningCapability `json:"fine_tuning"`
+}
+
+// FineTuningCapability describes the broker's support for fine-tune-derived
+// inference. When SupportsFineTunedAdapters is false, the other fields are
+// meaningless; clients should ignore them.
+type FineTuningCapability struct {
+	SupportsFineTunedAdapters bool   `json:"supports_fine_tuned_adapters"`
+	BaseModel                 string `json:"base_model,omitempty"`
+	AdapterPrefix             string `json:"adapter_prefix,omitempty"`
+}
+
+// GetCapabilities returns this broker's broker-level capabilities.
+//
+//	@Description  Returns broker-level capability flags (issue #468)
+//	@ID           getCapabilities
+//	@Tags         capabilities
+//	@Produce      json
+//	@Router       /capabilities [get]
+//	@Success      200  {object}  CapabilitiesResponse
+func (h *Handler) GetCapabilities(c *gin.Context) {
+	cfg := h.modelsCtrl.GetServiceConfig()
+
+	resp := CapabilitiesResponse{
+		BaseModel: cfg.ModelType,
+	}
+
+	if h.modelsCtrl.SupportsFineTunedAdapters() {
+		resp.FineTuning = FineTuningCapability{
+			SupportsFineTunedAdapters: true,
+			BaseModel:                 h.modelsCtrl.LoRABaseModel(),
+			AdapterPrefix:             "ft-",
+		}
+	}
+
+	c.JSON(http.StatusOK, resp)
+}

--- a/api/inference/internal/handler/handler.go
+++ b/api/inference/internal/handler/handler.go
@@ -126,6 +126,10 @@ func (h *Handler) Register(r *gin.Engine) {
 	loraGroup.POST("/adapters/deploy", h.DeployAdapter)
 	loraGroup.GET("/adapters", h.ListAdapters)
 	loraGroup.GET("/adapters/:name", h.GetAdapterStatus)
+	// Operator kill-switch for adapters (issue #470). Provider-key gated:
+	// auth is checked inside the handler against the broker's own provider
+	// signature, not the user session, so it cannot be abused by users.
+	loraGroup.POST("/admin/evict", h.AdminEvictAdapter)
 
 	// Internal API: fine-tuning broker pushes adapter keys here
 	internal := r.Group("/internal/v1")

--- a/api/inference/internal/handler/handler.go
+++ b/api/inference/internal/handler/handler.go
@@ -32,6 +32,11 @@ type asyncCtrl interface {
 type modelsCtrl interface {
 	GetCachedService(ctx context.Context) (model.Service, error)
 	GetServiceConfig() config.Service
+	// SupportsFineTunedAdapters returns true when this broker auto-deploys
+	// fine-tune-derived LoRA adapters (issue #468).
+	SupportsFineTunedAdapters() bool
+	// LoRABaseModel returns the LoRA base model name, or "" when disabled.
+	LoRABaseModel() string
 }
 
 type Handler struct {
@@ -94,6 +99,10 @@ func (h *Handler) Register(r *gin.Engine) {
 
 	group.GET("/quote", corsMiddleware(), middleware.RateLimitMiddleware(h.rateLimiter), h.GetQuote)
 	group.GET("/models", corsMiddleware(), middleware.RateLimitMiddleware(h.rateLimiter), h.GetModels)
+	// Public broker-level capabilities (issue #468). Unauthenticated so the
+	// 0G inference router / aggregators can enumerate fine-tune-capable
+	// brokers without holding an account on every provider.
+	group.GET("/capabilities", corsMiddleware(), middleware.RateLimitMiddleware(h.rateLimiter), h.GetCapabilities)
 
 	// User account query (authenticated: user can only query their own data)
 	group.GET("/user/:userAddress/unsettledfee", corsMiddleware(), middleware.RateLimitMiddleware(h.rateLimiter), h.GetUnsettledFee)

--- a/api/inference/internal/handler/lora.go
+++ b/api/inference/internal/handler/lora.go
@@ -155,3 +155,67 @@ func (h *Handler) ListAdapters(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{"adapters": result})
 }
+
+// adminEvictRequest is the body of POST /v1/lora/admin/evict (issue #470).
+type adminEvictRequest struct {
+	AdapterName string `json:"adapterName"`
+	TaskID      string `json:"taskId"`
+	Purge       bool   `json:"purge"`
+}
+
+// AdminEvictAdapter is the operator-facing kill-switch for LoRA adapters
+// (issue #470). It is gated by provider-key auth (`ValidateProviderAuth`),
+// not by the user session, so an attacker cannot DoS another user's
+// adapters even if they capture a session.
+//
+// Request body:
+//
+//	{"adapterName":"ft-...", "purge": false}
+//	{"taskId":"<uuid>", "purge": true}
+//
+// purge=false (default) sets the adapter to Archived and removes files;
+// purge=true also deletes the DB row. Adapters in Loading state cannot be
+// evicted — wait for the in-flight download to complete or fail.
+func (h *Handler) AdminEvictAdapter(c *gin.Context) {
+	if err := h.ctrl.ValidateProviderAuth(c); err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "provider auth required: " + err.Error()})
+		return
+	}
+
+	var req adminEvictRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if req.AdapterName == "" && req.TaskID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "provide adapterName or taskId"})
+		return
+	}
+
+	mgr := h.ctrl.GetLoRAManager()
+	if mgr == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "LoRA serving not enabled"})
+		return
+	}
+
+	name := req.AdapterName
+	if name == "" {
+		if found := mgr.FindAdapterByTaskID(req.TaskID); found != nil {
+			name = found.AdapterName
+		} else {
+			c.JSON(http.StatusNotFound, gin.H{"error": "adapter not found for taskId " + req.TaskID})
+			return
+		}
+	}
+
+	if err := mgr.EvictAdapter(c.Request.Context(), name, req.Purge); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"status":      "evicted",
+		"adapterName": name,
+		"purged":      req.Purge,
+	})
+}

--- a/api/inference/internal/handler/models.go
+++ b/api/inference/internal/handler/models.go
@@ -31,6 +31,15 @@ type ModelObject struct {
 	TeeType             string                    `json:"tee_type,omitempty"`
 	TeeVerifier         string                    `json:"tee_verifier,omitempty"`
 	ExpirationDate      string                    `json:"expiration_date,omitempty"`
+
+	// SupportsFineTunedAdapters reports whether this broker auto-deploys
+	// fine-tune-derived LoRA adapters (issue #468). Aggregators and routers
+	// can use this flag to decide whether to route ft-* model requests here.
+	SupportsFineTunedAdapters bool `json:"supports_fine_tuned_adapters"`
+	// FineTunedAdapterPrefix tells clients the model-name prefix used for
+	// fine-tune-derived adapters served by this broker. Empty when the
+	// broker does not advertise LoRA support. Currently always "ft-".
+	FineTunedAdapterPrefix string `json:"fine_tuned_adapter_prefix,omitempty"`
 }
 
 // ModelPricing holds per-token pricing in the smallest unit (wei).
@@ -107,6 +116,13 @@ func (h *Handler) GetModels(ctx *gin.Context) {
 
 	// Extract TEE verifier from on-chain additionalInfo JSON
 	obj.TeeVerifier = parseTeeVerifier(svc.AdditionalInfo)
+
+	// Advertise LoRA capability so aggregators can decide whether to route
+	// ft-* model requests here without an authenticated probe (issue #468).
+	if h.modelsCtrl.SupportsFineTunedAdapters() {
+		obj.SupportsFineTunedAdapters = true
+		obj.FineTunedAdapterPrefix = "ft-"
+	}
 
 	ctx.JSON(http.StatusOK, ModelListResponse{
 		Object: "list",

--- a/api/inference/internal/handler/models_test.go
+++ b/api/inference/internal/handler/models_test.go
@@ -15,9 +15,11 @@ import (
 // --- Mock modelsCtrl ---
 
 type mockModelsCtrl struct {
-	service       model.Service
-	serviceErr    error
-	serviceConfig config.Service
+	service                   model.Service
+	serviceErr                error
+	serviceConfig             config.Service
+	supportsFineTunedAdapters bool
+	loraBaseModel             string
 }
 
 func (m *mockModelsCtrl) GetCachedService(_ context.Context) (model.Service, error) {
@@ -26,6 +28,14 @@ func (m *mockModelsCtrl) GetCachedService(_ context.Context) (model.Service, err
 
 func (m *mockModelsCtrl) GetServiceConfig() config.Service {
 	return m.serviceConfig
+}
+
+func (m *mockModelsCtrl) SupportsFineTunedAdapters() bool {
+	return m.supportsFineTunedAdapters
+}
+
+func (m *mockModelsCtrl) LoRABaseModel() string {
+	return m.loraBaseModel
 }
 
 func newModelsTestHandler(mock *mockModelsCtrl) *Handler {

--- a/api/inference/internal/lora/event_watcher.go
+++ b/api/inference/internal/lora/event_watcher.go
@@ -2,6 +2,7 @@ package lora
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -177,6 +178,16 @@ func (w *EventWatcher) processAcknowledgedEvents(
 			rootHash,
 			event.Raw.BlockNumber,
 		); err != nil {
+			// Admission rejections (quota, blocklist) are *not* retryable —
+			// re-replaying the same event will hit the same quota state.
+			// Treat them as permanent for the purpose of the watcher cursor
+			// so we don't pin block scanning forever (issue #470).
+			var adm *AdmissionError
+			if errors.As(err, &adm) {
+				w.logger.Warnf("admission rejected for task %s: %s (advancing cursor)",
+					event.DeliverableId, adm.Code)
+				continue
+			}
 			w.logger.Errorf("failed to register adapter for task %s: %v", event.DeliverableId, err)
 			if lowestFailed == 0 || event.Raw.BlockNumber < lowestFailed {
 				lowestFailed = event.Raw.BlockNumber

--- a/api/inference/internal/lora/manager.go
+++ b/api/inference/internal/lora/manager.go
@@ -30,6 +30,37 @@ type AdapterInfo struct {
 	AdapterPath     string
 }
 
+// Default quota values applied when LoRAConfig.Quota fields are zero. These
+// match the documented defaults in config.go but are duplicated here so the
+// manager applies them even if the YAML schema is older or the operator
+// explicitly cleared the field. 0 means "no limit" only after passing
+// through these helpers — see quotaXxx() methods below.
+const (
+	defaultMaxAdaptersPerUser           = 5
+	defaultMaxAdaptersTotal             = 100
+	defaultMaxConcurrentDownloads       = 3
+	defaultMaxAdapterDiskBytes    int64 = 100 * 1024 * 1024 * 1024 // 100 GiB
+	defaultCapacityCheckInterval        = 5 * time.Minute
+)
+
+// AdmissionError is returned by RegisterAdapter when admission control rejects
+// a new adapter. It carries a stable code so on-chain event watchers and the
+// admin tooling can distinguish the rejection reason.
+type AdmissionError struct {
+	Code    string
+	Message string
+}
+
+func (e *AdmissionError) Error() string { return e.Message }
+
+const (
+	AdmissionRejectedBlocked       = "user_blocked"
+	AdmissionRejectedPerUserQuota  = "per_user_quota_exceeded"
+	AdmissionRejectedTotalQuota    = "total_quota_exceeded"
+	AdmissionRejectedDiskQuota     = "disk_quota_exceeded"
+	AdmissionRejectedManagerClosed = "manager_closed"
+)
+
 // Manager manages the lifecycle of LoRA adapters: discovery via on-chain events,
 // download/decrypt from 0G Storage, deployment to ServerlessLLM, offloading, and restoration.
 type Manager struct {
@@ -37,11 +68,20 @@ type Manager struct {
 	adapters map[string]*AdapterInfo // adapterName → info
 	ctx      context.Context         // application-scoped context for graceful shutdown
 
-	config             config.LoRAConfig
-	db                 *db.DB
-	sllmClient         *SLLMClient
-	storageDownloader  *StorageDownloader
-	logger             log.Logger
+	config            config.LoRAConfig
+	db                *db.DB
+	sllmClient        *SLLMClient
+	storageDownloader *StorageDownloader
+	logger            log.Logger
+
+	// blockedUsers is the lower-cased operator kill-switch set. New adapter
+	// registrations from these addresses are rejected at admission time
+	// (issue #470).
+	blockedUsers map[string]struct{}
+
+	// downloadSemaphore caps concurrent 0G Storage download goroutines.
+	// nil means no cap. Sized at construction from the quota config.
+	downloadSemaphore chan struct{}
 }
 
 // NewManager creates a LoRA adapter manager with the given config, 0G Storage downloader,
@@ -94,7 +134,142 @@ func NewManager(cfg config.LoRAConfig, networks commonconfig.Networks, database 
 		logger:            logger,
 	}
 
+	// Build the blocklist as a lower-cased set for O(1) admission lookups.
+	if len(cfg.Quota.BlockedUsers) > 0 {
+		m.blockedUsers = make(map[string]struct{}, len(cfg.Quota.BlockedUsers))
+		for _, u := range cfg.Quota.BlockedUsers {
+			m.blockedUsers[strings.ToLower(strings.TrimSpace(u))] = struct{}{}
+		}
+		logger.Infof("LoRA blocklist: %d address(es) will have new registrations rejected", len(m.blockedUsers))
+	}
+
+	if cap := m.quotaMaxConcurrentDownloads(); cap > 0 {
+		m.downloadSemaphore = make(chan struct{}, cap)
+		logger.Infof("LoRA download concurrency capped at %d", cap)
+	}
+
 	return m, nil
+}
+
+// quotaMaxAdaptersPerUser returns the configured per-user quota with the
+// default applied when the field is zero. A negative value disables the
+// check entirely (operator opt-out).
+func (m *Manager) quotaMaxAdaptersPerUser() int {
+	v := m.config.Quota.MaxAdaptersPerUser
+	if v < 0 {
+		return 0 // disabled
+	}
+	if v == 0 {
+		return defaultMaxAdaptersPerUser
+	}
+	return v
+}
+
+// quotaMaxAdaptersTotal returns the broker-wide adapter cap with default applied.
+func (m *Manager) quotaMaxAdaptersTotal() int {
+	v := m.config.Quota.MaxAdaptersTotal
+	if v < 0 {
+		return 0
+	}
+	if v == 0 {
+		return defaultMaxAdaptersTotal
+	}
+	return v
+}
+
+// quotaMaxConcurrentDownloads returns the download concurrency cap with default applied.
+func (m *Manager) quotaMaxConcurrentDownloads() int {
+	v := m.config.Quota.MaxConcurrentDownloads
+	if v < 0 {
+		return 0
+	}
+	if v == 0 {
+		return defaultMaxConcurrentDownloads
+	}
+	return v
+}
+
+// quotaMaxAdapterDiskBytes returns the disk usage cap with default applied.
+// 0 disables; default is 100 GiB.
+func (m *Manager) quotaMaxAdapterDiskBytes() int64 {
+	v := m.config.Quota.MaxAdapterDiskBytes
+	if v < 0 {
+		return 0
+	}
+	if v == 0 {
+		return defaultMaxAdapterDiskBytes
+	}
+	return v
+}
+
+// quotaCapacityCheckInterval returns how often the LRU eviction loop runs.
+func (m *Manager) quotaCapacityCheckInterval() time.Duration {
+	v := time.Duration(m.config.Quota.CapacityCheckIntervalMinutes) * time.Minute
+	if v <= 0 {
+		return defaultCapacityCheckInterval
+	}
+	return v
+}
+
+// isUserBlocked reports whether the address is on the operator kill-switch list.
+// Comparison is case-insensitive on the hex address.
+func (m *Manager) isUserBlocked(userAddress string) bool {
+	if len(m.blockedUsers) == 0 {
+		return false
+	}
+	_, ok := m.blockedUsers[strings.ToLower(strings.TrimSpace(userAddress))]
+	return ok
+}
+
+// admissionCheck enforces per-user, broker-wide, and disk quotas before an
+// adapter is persisted to the DB. Returning a non-nil error rejects the
+// registration upstream — the event watcher will log it and move on.
+func (m *Manager) admissionCheck(userAddress string) error {
+	if m.isUserBlocked(userAddress) {
+		return &AdmissionError{Code: AdmissionRejectedBlocked,
+			Message: fmt.Sprintf("user %s is blocked from registering new adapters", userAddress)}
+	}
+
+	if m.db == nil {
+		// Without a DB we have no way to enforce counts. Allow but log.
+		m.logger.Warn("admissionCheck: DB not configured, skipping quota checks")
+		return nil
+	}
+
+	if cap := m.quotaMaxAdaptersPerUser(); cap > 0 {
+		n, err := m.db.CountAdaptersByUser(userAddress)
+		if err != nil {
+			m.logger.Warnf("admissionCheck: count by user %s: %v (allowing)", userAddress, err)
+		} else if int(n) >= cap {
+			return &AdmissionError{
+				Code:    AdmissionRejectedPerUserQuota,
+				Message: fmt.Sprintf("per-user quota exceeded: user %s already owns %d/%d adapters", userAddress, n, cap),
+			}
+		}
+	}
+
+	if cap := m.quotaMaxAdaptersTotal(); cap > 0 {
+		n, err := m.db.CountTotalAdapters()
+		if err != nil {
+			m.logger.Warnf("admissionCheck: count total: %v (allowing)", err)
+		} else if int(n) >= cap {
+			return &AdmissionError{
+				Code:    AdmissionRejectedTotalQuota,
+				Message: fmt.Sprintf("broker-wide quota exceeded: %d/%d adapters", n, cap),
+			}
+		}
+	}
+
+	if cap := m.quotaMaxAdapterDiskBytes(); cap > 0 && m.config.LoraModulesDir != "" {
+		if used, err := dirSize(m.config.LoraModulesDir); err == nil && used >= cap {
+			return &AdmissionError{
+				Code:    AdmissionRejectedDiskQuota,
+				Message: fmt.Sprintf("disk quota exceeded: %d / %d bytes used", used, cap),
+			}
+		}
+	}
+
+	return nil
 }
 
 // Start loads known adapters from DB and begins background loops.
@@ -114,9 +289,30 @@ func (m *Manager) Start(ctx context.Context) error {
 	m.mu.RUnlock()
 
 	go m.offloadLoop(ctx)
+	// Capacity-based eviction is enforced separately from idle-based offload
+	// (issue #470). The latter only releases GPU slots; this one releases
+	// disk and DB rows when the broker is over its quota.
+	go m.capacityEvictionLoop(ctx)
 
 	m.logger.Infof("LoRA Manager started: %d adapters loaded", adapterCount)
 	return nil
+}
+
+// dirSize sums the size of all regular files under root. Errors on individual
+// files are tolerated so a single unreadable file does not block the quota
+// check; the caller logs and continues.
+func dirSize(root string) (int64, error) {
+	var total int64
+	err := filepath.Walk(root, func(_ string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return nil
+		}
+		if info.Mode().IsRegular() {
+			total += info.Size()
+		}
+		return nil
+	})
+	return total, err
 }
 
 // GetBaseModel returns the base model path configured for this LoRA manager.
@@ -201,6 +397,11 @@ func (m *Manager) RecordAccess(adapterName string) {
 
 // RegisterAdapter adds a new LoRA adapter (called when on-chain event detected).
 // DB is written first so that a failed DB write doesn't leave orphaned in-memory state.
+//
+// Admission control (issue #470): rejects the registration if the user is
+// blocked or any of the per-user / broker-wide / disk quotas would be
+// exceeded. Returns an *AdmissionError so the caller can distinguish a
+// rejection from an internal error.
 func (m *Manager) RegisterAdapter(ctx context.Context, taskID, userAddress, baseModel, storageRootHash string, blockNumber uint64) error {
 	adapterName := MakeAdapterName(baseModel, taskID)
 	adapterPath := filepath.Join(m.config.LoraModulesDir, adapterName)
@@ -211,6 +412,14 @@ func (m *Manager) RegisterAdapter(ctx context.Context, taskID, userAddress, base
 	if exists {
 		m.logger.Infof("adapter %s already registered, skipping", adapterName)
 		return nil
+	}
+
+	// Admission control runs before any DB write so a rejected registration
+	// does not consume disk, bandwidth, or a DB row. Re-running for the same
+	// task is idempotent because the duplicate-name check above handles it.
+	if err := m.admissionCheck(userAddress); err != nil {
+		m.logger.Warnf("admission rejected for adapter %s (user %s): %v", adapterName, userAddress, err)
+		return err
 	}
 
 	now := time.Now()
@@ -265,10 +474,26 @@ func (m *Manager) RegisterAdapter(ctx context.Context, taskID, userAddress, base
 // downloadAdapter downloads the adapter from 0G Storage and decrypts it.
 // If AutoDeploy is enabled, it also deploys to ServerlessLLM immediately.
 // Otherwise, the adapter is left in "ready" state for user-triggered deployment.
+//
+// The actual 0G Storage transfer is gated by downloadSemaphore (issue #470)
+// so a burst of on-chain ack events cannot spawn unbounded concurrent
+// downloads. State stays Loading for the entire wait + download window.
 func (m *Manager) downloadAdapter(ctx context.Context, info *AdapterInfo) {
 	m.logger.Infof("downloading adapter %s (hash: %s)", info.AdapterName, info.StorageRootHash)
 
 	if _, err := os.Stat(info.AdapterPath); os.IsNotExist(err) {
+		// Acquire a download slot; bail out cleanly on shutdown.
+		if m.downloadSemaphore != nil {
+			select {
+			case m.downloadSemaphore <- struct{}{}:
+			case <-ctx.Done():
+				m.logger.Warnf("context cancelled before acquiring download slot for %s", info.AdapterName)
+				m.setAdapterState(info.AdapterName, model.AdapterStateFailed)
+				return
+			}
+			defer func() { <-m.downloadSemaphore }()
+		}
+
 		if err := m.downloadFromStorage(ctx, info); err != nil {
 			m.logger.Errorf("failed to download adapter %s from 0G Storage: %v", info.AdapterName, err)
 			os.RemoveAll(info.AdapterPath)
@@ -579,6 +804,147 @@ func (m *Manager) offloadIdleAdapters(ctx context.Context) {
 		}
 		m.setAdapterState(a.AdapterName, model.AdapterStateOffloaded)
 	}
+}
+
+// capacityEvictionLoop runs periodically and drives capacity-based eviction
+// of LoRA adapters when the broker exceeds the per-broker count quota or
+// the disk quota (issue #470). Unlike offloadLoop which only releases the
+// GPU slot, this loop reclaims disk and DB rows by transitioning oldest
+// adapters all the way to Archived.
+func (m *Manager) capacityEvictionLoop(ctx context.Context) {
+	interval := m.quotaCapacityCheckInterval()
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			m.evictForCapacity(ctx)
+		}
+	}
+}
+
+// evictForCapacity computes the over-quota delta and archives that many
+// LRU adapters. Eviction stops as soon as either count and disk caps are
+// satisfied, even if the disk-walk reports stale data.
+func (m *Manager) evictForCapacity(ctx context.Context) {
+	if m.db == nil {
+		return
+	}
+
+	totalCap := m.quotaMaxAdaptersTotal()
+	diskCap := m.quotaMaxAdapterDiskBytes()
+
+	currentCount, err := m.db.CountTotalAdapters()
+	if err != nil {
+		m.logger.Errorf("evict: count total: %v", err)
+		return
+	}
+
+	var diskUsed int64
+	if m.config.LoraModulesDir != "" {
+		if du, err := dirSize(m.config.LoraModulesDir); err == nil {
+			diskUsed = du
+		} else {
+			m.logger.Warnf("evict: dir size for %s: %v", m.config.LoraModulesDir, err)
+		}
+	}
+
+	overCount := totalCap > 0 && int(currentCount) > totalCap
+	overDisk := diskCap > 0 && diskUsed > diskCap
+	if !overCount && !overDisk {
+		return
+	}
+
+	m.logger.Infof("evict: over capacity (count=%d/%d, disk=%d/%d), starting LRU eviction",
+		currentCount, totalCap, diskUsed, diskCap)
+
+	// Pick at most a small batch per tick so a flood of evictions does not
+	// stall request handling.
+	const maxEvictPerTick = 20
+	candidates, err := m.db.ListLRUEvictionCandidates(maxEvictPerTick)
+	if err != nil {
+		m.logger.Errorf("evict: list LRU: %v", err)
+		return
+	}
+
+	for _, a := range candidates {
+		if !overCount && !overDisk {
+			break
+		}
+		if err := m.archiveAdapter(ctx, a.AdapterName); err != nil {
+			m.logger.Warnf("evict: archive %s: %v", a.AdapterName, err)
+			continue
+		}
+		currentCount--
+		if a.AdapterPath != "" {
+			if fi, err := os.Stat(a.AdapterPath); err == nil {
+				diskUsed -= fi.Size()
+			}
+		}
+		overCount = totalCap > 0 && int(currentCount) > totalCap
+		overDisk = diskCap > 0 && diskUsed > diskCap
+	}
+}
+
+// archiveAdapter releases ServerlessLLM slot, deletes adapter files on disk,
+// transitions the DB row to Archived. The DB row is intentionally retained
+// so a future on-chain re-acknowledge can re-download via the same path.
+//
+// Provider operators wanting full row removal should call DeleteAdapter via
+// the admin endpoint, which is gated by provider-key auth.
+func (m *Manager) archiveAdapter(ctx context.Context, adapterName string) error {
+	m.mu.RLock()
+	a, ok := m.adapters[adapterName]
+	var path string
+	if ok {
+		path = a.AdapterPath
+	}
+	m.mu.RUnlock()
+	if !ok {
+		return fmt.Errorf("adapter %s not in memory", adapterName)
+	}
+
+	if err := m.sllmClient.DeleteAdapter(ctx, adapterName); err != nil {
+		// Continue even if SLLM unload fails — the adapter may already
+		// be offloaded; we still want to reclaim disk.
+		m.logger.Warnf("archive %s: SLLM delete: %v", adapterName, err)
+	}
+	if path != "" {
+		if err := os.RemoveAll(path); err != nil {
+			m.logger.Warnf("archive %s: remove %s: %v", adapterName, path, err)
+		}
+	}
+	m.setAdapterState(adapterName, model.AdapterStateArchived)
+	m.logger.Infof("archived adapter %s (LRU eviction)", adapterName)
+	return nil
+}
+
+// EvictAdapter is the operator-facing eviction entry point. It is exposed via
+// the provider-only admin endpoint (issue #470) and goes through the same
+// archiveAdapter path used by capacity eviction.
+//
+// purge: when true the DB row is also deleted, otherwise it is kept in
+// Archived state so the user can later re-acknowledge to redownload.
+func (m *Manager) EvictAdapter(ctx context.Context, adapterName string, purge bool) error {
+	if err := m.archiveAdapter(ctx, adapterName); err != nil {
+		return err
+	}
+	if !purge {
+		return nil
+	}
+
+	m.mu.Lock()
+	delete(m.adapters, adapterName)
+	m.mu.Unlock()
+	if m.db != nil {
+		if err := m.db.DeleteLoRAAdapter(adapterName); err != nil {
+			return fmt.Errorf("delete adapter %s from DB: %w", adapterName, err)
+		}
+	}
+	return nil
 }
 
 // MakeAdapterName builds a deterministic adapter name from base model and task ID.

--- a/doc/provider-guide.md
+++ b/doc/provider-guide.md
@@ -1,0 +1,521 @@
+# 0G Compute Network - Provider Guide
+
+This guide covers how to set up and operate a compute provider node on the 0G Compute Network, offering fine-tuning and inference services.
+
+## Overview
+
+As a provider, you run GPU nodes that serve two functions:
+- **Fine-tuning**: Train LoRA adapters on user-supplied datasets
+- **Inference**: Serve base models and fine-tuned LoRA adapters via an OpenAI-compatible API
+
+The broker software handles service registration, TEE attestation, settlement, and model management automatically.
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  Provider Node (CVM / GPU Server)                            │
+│                                                              │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐       │
+│  │   MySQL      │  │   Broker     │  │   vLLM       │       │
+│  │  (state DB)  │  │  (Go binary) │  │  (GPU model) │       │
+│  └──────────────┘  └──────────────┘  └──────────────┘       │
+│                         │                    │               │
+│                    ┌────┴────┐          ┌────┴────┐          │
+│                    │  Nginx  │          │  sLLM   │          │
+│                    │ (proxy) │          │ Wrapper │          │
+│                    └─────────┘          └─────────┘          │
+└──────────────────────────────────────────────────────────────┘
+            │                                 │
+    Smart Contracts                    0G Storage
+    (Registration,                     (Datasets,
+     Settlement)                        Models)
+```
+
+## Prerequisites
+
+- **GPU Server**: NVIDIA GPU with sufficient VRAM (H100/H200 recommended for large models)
+- **Docker** and **Docker Compose**
+- **A0GI Tokens**: At least 100 A0GI for provider stake (per service)
+- **Private Key**: Ethereum-compatible wallet for on-chain operations
+
+## Broker Binary
+
+The broker is distributed as a Docker image:
+
+```
+ghcr.io/0gfoundation/0g-serving-broker:latest
+```
+
+The single binary supports multiple modes via its first argument:
+
+| Command | Description |
+|---|---|
+| `0g-inference-server` | Inference HTTP broker |
+| `0g-inference-event` | Inference background event/settlement worker |
+| `0g-fine-tuning-server` | Fine-tuning broker |
+| `0g-controller` | Optional controller service for remote management |
+
+## Setup: Fine-Tuning Provider
+
+### 1. Configuration
+
+Create `config-ft.yaml`:
+
+```yaml
+contractAddress: "<FINE_TUNING_SERVING_CONTRACT>"
+
+networks:
+  ethereum0g:
+    url: "https://evmrpc-testnet.0g.ai"
+    chainID: 16602
+    privateKeys:
+      - "<YOUR_PRIVATE_KEY>"
+
+database:
+  fineTune: "root:password@tcp(mysql-ft:3306)/fine_tuning?parseTime=true"
+
+servingUrl: "https://<YOUR_PUBLIC_ENDPOINT>"
+
+service:
+  dataDir: "/data/ft-data"
+  pricePerToken: 800000000000
+  quota:
+    cpuCount: 8
+    nodeMemory: 187
+    gpuCount: 1
+    nodeStorage: 900
+    gpuType: "H200"
+  supportedPredefinedModels:
+    - "Qwen2.5-0.5B-Instruct"
+  localModelPathMap:
+    "Qwen2.5-0.5B-Instruct": "/data/models/Qwen2.5-0.5B-Instruct"
+  inferenceServiceUrl: "https://<INFERENCE_BROKER_ENDPOINT>"
+
+storageClient:
+  indexerStandard: "https://indexer-storage-testnet-standard.0g.ai"
+  indexerTurbo: "https://indexer-storage-testnet-turbo.0g.ai"
+```
+
+Key fields:
+
+| Field | Description |
+|---|---|
+| `contractAddress` | FineTuningServing contract address on the target network |
+| `networks.ethereum0g.privateKeys` | Provider wallet private key (used for signing transactions) |
+| `servingUrl` | Public HTTPS URL where the broker API is accessible |
+| `service.dataDir` | Local directory for datasets, models, and training artifacts |
+| `service.pricePerToken` | Price per token in neuron (1 A0GI = 10^18 neuron) |
+| `service.quota` | Hardware specs advertised to users |
+| `service.localModelPathMap` | Map of model names to local paths (pre-downloaded) |
+| `service.inferenceServiceUrl` | URL of the inference broker (for pushing LoRA adapters after training) |
+| `storageClient` | 0G Storage indexer endpoints for dataset/model transfer |
+
+### 2. Docker Compose
+
+```yaml
+services:
+  mysql-ft:
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_DATABASE: fine_tuning
+    volumes:
+      - mysql-ft-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      retries: 5
+
+  fine-tuning-broker:
+    image: ghcr.io/0gfoundation/0g-serving-broker:latest
+    command: 0g-fine-tuning-server
+    ports:
+      - "3080:3080"
+    environment:
+      CONFIG_FILE: /etc/config.yaml
+      PORT: "3080"
+    volumes:
+      - ./config-ft.yaml:/etc/config.yaml:ro
+      - ./ft-data:/data/ft-data
+      - ./models:/data/models:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+    depends_on:
+      mysql-ft:
+        condition: service_healthy
+    privileged: true
+    restart: unless-stopped
+
+volumes:
+  mysql-ft-data:
+```
+
+> **Note**: `privileged: true` and Docker socket mounting are required because the fine-tuning broker spawns training containers internally.
+
+### 3. Pre-download Models
+
+Download supported models before starting the broker:
+
+```bash
+# Using huggingface-cli
+pip install huggingface_hub
+huggingface-cli download Qwen/Qwen2.5-0.5B-Instruct --local-dir ./models/Qwen2.5-0.5B-Instruct
+```
+
+### 4. Start Services
+
+```bash
+docker compose up -d
+```
+
+The broker will automatically:
+1. Connect to the smart contract
+2. Register/update the provider service (with 100 A0GI stake on first registration)
+3. Start polling for new tasks
+4. Build the training executor Docker image (first startup takes several minutes)
+
+### 5. TEE Signer Acknowledgement
+
+After registration, the contract owner must acknowledge your TEE signer before users can submit tasks. Contact the 0G team with:
+- Your provider address
+- The contract address
+- Your TEE signer address (visible in broker logs)
+
+## Setup: Inference Provider
+
+### 1. Configuration
+
+Create `config-inf.yaml`:
+
+```yaml
+contractAddress: "<INFERENCE_SERVING_CONTRACT>"
+
+networks:
+  ethereum0g:
+    url: "https://evmrpc-testnet.0g.ai"
+    chainID: 16602
+    privateKeys:
+      - "<YOUR_PRIVATE_KEY>"
+
+database:
+  provider: "root:password@tcp(mysql-inf:3306)/inference?parseTime=true"
+
+service:
+  servingUrl: "https://<YOUR_PUBLIC_ENDPOINT>"
+  targetUrl: "http://vllm:8000"
+  inputPrice: 10000000
+  outputPrice: 10000000
+  type: "chatbot"
+  model: "Qwen2.5-0.5B-Instruct"
+  verifiability: "dstack"
+
+lora:
+  sllmUrl: "http://sllm-wrapper:8343"
+  storageClient:
+    indexerStandard: "https://indexer-storage-testnet-standard.0g.ai"
+    indexerTurbo: "https://indexer-storage-testnet-turbo.0g.ai"
+  loraAdaptersHostPath: "/data/lora-adapters"
+  loraAdaptersContainerPath: "/lora-adapters"
+  fineTuningContractAddress: "<FINE_TUNING_SERVING_CONTRACT>"
+  networks:
+    ethereum0g:
+      url: "https://evmrpc-testnet.0g.ai"
+      chainID: 16602
+      privateKeys:
+        - "<YOUR_PRIVATE_KEY>"
+```
+
+Key fields:
+
+| Field | Description |
+|---|---|
+| `service.targetUrl` | Internal URL of the vLLM server |
+| `service.inputPrice` / `outputPrice` | Price per token in neuron |
+| `service.type` | Service type: `chatbot`, `text-to-image`, or `speech-to-text` |
+| `service.model` | Model name served by vLLM |
+| `lora.sllmUrl` | URL of the ServerlessLLM wrapper for LoRA management |
+| `lora.loraAdaptersHostPath` | Host path where LoRA adapters are stored |
+| `lora.fineTuningContractAddress` | FineTuningServing contract (to listen for adapter delivery events) |
+
+### 2. Docker Compose
+
+```yaml
+services:
+  mysql-inf:
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_DATABASE: inference
+    volumes:
+      - mysql-inf-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      retries: 5
+
+  vllm:
+    image: vllm/vllm-openai:v0.8.5.post1
+    command: >
+      --model /models/Qwen2.5-0.5B-Instruct
+      --served-model-name Qwen2.5-0.5B-Instruct
+      --enable-lora
+      --lora-modules {}
+      --max-lora-rank 64
+      --max-loras 4
+      --max-cpu-loras 8
+      --gpu-memory-utilization 0.85
+      --max-model-len 4096
+    volumes:
+      - ./models:/models:ro
+      - ./lora-adapters:/lora-adapters
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8000/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 10
+      start_period: 120s
+
+  sllm-wrapper:
+    image: python:3.11-slim
+    command: python3 /app/sllm-wrapper.py
+    environment:
+      VLLM_BASE: "http://vllm:8000"
+      LORA_HOST_PREFIX: "/data/lora-adapters"
+      LORA_CONTAINER_PREFIX: "/lora-adapters"
+    volumes:
+      - ./sllm-wrapper.py:/app/sllm-wrapper.py:ro
+      - ./lora-adapters:/data/lora-adapters
+    depends_on:
+      vllm:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8343/health || exit 1"]
+      interval: 10s
+      retries: 5
+
+  inference-broker:
+    image: ghcr.io/0gfoundation/0g-serving-broker:latest
+    command: 0g-inference-server
+    environment:
+      CONFIG_FILE: /etc/config.yaml
+      PORT: "3080"
+    volumes:
+      - ./config-inf.yaml:/etc/config.yaml:ro
+      - ./lora-adapters:/data/lora-adapters
+    depends_on:
+      mysql-inf:
+        condition: service_healthy
+      vllm:
+        condition: service_healthy
+      sllm-wrapper:
+        condition: service_healthy
+    restart: unless-stopped
+
+  inference-event:
+    image: ghcr.io/0gfoundation/0g-serving-broker:latest
+    command: 0g-inference-event
+    environment:
+      CONFIG_FILE: /etc/config.yaml
+    volumes:
+      - ./config-inf.yaml:/etc/config.yaml:ro
+      - ./lora-adapters:/data/lora-adapters
+    depends_on:
+      mysql-inf:
+        condition: service_healthy
+    restart: unless-stopped
+
+  nginx:
+    image: nginx:1.27.0
+    ports:
+      - "3081:80"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      - inference-broker
+    restart: unless-stopped
+
+volumes:
+  mysql-inf-data:
+```
+
+### 3. Nginx Configuration
+
+```nginx
+events { worker_connections 1024; }
+
+http {
+    server {
+        listen 80;
+        client_max_body_size 100M;
+
+        location / {
+            proxy_pass http://inference-broker:3080;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_read_timeout 300s;
+            proxy_buffering off;
+        }
+    }
+}
+```
+
+### 4. sLLM Wrapper
+
+The sLLM wrapper bridges the broker's LoRA management API to vLLM. See `sllm-wrapper.py` in the repository for the reference implementation. It provides:
+
+- `POST /deploy` — Load a LoRA adapter into vLLM
+- `POST /remove` — Unload a LoRA adapter
+- `GET /adapters` — List loaded adapters
+- `GET /health` — Health check
+
+### 5. Start Services
+
+```bash
+docker compose up -d
+```
+
+Monitor startup:
+
+```bash
+docker compose logs -f inference-broker
+```
+
+Wait for:
+```
+[SyncService] Service sync successful
+```
+
+## Provider Stake
+
+First-time service registration requires a stake of **100 A0GI** (configurable via `service.providerStake` in the config). The stake is sent automatically during the first `addOrUpdateService` call.
+
+- **Fine-tuning**: 100 A0GI stake on the FineTuningServing contract
+- **Inference**: 100 A0GI stake on the InferenceServing contract
+
+If running both services with the same wallet, ensure at least **200 A0GI** balance plus gas fees.
+
+To override the default stake amount, add to your config:
+
+```yaml
+service:
+  providerStake: "100000000000000000000"  # 100 A0GI in wei
+```
+
+## Operations
+
+### Monitoring
+
+Check service status:
+
+```bash
+docker compose ps
+docker compose logs --tail 50 <service-name>
+```
+
+The broker logs service sync status every minute:
+```
+[GetService] Retrieved service from contract - url=..., model=..., pricePerToken=...
+```
+
+### Updating Configuration
+
+1. Edit the config YAML file
+2. Restart the affected services:
+
+```bash
+docker compose restart inference-broker inference-event
+```
+
+### Updating the Broker
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
+### Adding New Models
+
+1. Download the model to the models directory
+2. For fine-tuning: Add to `service.localModelPathMap` and `service.supportedPredefinedModels`
+3. For inference: Update `service.model` and vLLM command
+4. Restart services
+
+### Service Removal
+
+To remove your service from the contract (returns your stake):
+
+```bash
+0g-compute-cli fine-tuning remove-service
+0g-compute-cli inference remove-service
+```
+
+## Contract Addresses
+
+### Testnet (Chain ID: 16602)
+
+| Contract | Address |
+|---|---|
+| InferenceServing | `0xa79F4c8311FF93C06b8CfB403690cc987c93F91E` |
+| FineTuningServing | `0xaC66eBd174435c04F1449BBa08157a707B6fa7b1` |
+| LedgerManager | `0xE70830508dAc0A97e6c087c75f402f9Be669E406` |
+
+### Testnet Dev (Chain ID: 16602)
+
+| Contract | Address |
+|---|---|
+| InferenceServing | `0x41bD7Ac5c19000A974D5c192bcd5FB67b56C85c5` |
+| FineTuningServing | `0x4e4158DF35CfdC0ac63264D3E112F5B8E9a5c569` |
+| LedgerManager | `0x815B93ab4Ba4BDF530dbF1552649a3c534F8BbF7` |
+
+## Troubleshooting
+
+### "InsufficientStake"
+
+Ensure your wallet has at least 100 A0GI balance. Check with:
+
+```bash
+# Using web3
+python3 -c "
+from web3 import Web3
+w3 = Web3(Web3.HTTPProvider('https://evmrpc-testnet.0g.ai'))
+print(w3.from_wei(w3.eth.get_balance('<YOUR_ADDRESS>'), 'ether'), 'A0GI')
+"
+```
+
+### "execution reverted" on addOrUpdateService
+
+Common causes:
+1. **Insufficient funds** for stake
+2. **Trying to add stake on update** — updates must send 0 value
+3. **ABI mismatch** — ensure broker image matches the deployed contract version
+
+### Broker keeps restarting
+
+Check logs for the root cause:
+
+```bash
+docker compose logs --tail 100 fine-tuning-broker
+```
+
+Common issues:
+- MySQL not ready (wait for healthcheck)
+- Invalid config YAML (check `yaml.UnmarshalStrict` errors)
+- Network connectivity (check RPC endpoint)
+
+### TEE signer not acknowledged
+
+After deploying to a new CVM, the broker generates a new TEE signing key. Contact the 0G team to acknowledge it. Provide:
+- Provider address
+- Contract address(es)
+- TEE signer address (from broker logs: `teeAddress: 0x...`)
+
+### Training executor image build slow
+
+On first startup, the fine-tuning broker builds a PyTorch Docker image (~5-10 minutes). The broker HTTP server won't be available until this completes. This is a one-time operation.

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -200,6 +200,18 @@ Once status is `Delivered`, download the model and acknowledge on-chain:
 
 The `--deploy` flag also deploys the LoRA adapter to the inference GPU. The CLI will wait until the adapter is ready.
 
+If the inference provider is different from the fine-tuning provider, specify it separately:
+
+```bash
+0g-compute-cli fine-tuning acknowledge-model \
+  --provider <FT_PROVIDER_ADDRESS> \
+  --inference-provider <INF_PROVIDER_ADDRESS> \
+  --task-id <TASK_ID> \
+  --data-path ./output \
+  --deploy \
+  --model "Qwen2.5-0.5B-Instruct"
+```
+
 ### Step 8: Decrypt Model (Optional)
 
 If you want to keep a local copy of the LoRA adapter:

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -37,6 +37,14 @@ Select testnet or mainnet. You can check the current network with:
 0g-compute-cli show-network
 ```
 
+If you are using the **dev testnet** environment, enable dev mode so the CLI connects to the correct contracts:
+
+```bash
+export ZG_DEV_MODE=true
+```
+
+When dev mode is active, the CLI prints `[DEV MODE]` in its output to confirm.
+
 ### 3. Deposit Funds
 
 Deposit A0GI into your main account:

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -1,0 +1,407 @@
+# 0G Compute Network - User Guide
+
+This guide covers how to fine-tune models, deploy LoRA adapters, and run inference on the 0G Compute Network.
+
+## Prerequisites
+
+- **Node.js** v18+
+- **0G Compute CLI** installed globally:
+  ```bash
+  npm install -g @0glabs/0g-serving-broker
+  ```
+- A wallet with A0GI tokens on the 0G network
+
+## Quick Start
+
+### 1. Login
+
+```bash
+0g-compute-cli login --private-key <YOUR_PRIVATE_KEY>
+```
+
+Verify your login status:
+
+```bash
+0g-compute-cli status
+```
+
+### 2. Configure Network
+
+```bash
+0g-compute-cli setup-network
+```
+
+Select testnet or mainnet. You can check the current network with:
+
+```bash
+0g-compute-cli show-network
+```
+
+### 3. Deposit Funds
+
+Deposit A0GI into your main account:
+
+```bash
+0g-compute-cli deposit --amount 5
+```
+
+Transfer funds to a provider sub-account for fine-tuning:
+
+```bash
+0g-compute-cli transfer-fund \
+  --provider <PROVIDER_ADDRESS> \
+  --service fine-tuning \
+  --amount 2
+```
+
+For inference:
+
+```bash
+0g-compute-cli transfer-fund \
+  --provider <PROVIDER_ADDRESS> \
+  --service inference \
+  --amount 2
+```
+
+Check your account balance:
+
+```bash
+0g-compute-cli get-account
+```
+
+## Fine-Tuning
+
+### Step 1: Find a Provider
+
+```bash
+0g-compute-cli fine-tuning list-providers
+```
+
+This shows available providers, their pricing, and availability status.
+
+### Step 2: Verify Provider TEE
+
+Before submitting tasks, verify the provider's TEE attestation:
+
+```bash
+0g-compute-cli fine-tuning verify --provider <PROVIDER_ADDRESS>
+```
+
+### Step 3: Prepare Dataset
+
+Create a JSONL file in the chat format:
+
+```json
+{"messages": [{"role": "system", "content": "You are a helpful assistant."}, {"role": "user", "content": "What is Python?"}, {"role": "assistant", "content": "Python is a programming language."}]}
+{"messages": [{"role": "system", "content": "You are a helpful assistant."}, {"role": "user", "content": "What is Go?"}, {"role": "assistant", "content": "Go is a statically typed, compiled language designed at Google."}]}
+```
+
+Each line must be a valid JSON object with a `messages` array following the chat format (system/user/assistant roles).
+
+### Step 4: Create Training Config
+
+Create a JSON file with training hyperparameters:
+
+```json
+{
+  "num_train_epochs": 1,
+  "per_device_train_batch_size": 2,
+  "learning_rate": 0.0002,
+  "max_steps": 3
+}
+```
+
+Common parameters:
+
+| Parameter | Description | Default |
+|---|---|---|
+| `num_train_epochs` | Number of training epochs | 1 |
+| `per_device_train_batch_size` | Batch size per device | 2 |
+| `learning_rate` | Learning rate | 0.0002 |
+| `max_steps` | Max training steps (overrides epochs if set) | - |
+| `neftune_noise_alpha` | NEFTune noise for regularization | - |
+
+> **Note**: Use decimal notation for learning_rate (e.g., `0.0002`), not scientific notation (`2e-4`).
+
+### Step 5: Create Task
+
+**Option A**: Upload dataset to 0G Storage first (recommended):
+
+```bash
+# Upload dataset
+0g-compute-cli fine-tuning upload --data-path ./dataset.jsonl
+
+# Create task with the returned hash
+0g-compute-cli fine-tuning create-task \
+  --provider <PROVIDER_ADDRESS> \
+  --model "Qwen2.5-0.5B-Instruct" \
+  --dataset <DATASET_ROOT_HASH> \
+  --config-path ./config.json
+```
+
+**Option B**: Upload dataset and create task in one step:
+
+```bash
+0g-compute-cli fine-tuning create-task \
+  --provider <PROVIDER_ADDRESS> \
+  --model "Qwen2.5-0.5B-Instruct" \
+  --dataset-path ./dataset.jsonl \
+  --config-path ./config.json
+```
+
+The CLI will output a **Task ID** — save it for subsequent steps.
+
+> The fee is calculated automatically by the broker based on actual token count.
+
+### Step 6: Monitor Progress
+
+```bash
+0g-compute-cli fine-tuning get-task \
+  --provider <PROVIDER_ADDRESS> \
+  --task <TASK_ID>
+```
+
+Task lifecycle:
+
+```
+Init → SetUp → Training → Delivering → Delivered → Finished
+```
+
+| Status | Description |
+|---|---|
+| `Init` | Task created, broker is downloading dataset |
+| `SetUp` | Dataset processed, environment ready |
+| `Training` | GPU training in progress |
+| `Delivering` | Encrypting and uploading model to 0G Storage |
+| `Delivered` | Model ready for download |
+| `Finished` | Settlement complete |
+
+You can also check training logs:
+
+```bash
+0g-compute-cli fine-tuning get-log \
+  --provider <PROVIDER_ADDRESS> \
+  --task <TASK_ID>
+```
+
+### Step 7: Download and Acknowledge Model
+
+Once status is `Delivered`, download the model and acknowledge on-chain:
+
+```bash
+0g-compute-cli fine-tuning acknowledge-model \
+  --provider <PROVIDER_ADDRESS> \
+  --task-id <TASK_ID> \
+  --data-path ./output \
+  --deploy \
+  --model "Qwen2.5-0.5B-Instruct"
+```
+
+The `--deploy` flag also deploys the LoRA adapter to the inference GPU. The CLI will wait until the adapter is ready.
+
+### Step 8: Decrypt Model (Optional)
+
+If you want to keep a local copy of the LoRA adapter:
+
+```bash
+0g-compute-cli fine-tuning decrypt-model \
+  --provider <PROVIDER_ADDRESS> \
+  --task-id <TASK_ID> \
+  --encrypted-model ./output/model_<TASK_ID>.bin \
+  --output ./decrypted_model.zip
+```
+
+The decrypted ZIP contains:
+- `output_model/adapter_config.json` — PEFT LoRA configuration
+- `output_model/adapter_model.safetensors` — LoRA weights
+- `output_model/tokenizer.json` — Tokenizer
+
+### Step 9: Wait for Settlement
+
+The broker automatically settles the fee. Check status until `Finished`:
+
+```bash
+0g-compute-cli fine-tuning get-task \
+  --provider <PROVIDER_ADDRESS> \
+  --task <TASK_ID>
+```
+
+## Inference
+
+### Chat with Base Model
+
+Start the local proxy and send requests:
+
+```bash
+# Start local inference proxy (foreground)
+0g-compute-cli inference serve \
+  --provider <PROVIDER_ADDRESS> \
+  --port 3000
+```
+
+Then use the OpenAI-compatible API:
+
+```bash
+curl http://localhost:3000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen2.5-0.5B-Instruct",
+    "messages": [
+      {"role": "user", "content": "Hello!"}
+    ],
+    "max_tokens": 100
+  }'
+```
+
+### Chat with Fine-Tuned Model
+
+After deploying a LoRA adapter (Step 7), use the adapter name:
+
+```bash
+0g-compute-cli fine-tuning chat \
+  --provider <PROVIDER_ADDRESS> \
+  --model "Qwen2.5-0.5B-Instruct" \
+  --task-id <TASK_ID> \
+  --message "Write a hello world in Python"
+```
+
+Or use the local proxy with the adapter model name:
+
+```bash
+# Get adapter name
+0g-compute-cli fine-tuning get-adapter-name \
+  --model "Qwen2.5-0.5B-Instruct" \
+  --task-id <TASK_ID>
+
+# Use it in API calls
+curl http://localhost:3000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "ft-Qwen2-5-0-5B-Instruct-<TASK_ID_PREFIX>",
+    "messages": [
+      {"role": "user", "content": "Hello!"}
+    ]
+  }'
+```
+
+### Deploy Adapter Separately
+
+If you didn't use `--deploy` during acknowledge, deploy the adapter later:
+
+```bash
+0g-compute-cli fine-tuning deploy-adapter \
+  --provider <PROVIDER_ADDRESS> \
+  --model "Qwen2.5-0.5B-Instruct" \
+  --task-id <TASK_ID> \
+  --wait
+```
+
+### List Inference Providers
+
+```bash
+0g-compute-cli inference list-providers
+```
+
+For detailed health metrics:
+
+```bash
+0g-compute-cli inference list-providers-detail
+```
+
+### High-Availability Router
+
+For production use with automatic failover across multiple providers:
+
+```bash
+0g-compute-cli inference router-serve \
+  --port 3000
+```
+
+## Account Management
+
+### Check Balance
+
+```bash
+0g-compute-cli get-account
+```
+
+### Retrieve Funds from Sub-Account
+
+```bash
+0g-compute-cli retrieve-fund \
+  --provider <PROVIDER_ADDRESS> \
+  --service fine-tuning \
+  --amount 1
+```
+
+### Refund from Main Account
+
+```bash
+0g-compute-cli refund --amount 1
+```
+
+## Available Models
+
+List all supported models:
+
+```bash
+0g-compute-cli fine-tuning list-models
+```
+
+Common models:
+- `Qwen2.5-0.5B-Instruct`
+- `Qwen2.5-7B-Instruct`
+- `Qwen3-32B`
+
+> Use model names **without** the `Qwen/` prefix.
+
+## API Key Authentication
+
+Generate an API key for programmatic access:
+
+```bash
+0g-compute-cli inference get-secret --provider <PROVIDER_ADDRESS>
+```
+
+Revoke a specific key:
+
+```bash
+0g-compute-cli inference revoke-token \
+  --provider <PROVIDER_ADDRESS> \
+  --token-id <TOKEN_ID>
+```
+
+## Troubleshooting
+
+### "Insufficient balance"
+
+Deposit more funds and transfer to the provider sub-account:
+
+```bash
+0g-compute-cli deposit --amount 5
+0g-compute-cli transfer-fund --provider <ADDR> --service fine-tuning --amount 2
+```
+
+### Task stuck in "Init"
+
+The broker may be downloading the dataset from 0G Storage. Wait a few minutes and check again.
+
+### "User has not acknowledged the provider's TEE signer"
+
+Run the task creation command again — the CLI automatically acknowledges the provider signer. If it persists, explicitly acknowledge:
+
+```bash
+0g-compute-cli inference acknowledge-provider --provider <PROVIDER_ADDRESS>
+```
+
+### Model download fails
+
+By default, the CLI tries 0G Storage first, then falls back to TEE direct download. You can force a specific method:
+
+```bash
+0g-compute-cli fine-tuning acknowledge-model \
+  --provider <ADDR> \
+  --task-id <ID> \
+  --data-path ./output \
+  --download-method tee
+```

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -16,10 +16,10 @@ This guide covers how to fine-tune models, deploy LoRA adapters, and run inferen
 ### 1. Login
 
 ```bash
-0g-compute-cli login --private-key <YOUR_PRIVATE_KEY>
+0g-compute-cli login
 ```
 
-Verify your login status:
+The CLI will interactively prompt for your private key. Verify your login status:
 
 ```bash
 0g-compute-cli status
@@ -104,6 +104,7 @@ Create a JSON file with training hyperparameters:
 
 ```json
 {
+  "neftune_noise_alpha": 5,
   "num_train_epochs": 1,
   "per_device_train_batch_size": 2,
   "learning_rate": 0.0002,
@@ -119,7 +120,7 @@ Common parameters:
 | `per_device_train_batch_size` | Batch size per device | 2 |
 | `learning_rate` | Learning rate | 0.0002 |
 | `max_steps` | Max training steps (overrides epochs if set) | - |
-| `neftune_noise_alpha` | NEFTune noise for regularization | - |
+| `neftune_noise_alpha` | NEFTune noise for regularization (required) | 5 |
 
 > **Note**: Use decimal notation for learning_rate (e.g., `0.0002`), not scientific notation (`2e-4`).
 
@@ -327,12 +328,15 @@ For production use with automatic failover across multiple providers:
 
 ### Retrieve Funds from Sub-Account
 
+Request to return all funds from a provider sub-account back to your main account:
+
 ```bash
 0g-compute-cli retrieve-fund \
   --provider <PROVIDER_ADDRESS> \
-  --service fine-tuning \
-  --amount 1
+  --service fine-tuning
 ```
+
+> **Note**: This requests the return of all funds in the sub-account. There is a lock period before the funds become available in the main account. Use `get-sub-account` to check the remaining lock time.
 
 ### Refund from Main Account
 


### PR DESCRIPTION
## Summary

Resolves three related LoRA-pipeline issues filed against the inference broker:

- **#468** — broker now advertises whether it serves fine-tune-derived (LoRA) adapters. Off-chain routers / aggregators can discover this without an authenticated probe.
- **#470** — adds quota and admission control to the LoRA registration pipeline plus a capacity-based LRU eviction loop. Closes the "user spams ack events to drain disk + bandwidth" abuse vector.
- **#469** — provides a TEE-deployable compose example (`integration/provider-lora/`) and bakes `sllm-wrapper.py` into a publishable image (`integration/sllm-wrapper/`) so dstack/Phala deployments do not need any host bind-mounts beyond the broker config.

Three independent commits, one per issue, each compiles + vets + tests on its own.

## What changes

### #468 — capability advertising

| Surface | Field |
|---|---|
| on-chain `additionalInfo` | `LoRAEnabled`, `LoRABaseModel`, `LoRAAdapterPrefix` (only emitted when `lora.Enable && lora.AutoDeploy`, additive) |
| `GET /v1/models` | `supports_fine_tuned_adapters`, `fine_tuned_adapter_prefix` |
| `GET /v1/capabilities` | new public/unauthenticated endpoint, returns `{base_model, fine_tuning: {supports_fine_tuned_adapters, base_model, adapter_prefix}}` |

### #470 — quota & admission control

`config.LoRAQuotaConfig` (defaults shown, `-1` to disable a check):

| Field | Default | What it stops |
|---|---|---|
| `maxAdaptersPerUser` | 5 | One user spamming many ack events |
| `maxAdaptersTotal` | 100 | Broker-wide adapter count overflow |
| `maxConcurrentDownloads` | 3 | Burst of acks → unbounded download goroutines |
| `maxAdapterDiskBytes` | 100 GiB | Disk exhaustion |
| `capacityCheckIntervalMinutes` | 5 | LRU eviction tick |
| `blockedUsers` | `[]` | Operator kill-switch |

Pipeline changes:

- `Manager.admissionCheck()` runs **before** any DB write so a rejected event consumes neither disk nor a row. Returns a stable `AdmissionError` code (`user_blocked` / `per_user_quota_exceeded` / `total_quota_exceeded` / `disk_quota_exceeded`).
- `downloadSemaphore` caps concurrent 0G Storage downloads.
- New `capacityEvictionLoop` archives oldest adapters (LRU) when over count or disk cap. Files are removed; row stays as `archived` so a future re-acknowledge re-downloads.
- `archiveAdapter` / `EvictAdapter(purge)` for both background and operator-driven eviction.
- DB: `CountAdaptersByUser` / `CountTotalAdapters` / `ListLRUEvictionCandidates`.
- Event watcher no longer retries admission rejections (cursor advances past them).
- New `POST /v1/lora/admin/evict`, gated by `ValidateProviderAuth` (provider key signature, not user session). `purge=true` to also delete the DB row.

### #469 — TEE-deployable example

`api/inference/integration/sllm-wrapper/`
- `sllm-wrapper.py` (stdlib-only SLLM→vLLM shim) imported into the repo.
- `Dockerfile` for `ghcr.io/0gfoundation/0g-sllm-wrapper`.
- README with build / publish / configuration.

`api/inference/integration/provider-lora/`
- TEE-friendly `docker-compose.yml`: only `config.yaml` is host-mounted; vLLM auto-downloads the base model into a named `hf-cache` volume; sllm-wrapper uses the published image; nginx is dropped.
- `config.example.yaml` with `lora.quota.*` and capability flags from #468.
- README walks through topology, first-run notes (HF download time, GPU memory, named volumes), capability discovery (`/v1/capabilities`), quota tuning, and operator kill-switch usage.

## Test plan

- [x] `go build ./...` clean across the whole `api/` module.
- [x] `go vet ./inference/...` clean.
- [x] `go test ./inference/internal/lora/... ./inference/internal/handler/... ./inference/config/... ./inference/internal/ctrl/...` all pass.
- [x] Each commit compiles standalone (verified by stash + build between commits).
- [ ] Reviewer to deploy `provider-lora/` example to a Phala/dstack CVM and verify:
  - [ ] vLLM HF download completes on first start
  - [ ] sllm-wrapper baked image responds to `/health`
  - [ ] `curl /v1/capabilities` returns `supports_fine_tuned_adapters: true`
  - [ ] On-chain `additionalInfo` after first sync contains `"LoRAEnabled":true`
  - [ ] Trigger >5 fine-tune acks for a single user → 6th rejected with `per_user_quota_exceeded` in logs
  - [ ] `POST /v1/lora/admin/evict` (signed by provider key) archives an adapter

## Backward compatibility

- Additive only. `additionalInfo` keys are emitted *only* when `lora.Enable && lora.AutoDeploy`, so existing brokers that do not enable LoRA serving keep their current JSON byte-for-byte.
- Quota defaults take effect on upgrade. Operators that want the old "no limits" behaviour can set the relevant fields to `-1`.
- New endpoints (`/v1/capabilities`, `/v1/lora/admin/evict`) do not collide with existing routes.

## Note on base branch

This branch was cut from `docs/user-and-provider-guide` to keep the existing fix commits (`gas price floor`, `adapter key upsert`) in scope while testing locally. If those commits are merged separately first, this PR can be rebased onto `main` cleanly — only the three feature commits at the top of the branch are net-new.