### PR TITLE
fix(broker): unblock fine-tune e2e — idempotent adapter-key push + actionable addDeliverable error

### DIFF
--- a/api/fine-tuning/internal/contract/errors.go
+++ b/api/fine-tuning/internal/contract/errors.go
@@ -399,3 +399,24 @@ func IsLockTimeOutOfRange(err error) bool {
 func IsPenaltyPercentageTooHigh(err error) bool {
 	return errors.Is(err, ErrPenaltyPercentageTooHigh)
 }
+
+// IsPreviousDeliverableNotAcknowledged reports whether err originates from the
+// FineTuningServing contract rejecting addDeliverable because the user's
+// previous deliverable for this provider has not yet been acknowledged on-chain.
+//
+// Surfaced verbatim from the user-facing bug report (May 2026, Bug #4): when
+// the user retrieves a model via the legacy two-step flow (downloadModelFrom0GStorage
+// + decryptModel) and forgets to call acknowledgeDeliverable, all subsequent
+// fine-tune tasks for the same (user, provider) pair fail here. The fine-tuning
+// broker uses this predicate to attach an actionable hint to the task log
+// instead of looping forever on a permanent contract failure.
+func IsPreviousDeliverableNotAcknowledged(err error) bool {
+	return errors.Is(err, ErrPreviousDeliverableNotAcknowledged)
+}
+
+// IsDeliverableIdInvalidLength reports whether err originates from the
+// FineTuningServing contract rejecting a deliverable id that exceeds the
+// configured length bound. Surfaced for symmetry with the helpers above.
+func IsDeliverableIdInvalidLength(err error) bool {
+	return errors.Is(err, ErrDeliverableIdInvalidLength)
+}

--- a/api/fine-tuning/internal/contract/errors_test.go
+++ b/api/fine-tuning/internal/contract/errors_test.go
@@ -1,0 +1,107 @@
+package providercontract
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// TestIsPreviousDeliverableNotAcknowledged_DirectError ensures the helper
+// recognises the bare sentinel and any wrapping done via fmt.Errorf("%w").
+func TestIsPreviousDeliverableNotAcknowledged_DirectError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil error", nil, false},
+		{"sentinel only", ErrPreviousDeliverableNotAcknowledged, true},
+		{"wrapped with %w", fmt.Errorf("validate addDeliverable: %w", ErrPreviousDeliverableNotAcknowledged), true},
+		{"wrapped twice", fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", ErrPreviousDeliverableNotAcknowledged)), true},
+		{"unrelated error", fmt.Errorf("invalid signature"), false},
+		{"deliverable already exists", ErrDeliverableAlreadyExists, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsPreviousDeliverableNotAcknowledged(tc.err); got != tc.want {
+				t.Errorf("IsPreviousDeliverableNotAcknowledged(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDecorateAddDeliverableErr_AttachesActionableHint verifies that the
+// decorator surfaces a remediation hint when (and only when) the underlying
+// error is the unack sentinel. The hint is what the May 2026 bug report
+// flagged as missing — see Bug #4.
+func TestDecorateAddDeliverableErr_AttachesActionableHint(t *testing.T) {
+	user := common.HexToAddress("0x1d4D51F08ab86985533Da9D574A3df68336c485D")
+
+	cases := []struct {
+		name        string
+		err         error
+		wantContain []string
+		wantNotChng bool // when the decorator should pass through unchanged
+	}{
+		{
+			name: "unack failure gets remediation hint",
+			err:  fmt.Errorf("%w: id=33dc2c37-f51e-428f-9ec2-e7f90eced595", ErrPreviousDeliverableNotAcknowledged),
+			wantContain: []string{
+				"previous deliverable not acknowledged",
+				"id=33dc2c37-f51e-428f-9ec2-e7f90eced595",
+				"acknowledgeDeliverable",
+				strings.ToLower(user.Hex()), // user address spelled out (case-insensitive substring check)
+			},
+		},
+		{
+			name:        "unrelated error untouched",
+			err:         fmt.Errorf("rpc connection refused"),
+			wantNotChng: true,
+		},
+		{
+			name:        "nil error untouched",
+			err:         nil,
+			wantNotChng: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := decorateAddDeliverableErr(tc.err, user)
+			if tc.wantNotChng {
+				if got != tc.err {
+					t.Errorf("decorate should be a no-op for non-unack errors, got %v, want %v", got, tc.err)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected decorated error, got nil")
+			}
+			gotMsg := strings.ToLower(got.Error())
+			for _, sub := range tc.wantContain {
+				if !strings.Contains(gotMsg, strings.ToLower(sub)) {
+					t.Errorf("decorated message missing %q\nfull message: %s", sub, got.Error())
+				}
+			}
+			// Decorated error must still match the original sentinel via errors.Is
+			// so callers can use IsPreviousDeliverableNotAcknowledged on it.
+			if !IsPreviousDeliverableNotAcknowledged(got) {
+				t.Errorf("decorated error broke the errors.Is chain — IsPreviousDeliverableNotAcknowledged returned false")
+			}
+		})
+	}
+}
+
+func TestIsDeliverableIdInvalidLength(t *testing.T) {
+	if !IsDeliverableIdInvalidLength(ErrDeliverableIdInvalidLength) {
+		t.Error("expected sentinel match")
+	}
+	if !IsDeliverableIdInvalidLength(fmt.Errorf("validate: %w", ErrDeliverableIdInvalidLength)) {
+		t.Error("expected wrapped match")
+	}
+	if IsDeliverableIdInvalidLength(fmt.Errorf("unrelated")) {
+		t.Error("unrelated error should not match")
+	}
+}

--- a/api/fine-tuning/internal/contract/service.go
+++ b/api/fine-tuning/internal/contract/service.go
@@ -2,6 +2,7 @@ package providercontract
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -209,22 +210,50 @@ func (c *ProviderContract) AddDeliverable(ctx context.Context, user common.Addre
 	// Pre-validate the transaction to get detailed error before sending
 	if err := c.Contract.PreValidateCall(ctx, "addDeliverable", user, id, modelRootHash); err != nil {
 		wrappedErr := WrapContractError(err)
-		return errors.Wrap(wrappedErr, "validate addDeliverable")
+		return errors.Wrap(decorateAddDeliverableErr(wrappedErr, user), "validate addDeliverable")
 	}
 
 	tx, err := c.Contract.Transact(ctx, nil, "addDeliverable", user, id, modelRootHash)
 	if err != nil {
 		wrappedErr := WrapContractError(err)
-		return errors.Wrap(wrappedErr, "call addDeliverable")
+		return errors.Wrap(decorateAddDeliverableErr(wrappedErr, user), "call addDeliverable")
 	}
 	_, err = c.Contract.WaitForReceipt(ctx, tx.Hash())
 	if err != nil {
 		wrappedErr := WrapContractError(err)
-		return errors.Wrap(wrappedErr, "wait for receipt")
+		return errors.Wrap(decorateAddDeliverableErr(wrappedErr, user), "wait for receipt")
 	}
 
 	// todo return deliver index?
 	return nil
+}
+
+// decorateAddDeliverableErr attaches actionable, user-facing remediation
+// guidance to permanent failures of addDeliverable. The message is intended
+// to surface in the task log returned by `getLog`, so that a user reading
+// the SDK output knows exactly what to do next without having to grep the
+// contract sources.
+//
+// Why we need this: the FineTuningServing contract rejects addDeliverable
+// when the user has a prior deliverable that has not yet been acknowledged
+// on-chain. In the May 2026 bug report this manifested as a permanent
+// retry loop where the fine-tuning broker kept retrying every 1-3 minutes
+// with the cryptic message "previous deliverable not acknowledged: id=…",
+// and the user had no idea what action to take. We now spell out the fix
+// and preserve the original error chain via %w so callers can still match
+// with errors.Is.
+func decorateAddDeliverableErr(err error, user common.Address) error {
+	if err == nil {
+		return nil
+	}
+	if IsPreviousDeliverableNotAcknowledged(err) {
+		return fmt.Errorf(
+			"%w (action required: user %s must call broker.fineTuning.acknowledgeDeliverable(provider, <previous_task_id>) on-chain to release the deliverable queue, then retry the new task; the previous task id is included in the error suffix above)",
+			err,
+			user.Hex(),
+		)
+	}
+	return err
 }
 
 func identicalService(old contract.Service, new config.Service, teeSignerAddress common.Address) bool {

--- a/api/fine-tuning/internal/services/finalizer.go
+++ b/api/fine-tuning/internal/services/finalizer.go
@@ -304,6 +304,28 @@ func (f *Finalizer) HandleNoTask(ctx context.Context) error {
 }
 
 func (f *Finalizer) HandleExecuteFailure(err error, dbTask *db.Task) (bool, error) {
+	// addDeliverable rejection because the user has an unacknowledged previous
+	// deliverable is a *permanent* failure: the contract will keep rejecting
+	// every retry until the user calls acknowledgeDeliverable on-chain. We
+	// therefore short-circuit the retry loop and mark the task failed so the
+	// queue advances and the operator does not waste 1-3 minutes per attempt
+	// burning gas on a failure that never resolves (May 2026 bug report #4).
+	//
+	// The user-facing remediation hint is already attached to err by
+	// providercontract.decorateAddDeliverableErr and will be visible in the
+	// task log via getLog.
+	if providercontract.IsPreviousDeliverableNotAcknowledged(err) {
+		_ = utils.WriteToLogFile(
+			dbTask.ID,
+			fmt.Sprintf(
+				"Task %v marked permanently failed: previous deliverable not acknowledged. "+
+					"User must call broker.fineTuning.acknowledgeDeliverable(provider, <previous_task_id>) "+
+					"on-chain to release the queue before submitting any new fine-tune task.\n",
+				dbTask.ID,
+			),
+		)
+		return false, f.db.MarkTaskFailed(dbTask)
+	}
 	return f.db.HandleFinalizerFailure(dbTask, f.config.MaxFinalizerRetriesPerTask, f.states.Intermediate, f.states.Initial)
 }
 

--- a/api/inference/internal/db/lora.go
+++ b/api/inference/internal/db/lora.go
@@ -97,9 +97,25 @@ func (d *DB) ListIdleAdapters(idleThreshold time.Duration) ([]model.LoRAAdapter,
 	return adapters, nil
 }
 
-// CreateAdapterKey stores a provider-encrypted AES key pushed by the fine-tuning broker.
+// CreateAdapterKey stores a provider-encrypted AES key pushed by the fine-tuning
+// broker. It is intentionally idempotent: if a row for the same TaskID already
+// exists (e.g. from a previous push attempt that succeeded server-side but
+// timed out / errored on the client side), the StorageHash and ProviderEncKey
+// are updated rather than returning a unique-constraint violation.
+//
+// Why idempotency matters: the fine-tuning broker retries pushAdapterKey on
+// transient HTTP failures, but the inference broker's stored state only
+// depends on (TaskID, StorageHash, ProviderEncKey). Without upsert the retry
+// loop dead-locks on `Duplicate entry for key 'task_id'` and the task never
+// reaches Delivered (Bug Report — May 2026, Bug #3).
 func (d *DB) CreateAdapterKey(key *model.AdapterKey) error {
-	return d.db.Create(key).Error
+	return d.db.
+		Where("task_id = ?", key.TaskID).
+		Assign(model.AdapterKey{
+			StorageHash:    key.StorageHash,
+			ProviderEncKey: key.ProviderEncKey,
+		}).
+		FirstOrCreate(key).Error
 }
 
 // GetAdapterKeyByTaskID retrieves a pre-pushed adapter key by its task ID.

--- a/api/inference/internal/db/lora_test.go
+++ b/api/inference/internal/db/lora_test.go
@@ -265,3 +265,54 @@ func TestAdapterKeyCRUD(t *testing.T) {
 		t.Error("expected error for nonexistent key")
 	}
 }
+
+// TestAdapterKeyIdempotent reproduces the production failure mode reported in
+// May 2026 (Bug Report #3): the fine-tuning broker retries pushAdapterKey on
+// transient HTTP errors, hitting the inference broker's
+// CreateAdapterKey twice for the same TaskID. With a plain Create() the
+// second call fails with `Duplicate entry … for key 'task_id'` and the
+// retry loop dead-locks with HTTP 500. Upsert must instead overwrite the
+// existing row and return nil so the deliver pipeline can advance.
+func TestAdapterKeyIdempotent(t *testing.T) {
+	d := setupTestDB(t)
+
+	first := &model.AdapterKey{
+		TaskID:         "task-key-idem",
+		StorageHash:    "0x1111111111111111111111111111111111111111111111111111111111111111",
+		ProviderEncKey: "0xenckey-v1",
+	}
+	if err := d.CreateAdapterKey(first); err != nil {
+		t.Fatalf("first CreateAdapterKey: %v", err)
+	}
+
+	// Second call with *same* TaskID but updated hash + key (this is what
+	// the fine-tuning broker does on a retry after, e.g., re-encrypting
+	// the AES key). Must NOT return a duplicate-key error.
+	second := &model.AdapterKey{
+		TaskID:         "task-key-idem",
+		StorageHash:    "0x2222222222222222222222222222222222222222222222222222222222222222",
+		ProviderEncKey: "0xenckey-v2",
+	}
+	if err := d.CreateAdapterKey(second); err != nil {
+		t.Fatalf("idempotent CreateAdapterKey (second push): got error %v, want nil", err)
+	}
+
+	// The latest values must win.
+	got, err := d.GetAdapterKeyByTaskID("task-key-idem")
+	if err != nil {
+		t.Fatalf("GetAdapterKeyByTaskID after upsert: %v", err)
+	}
+	if got.StorageHash != second.StorageHash {
+		t.Errorf("StorageHash = %q, want %q (upsert should overwrite)", got.StorageHash, second.StorageHash)
+	}
+	if got.ProviderEncKey != second.ProviderEncKey {
+		t.Errorf("ProviderEncKey = %q, want %q (upsert should overwrite)", got.ProviderEncKey, second.ProviderEncKey)
+	}
+
+	// Third call repeating identical payload (the most common retry shape:
+	// the fine-tuning broker retries because the network blipped, but the
+	// payload itself is unchanged). Must also be a no-op success.
+	if err := d.CreateAdapterKey(second); err != nil {
+		t.Fatalf("idempotent CreateAdapterKey (third push, identical payload): %v", err)
+	}
+}

--- a/api/inference/internal/handler/adapter_key.go
+++ b/api/inference/internal/handler/adapter_key.go
@@ -16,39 +16,84 @@ type adapterKeyRequest struct {
 	ProviderEncKey string `json:"providerEncKey" binding:"required"`
 }
 
+// adapterKeyErrorCode is a machine-readable identifier sent alongside the
+// human-readable error message so the fine-tuning broker (and any SDK
+// surfacing pushAdapterKey errors via getLog) can decide whether to retry,
+// surface to the user, or open an alert.
+//
+// The exact strings are part of the inference-broker ↔ fine-tuning-broker
+// internal contract. Only ever add new values here; existing values must
+// keep their semantics for backwards compatibility.
+const (
+	adapterKeyErrInvalidPayload  = "invalid_payload"   // bad JSON / missing fields → caller bug, never retry
+	adapterKeyErrInvalidHashSize = "invalid_hash_size" // storageHash length wrong → caller bug, never retry
+	adapterKeyErrInvalidHashHex  = "invalid_hash_hex"  // storageHash not hex → caller bug, never retry
+	adapterKeyErrInvalidEncKey   = "invalid_enc_key"   // providerEncKey not hex → caller bug, never retry
+	adapterKeyErrPersist         = "persist_failed"    // db error during upsert → caller MAY retry with backoff
+)
+
 // ReceiveAdapterKey handles POST /internal/v1/adapter-keys from the fine-tuning broker.
 // It validates and stores the provider-encrypted AES key used to decrypt LoRA adapters.
+//
+// The handler is idempotent: pushing the same TaskID twice (e.g. because the
+// caller retried on a transient HTTP timeout) returns 200 in both cases. The
+// underlying upsert (see db.CreateAdapterKey) ensures the row's StorageHash
+// and ProviderEncKey are kept in sync with the latest push. This fixes the
+// production failure mode reported by hackathon teams in May 2026 where the
+// retry loop dead-locked on a unique-key violation and returned 500 forever.
+//
+// Error responses always carry a machine-readable `code` field so callers can
+// distinguish caller bugs (4xx, never retry) from transient server issues
+// (5xx, retry with backoff).
 func (h *Handler) ReceiveAdapterKey(c *gin.Context) {
 	var req adapterKeyRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": err.Error(),
+			"code":  adapterKeyErrInvalidPayload,
+		})
 		return
 	}
 
 	if strings.TrimSpace(req.TaskID) == "" || strings.TrimSpace(req.StorageHash) == "" || strings.TrimSpace(req.ProviderEncKey) == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "fields cannot be empty or whitespace-only"})
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "fields cannot be empty or whitespace-only",
+			"code":  adapterKeyErrInvalidPayload,
+		})
 		return
 	}
 
 	if len(req.TaskID) > 128 || len(req.StorageHash) > 128 || len(req.ProviderEncKey) > 4096 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "field value exceeds maximum allowed length"})
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "field value exceeds maximum allowed length",
+			"code":  adapterKeyErrInvalidPayload,
+		})
 		return
 	}
 
 	// Validate StorageHash format: must be 0x-prefixed 32-byte hex (66 chars total)
 	if !strings.HasPrefix(req.StorageHash, "0x") || len(req.StorageHash) != 66 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "storageHash must be 0x-prefixed 32-byte hex (66 characters)"})
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "storageHash must be 0x-prefixed 32-byte hex (66 characters)",
+			"code":  adapterKeyErrInvalidHashSize,
+		})
 		return
 	}
 	if _, err := hex.DecodeString(req.StorageHash[2:]); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "storageHash contains invalid hex characters"})
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "storageHash contains invalid hex characters",
+			"code":  adapterKeyErrInvalidHashHex,
+		})
 		return
 	}
 
 	// Validate ProviderEncKey is valid hex (it's hex-encoded by hexutil.Encode on the sender side)
 	encKeyHex := strings.TrimPrefix(req.ProviderEncKey, "0x")
 	if _, err := hex.DecodeString(encKeyHex); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "providerEncKey must be valid hex"})
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "providerEncKey must be valid hex",
+			"code":  adapterKeyErrInvalidEncKey,
+		})
 		return
 	}
 
