### PR TITLE
Standardize JSON field naming to snake_case

### DIFF
--- a/api/inference/internal/handler/models.go
+++ b/api/inference/internal/handler/models.go
@@ -28,7 +28,7 @@ type ModelObject struct {
 	SupportedFormats    []string                  `json:"supported_formats,omitempty"`
 	DefaultParameters   map[string]interface{}    `json:"default_parameters,omitempty"`
 	Pricing             *ModelPricing             `json:"pricing,omitempty"`
-	PricingUSD          *ModelPricingUSD          `json:"pricingUSD,omitempty"`
+	PricingUSD          *ModelPricingUSD          `json:"pricing_usd,omitempty"`
 	Verifiability       string                    `json:"verifiability,omitempty"`
 	TeeAttested         bool                      `json:"tee_attested"`
 	TeeType             string                    `json:"tee_type,omitempty"`
@@ -87,17 +87,17 @@ type ModelPricingUSD struct {
 // than polling on a fixed cadence.  The real tick can slip behind retries,
 // so treat this as "not before", not a guarantee.
 type PriceFeedState struct {
-	RateUSDPerOG   string    `json:"rateUSDPerOG"`
-	UpdatedAt      time.Time `json:"updatedAt"`
-	NextUpdateTime time.Time `json:"nextUpdateTime"`
-	IsStale        bool      `json:"isStale"`
+	RateUSDPerOG   string    `json:"rate_usd_per_og"`
+	UpdatedAt      time.Time `json:"updated_at"`
+	NextUpdateTime time.Time `json:"next_update_time"`
+	IsStale        bool      `json:"is_stale"`
 }
 
 // ModelListResponse is the OpenAI-compatible response for GET /v1/models.
 type ModelListResponse struct {
 	Object    string          `json:"object"`
 	Data      []ModelObject   `json:"data"`
-	PriceFeed *PriceFeedState `json:"priceFeed,omitempty"`
+	PriceFeed *PriceFeedState `json:"price_feed,omitempty"`
 }
 
 // GetModels returns the list of models served by this broker.

--- a/api/inference/internal/handler/models_test.go
+++ b/api/inference/internal/handler/models_test.go
@@ -588,16 +588,16 @@ func TestGetModels_NativeModeOmitsUSDBlocks(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
 		t.Fatalf("parse raw: %v", err)
 	}
-	if _, exists := raw["priceFeed"]; exists {
-		t.Error("priceFeed key should be absent in NATIVE mode")
+	if _, exists := raw["price_feed"]; exists {
+		t.Error("price_feed key should be absent in NATIVE mode")
 	}
 	data, _ := raw["data"].([]interface{})
 	if len(data) == 0 {
 		t.Fatal("data empty")
 	}
 	m, _ := data[0].(map[string]interface{})
-	if _, exists := m["pricingUSD"]; exists {
-		t.Error("pricingUSD key should be absent in NATIVE mode")
+	if _, exists := m["pricing_usd"]; exists {
+		t.Error("pricing_usd key should be absent in NATIVE mode")
 	}
 }
 
@@ -663,8 +663,8 @@ func TestGetModels_USDModeUnpopulatedCacheOmitsPriceFeed(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
 		t.Fatalf("parse: %v", err)
 	}
-	if _, exists := raw["priceFeed"]; exists {
-		t.Error("priceFeed should be absent when cache unpopulated")
+	if _, exists := raw["price_feed"]; exists {
+		t.Error("price_feed should be absent when cache unpopulated")
 	}
 	var resp ModelListResponse
 	_ = json.Unmarshal(w.Body.Bytes(), &resp)


### PR DESCRIPTION
## Summary
Standardized JSON field naming conventions across the models API by converting camelCase field tags to snake_case, following REST API best practices and improving consistency with common JSON naming conventions.

## Key Changes
- Updated `ModelObject.PricingUSD` JSON tag from `pricingUSD` to `pricing_usd`
- Updated `PriceFeedState` JSON tags:
  - `rateUSDPerOG` → `rate_usd_per_og`
  - `updatedAt` → `updated_at`
  - `nextUpdateTime` → `next_update_time`
  - `isStale` → `is_stale`
- Updated `ModelListResponse.PriceFeed` JSON tag from `priceFeed` to `price_feed`
- Updated corresponding test assertions to match the new snake_case field names

## Implementation Details
All changes are JSON serialization tag updates only—no Go struct field names or logic were modified. This ensures backward compatibility at the code level while standardizing the API response format. Tests were updated to verify the correct snake_case field names in JSON responses.

https://claude.ai/code/session_01SCSJ6pwnHuwcEp8pGR6J93