### PR TITLE
fix(inference): collapse redundant /v1 prefix in proxy path

### DIFF
--- a/api/inference/internal/proxy/proxy.go
+++ b/api/inference/internal/proxy/proxy.go
@@ -211,6 +211,21 @@ func (p *Proxy) proxyHTTPRequest(ctx *gin.Context) {
 	p.serviceRoutesLock.RUnlock()
 
 	targetRoute := strings.TrimPrefix(ctx.Request.RequestURI, constant.ServicePrefix)
+	// Collapse a redundant "/v1" prefix so callers that hardcode it after the
+	// broker base URL (Anthropic SDK → /v1/messages, OpenAI SDK → /v1/chat/completions)
+	// land on the same upstream path as bare /messages or /chat/completions.
+	// Service.targetUrl is expected to carry the /v1 segment for OpenAI-compatible
+	// upstreams (vLLM, OpenAI, OpenRouter, DashScope, RedPill, …); LiteLLM also
+	// aliases both prefix variants, so this normalization is safe across all
+	// existing deployments. Billing keys (TargetRoute) are matched against the
+	// post-strip path, which is why /chat/completions and /messages — without
+	// /v1 — are the canonical entries in const.go.
+	if targetRoute == "/v1" || strings.HasPrefix(targetRoute, "/v1/") {
+		targetRoute = strings.TrimPrefix(targetRoute, "/v1")
+		if targetRoute == "" {
+			targetRoute = "/"
+		}
+	}
 	if targetRoute != "/" {
 		targetURL += targetRoute
 	}


### PR DESCRIPTION
Broker proxyHTTPRequest concatenates the post-/v1/proxy path onto the configured targetUrl. SDKs that hardcode /v1 after the broker base URL (Anthropic /v1/messages, OpenAI /v1/chat/completions) end up doubling the prefix when the upstream targetUrl already carries /v1, producing e.g. http://vllm:8000/v1/v1/messages and 404s.

Strip a leading /v1 segment from the post-prefix path so callers reach the same upstream regardless of whether they include /v1. This makes both /v1/proxy/messages and /v1/proxy/v1/messages route to the same upstream /v1/messages, matching how const.go TargetRoute already treats both as billable. Use HasPrefix("/v1/") (with trailing slash) to avoid clipping unrelated paths like /v1foo, and handle the bare "/v1" case explicitly.

Safe across existing deployments: LiteLLM aliases both prefix variants; OpenAI/OpenRouter/DashScope/RedPill all expose endpoints under /v1.