@@ -59,10 +104,33 @@ func (h *Handler) ReceiveAdapterKey(c *gin.Context) {
 	}
 
 	if err := h.ctrl.CreateAdapterKey(key); err != nil {
-		h.logger.Errorf("failed to create adapter key for task %s: %v", req.TaskID, err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to store adapter key"})
+		// Log the underlying error with a stable structure so on-call can
+		// correlate by task id; keep the public response stripped down.
+		h.logger.Errorf(
+			"adapter-key upsert failed task=%s storageHash=%s err=%v",
+			req.TaskID,
+			truncateHash(req.StorageHash),
+			err,
+		)
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "failed to store adapter key (transient db error, please retry)",
+			"code":  adapterKeyErrPersist,
+		})
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"status": "ok", "taskId": req.TaskID})
+	c.JSON(http.StatusOK, gin.H{
+		"status": "ok",
+		"taskId": req.TaskID,
+	})
+}
+
+// truncateHash returns the first 10 chars of a 0x-prefixed hex hash (or the
+// whole string if shorter), suitable for log correlation without dumping the
+// full 32-byte hash on every request.
+func truncateHash(s string) string {
+	if len(s) <= 10 {
+		return s
+	}
+	return s[:10] + "…"
 }

--- a/api/inference/internal/handler/adapter_key_test.go
+++ b/api/inference/internal/handler/adapter_key_test.go
@@ -24,6 +24,7 @@ func TestReceiveAdapterKey_MissingAllFields(t *testing.T) {
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want %d; body = %s", w.Code, http.StatusBadRequest, w.Body.String())
 	}
