### PR TITLE
fix(inference): decode upstream error body before logging

### DIFF
--- a/api/inference/internal/ctrl/proxy.go
+++ b/api/inference/internal/ctrl/proxy.go
@@ -2,6 +2,8 @@ package ctrl
 
 import (
 	"bytes"
+	"compress/flate"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -10,6 +12,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/andybalholm/brotli"
 	"github.com/gin-gonic/gin"
 
 	"github.com/0glabs/0g-serving-broker/common/errors"
@@ -158,7 +161,7 @@ func (c *Ctrl) ProcessHTTPRequest(ctx *gin.Context, svcType string, req *http.Re
 	c.addNoCacheHeaders(ctx)
 
 	if resp.StatusCode != http.StatusOK {
-		c.handleServiceError(ctx, resp.StatusCode, resp.Body)
+		c.handleServiceError(ctx, resp)
 		return err
 	}
 
@@ -282,20 +285,24 @@ func (c *Ctrl) handleBrokerError(ctx *gin.Context, err error, context string) {
 	errors.Response(ctx, errors.Wrap(err, info))
 }
 
-func (c *Ctrl) handleServiceError(ctx *gin.Context, statusCode int, body io.ReadCloser) {
-	respBody, err := io.ReadAll(body)
+func (c *Ctrl) handleServiceError(ctx *gin.Context, resp *http.Response) {
+	statusCode := resp.StatusCode
+	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		c.logger.Errorf("Failed to read service error response body: %v", err)
 		ctx.Writer.WriteHeader(statusCode)
 		return
 	}
 
-	bodyStr := string(respBody)
+	// Decode the body for inspection/logging based on upstream Content-Encoding.
+	// We must keep respBody raw (still encoded) for re-emission to the client,
+	// because the upstream Content-Encoding header was already forwarded above.
+	decodedBody := decodeErrorBody(respBody, resp.Header.Get("Content-Encoding"))
 
 	// Correct misclassified status codes: litellm sometimes wraps client errors
 	// (e.g., token limit exceeded) as 503 ServiceUnavailableError via MidStreamFallbackError.
 	// These are deterministic client errors that should not be retried.
-	if statusCode >= 500 && isClientError(bodyStr) {
+	if statusCode >= 500 && isClientError(decodedBody) {
 		statusCode = http.StatusBadRequest
 	}
 
@@ -307,13 +314,50 @@ func (c *Ctrl) handleServiceError(ctx *gin.Context, statusCode int, body io.Read
 	// Log the actual service error content for debugging
 	// Skip logging for telemetry endpoints to reduce noise
 	if !strings.Contains(ctx.Request.RequestURI, "/api/event_logging/batch") {
-		c.logger.Errorf("Service returned error response: %s, Incoming request: method=%s, URI=%s, path=%s, RemoteAddr=%s,", bodyStr, ctx.Request.Method, ctx.Request.RequestURI, ctx.Request.URL.Path, ctx.Request.RemoteAddr)
+		c.logger.Errorf("Service returned error response: %s, Incoming request: method=%s, URI=%s, path=%s, RemoteAddr=%s,", decodedBody, ctx.Request.Method, ctx.Request.RequestURI, ctx.Request.URL.Path, ctx.Request.RemoteAddr)
 	}
 
 	ctx.Writer.WriteHeader(statusCode)
 
 	if _, err := ctx.Writer.Write(respBody); err != nil {
 		c.logger.Errorf("Failed to write service error response: %v", err)
+	}
+}
+
+// decodeErrorBody returns a human-readable form of an upstream error body, decompressing
+// it according to the upstream Content-Encoding. On any failure, it returns the raw string —
+// callers use this only for logging and substring matching, never for re-emission.
+func decodeErrorBody(body []byte, contentEncoding string) string {
+	switch strings.ToLower(strings.TrimSpace(contentEncoding)) {
+	case "", "identity":
+		return string(body)
+	case "gzip":
+		gz, err := gzip.NewReader(bytes.NewReader(body))
+		if err != nil {
+			return string(body)
+		}
+		defer gz.Close()
+		decoded, err := io.ReadAll(gz)
+		if err != nil {
+			return string(body)
+		}
+		return string(decoded)
+	case "br":
+		decoded, err := io.ReadAll(brotli.NewReader(bytes.NewReader(body)))
+		if err != nil {
+			return string(body)
+		}
+		return string(decoded)
+	case "deflate":
+		fr := flate.NewReader(bytes.NewReader(body))
+		defer fr.Close()
+		decoded, err := io.ReadAll(fr)
+		if err != nil {
+			return string(body)
+		}
+		return string(decoded)
+	default:
+		return string(body)
 	}
 }
 

--- a/api/inference/internal/ctrl/proxy_test.go
+++ b/api/inference/internal/ctrl/proxy_test.go
@@ -1,8 +1,13 @@
 package ctrl
 
 import (
+	"bytes"
+	"compress/flate"
+	"compress/gzip"
 	"encoding/json"
 	"testing"
+
+	"github.com/andybalholm/brotli"
 
 	"github.com/0glabs/0g-serving-broker/inference/config"
 )
@@ -103,5 +108,57 @@ func TestEnforceConfiguredModel_InjectsUpstreamWhenMissing(t *testing.T) {
 	}
 	if out["model"] != "z-ai/glm-5" {
 		t.Errorf("model = %q, want %q", out["model"], "z-ai/glm-5")
+	}
+}
+
+func TestDecodeErrorBody(t *testing.T) {
+	const payload = `{"error":{"message":"upstream boom"}}`
+
+	gz := func(s string) []byte {
+		var buf bytes.Buffer
+		w := gzip.NewWriter(&buf)
+		_, _ = w.Write([]byte(s))
+		_ = w.Close()
+		return buf.Bytes()
+	}
+	br := func(s string) []byte {
+		var buf bytes.Buffer
+		w := brotli.NewWriter(&buf)
+		_, _ = w.Write([]byte(s))
+		_ = w.Close()
+		return buf.Bytes()
+	}
+	df := func(s string) []byte {
+		var buf bytes.Buffer
+		w, _ := flate.NewWriter(&buf, flate.DefaultCompression)
+		_, _ = w.Write([]byte(s))
+		_ = w.Close()
+		return buf.Bytes()
+	}
+
+	tests := []struct {
+		name     string
+		body     []byte
+		encoding string
+		want     string
+	}{
+		{"identity empty", []byte(payload), "", payload},
+		{"identity explicit", []byte(payload), "identity", payload},
+		{"gzip", gz(payload), "gzip", payload},
+		{"gzip case-insensitive", gz(payload), "GZIP", payload},
+		{"brotli", br(payload), "br", payload},
+		{"deflate", df(payload), "deflate", payload},
+		// Falls back to the raw bytes (as a string) on decode failure rather
+		// than dropping the message — half-readable beats nothing in logs.
+		{"malformed gzip falls back to raw", []byte("not gzip"), "gzip", "not gzip"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := decodeErrorBody(tt.body, tt.encoding)
+			if got != tt.want {
+				t.Errorf("decodeErrorBody() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

`handleServiceError` in `api/inference/internal/ctrl/proxy.go` logged the **raw** upstream response body, ignoring `Content-Encoding`. When upstream returned a gzip-encoded error (e.g. DashScope), every 5xx in production logs surfaced as ~250 bytes of unreadable `\x1f\x8b\x08...` escape sequences, hiding the real upstream message from on-call.

The same body was also fed to `isClientError()` for the 503→400 reclassification heuristic, so a gzipped 503 carrying e.g. `BadRequestError` would never be reclassified — a latent bug that matters whenever upstream gzips error responses.

### Real-world example

A redacted snippet from a recent production log (`time=2026-05-07T08:11:54Z`):

```
level=error msg="Service returned error response: \x1f\x8b\b\x00\x00\x00\x00\x00\x00\x03\x8c\x8e\xc1j\x83@\x14E\x7f...
```

After this fix, the same response logs as:

```
level=error msg="Service returned error response: {\"error\":{\"message\":\"<500> InternalError.Algo: An error occurred in model serving, error message is: [Inference engine abort. Finish reason: [STOP_ENGINE_ABORT].]\",\"type\":\"internal_server_error\",...
```

### Change

- Pass the full `*http.Response` to `handleServiceError` so it can read `Content-Encoding`.
- New helper `decodeErrorBody(body, contentEncoding)` handles `gzip`, `br`, `deflate`, and `identity`. Each branch uses an independent reader and returns the original raw string on any decode error — half-readable beats nothing in logs.
- The body **written back to the client** stays the original encoded bytes; we already forwarded the upstream `Content-Encoding` header to the client, so the encoded form is what the client expects.
- `isClientError()` now sees decoded text, fixing the latent 503→400 reclassification gap for gzipped responses.

## Test plan

- [x] New unit tests in `proxy_test.go` cover identity / gzip / brotli / deflate / case-insensitivity / malformed-input fallback.
- [x] \`go build ./...\` clean.
- [x] \`go test ./inference/...\` clean (full inference unit suite).
- [x] \`go vet ./inference/internal/ctrl/...\` clean.
- [ ] Verify in staging that an upstream gzip error surfaces decoded JSON in \`inference.broker.log\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)