### PR TITLE
fix(fine-tuning): improve setup resilience and failure visibility

### DIFF
--- a/api/fine-tuning/internal/contract/service.go
+++ b/api/fine-tuning/internal/contract/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -13,6 +14,14 @@ import (
 	"github.com/0glabs/0g-serving-broker/fine-tuning/config"
 	"github.com/0glabs/0g-serving-broker/fine-tuning/contract"
 )
+
+// getServiceRPCTimeout bounds a single GetService RPC call. The 0G testnet
+// endpoint has been observed to stall for tens of minutes without erroring,
+// which would freeze the executor's HandleNoTask polling goroutine
+// indefinitely. 30s is well above the normal call latency (sub-second) and
+// short enough that a stalled endpoint surfaces as an error instead of a
+// silent worker freeze.
+const getServiceRPCTimeout = 30 * time.Second
 
 var (
 	// DefaultProviderStake is the default stake amount for first-time service registration (100 0G)
@@ -162,6 +171,9 @@ func (c *ProviderContract) DeleteService(ctx context.Context) error {
 
 func (c *ProviderContract) GetService(ctx context.Context) (*contract.Service, error) {
 	c.logger.Infof("[GetService] Starting to get service - provider=%s", c.ProviderAddress)
+
+	ctx, cancel := context.WithTimeout(ctx, getServiceRPCTimeout)
+	defer cancel()
 
 	callOpts := &bind.CallOpts{
 		Context: ctx,

--- a/api/fine-tuning/internal/services/setup.go
+++ b/api/fine-tuning/internal/services/setup.go
@@ -103,7 +103,14 @@ func (s *Setup) HandleNoTask(ctx context.Context) error {
 }
 
 func (s *Setup) HandleExecuteFailure(err error, dbTask *db.Task) (bool, error) {
-	return s.db.HandleSetupFailure(dbTask, s.config.MaxFinalizerRetriesPerTask, s.states.Intermediate, s.states.Initial)
+	// Surface the failure in the per-task progress.log so callers can see the
+	// real cause via broker.fineTuning.getLog(provider, taskId). Previously
+	// only the broker-wide log carried the error and users saw a bare
+	// "progress: Failed" with no message.
+	if writeErr := utils.WriteToLogFile(dbTask.ID, fmt.Sprintf("setup failed: %v\n", err)); writeErr != nil {
+		s.logger.Errorf("failed to write setup failure to task log: %v", writeErr)
+	}
+	return s.db.HandleSetupFailure(dbTask, s.config.MaxSetupRetriesPerTask, s.states.Intermediate, s.states.Initial)
 }
 
 func (s *Setup) prepareData(ctx context.Context, task *db.Task, paths *utils.TaskPaths) error {
@@ -424,7 +431,6 @@ print(f"Converted {len(lines)} examples to {output_dir}")
 	}
 	defer os.Remove(scriptPath)
 
-	// Try running Python directly first
 	cmd := exec.Command("python3", scriptPath, rawPath, datasetPath)
 	output, err := cmd.CombinedOutput()
 	if err == nil {
@@ -432,27 +438,20 @@ print(f"Converted {len(lines)} examples to {output_dir}")
 		os.Remove(rawPath)
 		return nil
 	}
-	s.logger.Warnf("Direct Python conversion failed: %v (output: %s), trying Docker...", err, string(output))
 
-	// Fall back to Docker
-	parentDir := filepath.Dir(rawPath)
-	cmd = exec.Command("docker", "run", "--rm",
-		"-v", parentDir+":/data",
-		s.config.Images.ExecutionImageName,
-		"python3", "/data/"+filepath.Base(scriptPath),
-		"/data/"+filepath.Base(rawPath),
-		"/data/"+filepath.Base(datasetPath))
-
-	output, err = cmd.CombinedOutput()
-	if err != nil {
-		// Restore the raw file on failure
-		os.Rename(rawPath, datasetPath)
-		return errors.Wrapf(err, "convert raw dataset to HF format: %s", string(output))
+	// Restore the raw file so the task directory is in a consistent state for retries.
+	if renameErr := os.Rename(rawPath, datasetPath); renameErr != nil {
+		s.logger.Warnf("failed to restore raw dataset after conversion error: %v", renameErr)
 	}
 
-	s.logger.Infof("Converted raw dataset to HF format using Docker: %s", string(output))
-	os.Remove(rawPath)
-	return nil
+	// JSONDecodeError almost always means the user's dataset is not valid JSONL
+	// (empty leading line, BOM, wrong format). Returning the raw Python traceback
+	// is unhelpful — give the user something actionable to fix on their side.
+	if strings.Contains(string(output), "JSONDecodeError") {
+		return fmt.Errorf("dataset is not valid JSONL: each line must be a standalone JSON object (no BOM, no blank leading lines, UTF-8 encoded). Verify with: head -c 200 your-file.jsonl | xxd")
+	}
+
+	return errors.Wrapf(err, "convert raw dataset to HF format: %s", string(output))
 }
 
 // tryHuggingFaceFallback attempts to download model from HuggingFace if configured.


### PR DESCRIPTION
## Summary

A small bundle of fine-tuning robustness fixes, all aimed at making setup failures **visible** and **recoverable** instead of silently freezing or producing a bare "progress: Failed".

- **Add 30s timeout to `GetService` RPC** (`contract/service.go`) — 0G testnet endpoint occasionally stalls for tens of minutes without erroring, which froze the executor's `HandleNoTask` polling goroutine indefinitely. 30s is well above normal call latency (sub-second) and short enough that a stalled endpoint surfaces as an error instead of a silent worker freeze.
- **Surface setup failures in per-task `progress.log`** (`services/setup.go`) — users previously saw `progress: Failed` with no message via `broker.fineTuning.getLog(provider, taskId)`. Now the actual error is written into the per-task log, consistent with `settlement.go` / `executor.go` / `finalizer.go`.
- **Fix retry-count config in `HandleExecuteFailure`** — it was using `MaxFinalizerRetriesPerTask` (copy-paste from the Finalizer service); replaced with `MaxSetupRetriesPerTask`. The Finalizer keeps using its own field.
- **Replace dead Docker fallback in `convertRawToHF` with an actionable error** — the runtime image is `python:3.11.2-slim-buster` (broker is `umoci`-inserted on top), so `python3` is always available and the docker fallback was unreachable at runtime anyway (no docker.sock in the broker container). On Python failure, always restore `raw → dataset` to keep the task dir consistent for retries; if Python output contains `JSONDecodeError`, return a user-actionable message instead of a raw traceback.
- **Bump `0g-serving-contract` submodule** to `3ceeff0` — picks up #51 (unblock `addDeliverable` after penalty-settle) and #52 (deploy upgrade across devnet/testnet/mainnet).

## Test plan

- [ ] `cd api && go build ./...` passes
- [ ] `cd api && go test ./...` passes
- [ ] `cd api && make lint` passes
- [ ] Manually verify a task that fails during setup now shows the failure cause via `getLog(provider, taskId)` (no longer a bare `progress: Failed`)
- [ ] Manually verify a malformed JSONL dataset returns the actionable JSONDecodeError message
- [ ] Confirm `GetService` returns within seconds; if RPC stalls, executor logs the timeout instead of hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)