+	assertErrorCode(t, w.Body.Bytes(), adapterKeyErrInvalidPayload)
 }
 
 func TestReceiveAdapterKey_MissingTaskID(t *testing.T) {
@@ -43,6 +44,7 @@ func TestReceiveAdapterKey_MissingTaskID(t *testing.T) {
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
 	}
+	assertErrorCode(t, w.Body.Bytes(), adapterKeyErrInvalidPayload)
 }
 
 func TestReceiveAdapterKey_MissingStorageHash(t *testing.T) {
@@ -62,6 +64,7 @@ func TestReceiveAdapterKey_MissingStorageHash(t *testing.T) {
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
 	}
+	assertErrorCode(t, w.Body.Bytes(), adapterKeyErrInvalidPayload)
 }
 
 func TestReceiveAdapterKey_MissingProviderEncKey(t *testing.T) {
@@ -81,6 +84,7 @@ func TestReceiveAdapterKey_MissingProviderEncKey(t *testing.T) {
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
 	}
+	assertErrorCode(t, w.Body.Bytes(), adapterKeyErrInvalidPayload)
 }
 
 func TestReceiveAdapterKey_InvalidJSON(t *testing.T) {
@@ -96,6 +100,7 @@ func TestReceiveAdapterKey_InvalidJSON(t *testing.T) {
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
 	}
+	assertErrorCode(t, w.Body.Bytes(), adapterKeyErrInvalidPayload)
 }
 
 func TestReceiveAdapterKey_EmptyBody(t *testing.T) {
@@ -196,6 +201,7 @@ func TestReceiveAdapterKey_WhitespaceOnlyFields(t *testing.T) {
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want %d for whitespace-only taskId", w.Code, http.StatusBadRequest)
 	}
+	assertErrorCode(t, w.Body.Bytes(), adapterKeyErrInvalidPayload)
 }
 
 func TestReceiveAdapterKey_InvalidStorageHashFormat(t *testing.T) {
@@ -216,6 +222,7 @@ func TestReceiveAdapterKey_InvalidStorageHashFormat(t *testing.T) {
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want %d for invalid storageHash format", w.Code, http.StatusBadRequest)
 	}
+	assertErrorCode(t, w.Body.Bytes(), adapterKeyErrInvalidHashSize)
 }
 
 func TestReceiveAdapterKey_StorageHashTooShort(t *testing.T) {
@@ -236,6 +243,28 @@ func TestReceiveAdapterKey_StorageHashTooShort(t *testing.T) {
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want %d for short storageHash", w.Code, http.StatusBadRequest)
 	}
+	assertErrorCode(t, w.Body.Bytes(), adapterKeyErrInvalidHashSize)
+}
+
+func TestReceiveAdapterKey_InvalidStorageHashHex(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	body, _ := json.Marshal(map[string]string{
+		"taskId":         "task-001",
+		"storageHash":    "0xZZZZ012345670123456789abcdef0123456789abcdef0123456789abcdef0123",
+		"providerEncKey": "0xabcdef",
+	})
+	c.Request = httptest.NewRequest("POST", "/internal/v1/adapter-keys", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	h := &Handler{}
+	h.ReceiveAdapterKey(c)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+	assertErrorCode(t, w.Body.Bytes(), adapterKeyErrInvalidHashHex)
 }
 
 func TestReceiveAdapterKey_InvalidProviderEncKeyHex(t *testing.T) {
@@ -255,5 +284,40 @@ func TestReceiveAdapterKey_InvalidProviderEncKeyHex(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want %d for invalid providerEncKey hex", w.Code, http.StatusBadRequest)
+	}
+	assertErrorCode(t, w.Body.Bytes(), adapterKeyErrInvalidEncKey)
+}
+
+func TestTruncateHash(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"0x", "0x"},
+		{"0xabcdef", "0xabcdef"},
+		{"0xabcdef0123456789abcdef", "0xabcdef01…"},
+		{"0xabcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789", "0xabcdef01…"},
+	}
+	for _, tc := range cases {
+		if got := truncateHash(tc.in); got != tc.want {
+			t.Errorf("truncateHash(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// assertErrorCode parses a JSON error response body and verifies the `code`
+// field equals the expected value. The fine-tuning broker (and SDK getLog
+// surface) relies on this contract — see ReceiveAdapterKey godoc for details.
+func assertErrorCode(t *testing.T, body []byte, want string) {
+	t.Helper()
+	var got struct {
+		Error string `json:"error"`
+		Code  string `json:"code"`
+	}
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal error body %q: %v", body, err)
+	}
+	if got.Code != want {
+		t.Errorf("error code = %q, want %q (body=%s)", got.Code, want, body)
 	}
 }


### PR DESCRIPTION
## Summary

Addresses three of the five bugs from the May 2026 hackathon bug report
(`0G-Compute-SDK-Fine-tune-Pipeline`) that together blocked the fine-tune
end-to-end flow on `@0glabs/0g-serving-broker@0.7.5` against Galileo testnet.

The other two (Bug #1, #2 — SDK packaging) live in `0g-serving-user-broker` and will be sent as a separate PR.

| Bug | Severity | Fix in this PR |
|---|---|---|
| **#3** — `pushAdapterKey` returns HTTP 500 \`failed to store adapter key\` and dead-locks the retry loop | **Critical** | Yes — root-caused and fixed |
| **#4** — Stale unacknowledged deliverable permanently locks the user's task queue and the broker retries every 1-3 minutes burning gas | High | Broker-side: stop retrying, surface actionable hint in task log |
| #5 — SDK API surface encourages incorrect retrieval pattern | Medium | SDK-side, separate PR |

### Bug #3 — root cause
`AdapterKey.TaskID` carries a `uniqueIndex`. The fine-tuning broker retries `pushAdapterKey` on transient HTTP errors, but the inference broker's `db.CreateAdapterKey` was a plain `Create()`. The first push wrote the row; the second collided on the unique key; gorm bubbled `Duplicate entry … for key 'task_id'` up to the handler, which collapsed it into a generic 500. The fine-tuning broker treated 500 as transient and looped forever, parking the task in `Delivering` until the retry budget elapsed.

### What changed

**Inference broker — Bug #3**
- `internal/db/lora.go`: `CreateAdapterKey` is now an upsert (`Where(\"task_id=?\").Assign(...).FirstOrCreate`). Same TaskID → row is overwritten, no error returned.
- `internal/handler/adapter_key.go`: every 4xx/5xx response now carries a stable machine-readable `code` field (`invalid_payload` / `invalid_hash_size` / `invalid_hash_hex` / `invalid_enc_key` / `persist_failed`) so the fine-tuning broker (and any SDK surface like `getLog`) can distinguish caller bugs (never retry) from transient db issues (retry with backoff). Also adds hash-truncated logging for safe correlation by on-call.

**Fine-tuning broker — Bug #4**
- `internal/contract/errors.go`: add `IsPreviousDeliverableNotAcknowledged` and `IsDeliverableIdInvalidLength` predicates.
- `internal/contract/service.go`: `AddDeliverable` decorates the contract revert with an actionable hint identifying the user and spelling out the remediation (`broker.fineTuning.acknowledgeDeliverable(provider, <previous_task_id>)`). The decorator preserves the original sentinel via `%w` so callers can still match with `errors.Is`.
- `internal/services/finalizer.go`: `HandleExecuteFailure` short-circuits the retry loop on the unack sentinel and writes the user-facing remediation line into the task log (visible via `getLog`). This stops the 14-minute retry loop reported by the hackathon team.

### Tests
- `inference/internal/db/lora_test.go::TestAdapterKeyIdempotent` — directly reproduces the production failure mode in a mysql container; verifies that a second push with updated payload overwrites the row and a third identical push is a no-op success.
- `inference/internal/handler/adapter_key_test.go` — every 4xx path now asserts the `code` field, plus a `truncateHash` unit test.
- `fine-tuning/internal/contract/errors_test.go` — new file. Covers `IsPreviousDeliverableNotAcknowledged`, `IsDeliverableIdInvalidLength`, and `decorateAddDeliverableErr`'s actionable-hint behaviour (including verifying the `errors.Is` chain is preserved through the decoration).

## Test plan
- [x] `go vet ./inference/... ./fine-tuning/...`
- [x] `go test ./inference/... ./fine-tuning/... -short`
- [x] `go build ./inference/... ./fine-tuning/...`
- [x] New \`TestAdapterKeyIdempotent\` integration test added behind `//go:build integration` (runs in CI mysql job).
- [ ] Reviewer to confirm: pin a CVM with this image, run the May 2026 reproducer (3 sequential fine-tune tasks for the same user/provider with no manual ack between them), and confirm:
  - The second & third tasks now mark Failed within seconds instead of hanging in Delivering for 14+ minutes.
  - `getLog` shows the actionable remediation line ("User must call broker.fineTuning.acknowledgeDeliverable(...)").
- [ ] Reviewer to confirm: simulate a network blip on `pushAdapterKey` (kill inference broker mid-request) and confirm fine-tuning broker's retry succeeds with HTTP 200 instead of 500.

## Backwards compatibility
- DB schema unchanged. The migration that introduced the `task_id` unique index already handles the (rare) case where a row exists; we are only changing the application-level write path.
- The new \`code\` field on adapter-key error responses is purely additive; existing callers that only inspect HTTP status keep working unchanged.
- The actionable hint appended to addDeliverable errors is appended via `fmt.Errorf("%w …")` so any code that does \`errors.Is(err, ErrPreviousDeliverableNotAcknowledged)\` continues to work.

## Reference task IDs
For correlation with the original bug report:
- `33dc2c37-f51e-428f-9ec2-e7f90eced595` — original delivered-but-unacked task (Bug #4 trigger)
- `2b259586-fe48-4efe-87c9-883970705b81` — second task that hit Bug #3 + #4 cascade
- `e72933c5-727d-47cc-83c4-6feb31500fb1` — third task with same pattern
- Test user wallet: `0x1d4D51F08ab86985533Da9D574A3df68336c485D`
- Provider: `0xA02b95Aa6886b1116C4f334eDe00381511E31A09`