### PR TITLE
fix(inference): support CoinGecko Demo (free) API keys in price feed

### DIFF
--- a/api/inference/config/config.go
+++ b/api/inference/config/config.go
@@ -187,11 +187,21 @@ type PriceFeedConfig struct {
 	// new rate. If fewer sources respond successfully, the tick is skipped and
 	// the last good cache entry remains in use (subject to StalenessThreshold).
 	MinQuorum int `yaml:"minQuorum"`
-	// CoinGeckoAPIKey, when set, is sent in the x-cg-pro-api-key header to
-	// CoinGecko, activating Pro-tier rate limits.  The anonymous free tier
-	// is strict enough in production that quorum failures become common
-	// without a key; setting one is strongly recommended.
+	// CoinGeckoAPIKey, when set, authenticates requests to CoinGecko so that
+	// the per-key rate limit applies instead of the (much stricter) shared
+	// anonymous limit.  Setting one is strongly recommended — the anonymous
+	// free tier causes quorum failures regularly in production.  Whether
+	// this key is a Demo (free) or Pro (paid) key is selected via
+	// CoinGeckoKeyType; the two key tiers use different endpoints and
+	// different request headers and are not interchangeable.
 	CoinGeckoAPIKey string `yaml:"coinGeckoApiKey"`
+	// CoinGeckoKeyType selects which CoinGecko key tier CoinGeckoAPIKey
+	// belongs to.  Allowed values: "demo" (free tier — uses api.coingecko.com
+	// with x-cg-demo-api-key) or "pro" (paid tier — uses pro-api.coingecko.com
+	// with x-cg-pro-api-key).  Defaults to "demo" when CoinGeckoAPIKey is set,
+	// since the free Demo tier (30 req/min) is sufficient for typical update
+	// cadences.  Ignored when CoinGeckoAPIKey is empty.
+	CoinGeckoKeyType string `yaml:"coinGeckoKeyType"`
 	// UserAgent is the User-Agent header sent to every source.  Providers
 	// using private rate-feed deployments or whitelisted plans can set a
 	// stable identifier here so upstream operators can grant them higher
@@ -513,6 +523,18 @@ func validatePriceFeedConfig(pf *PriceFeedConfig) error {
 	}
 	if pf.UserAgent == "" {
 		pf.UserAgent = "0g-serving-broker/pricefeed"
+	}
+	if pf.CoinGeckoAPIKey != "" {
+		keyType := strings.ToLower(strings.TrimSpace(pf.CoinGeckoKeyType))
+		switch keyType {
+		case "":
+			keyType = "demo"
+		case "demo", "pro":
+			// ok
+		default:
+			return fmt.Errorf("invalid config: priceFeed.coinGeckoKeyType must be 'demo' or 'pro', got %q", pf.CoinGeckoKeyType)
+		}
+		pf.CoinGeckoKeyType = keyType
 	}
 	return nil
 }

--- a/api/inference/internal/pricefeed/coingecko.go
+++ b/api/inference/internal/pricefeed/coingecko.go
@@ -19,25 +19,41 @@ const maxResponseBytes = 1 << 20
 // Symbol is the CoinGecko coin id (e.g. "0g"), quote is the fiat / stablecoin
 // id (e.g. "usd"); these differ from the exchange-pair style used by Binance.
 //
-// When apiKey is set, the request is routed to pro-api.coingecko.com with
-// the x-cg-pro-api-key header — the free anonymous tier rate-limits
-// aggressively enough in production to cause regular quorum failures, so a
-// pro key is strongly recommended.
+// CoinGecko has two independent key tiers — Demo (free, served from
+// api.coingecko.com via x-cg-demo-api-key) and Pro (paid, served from
+// pro-api.coingecko.com via x-cg-pro-api-key) — and a key issued for one
+// tier is rejected by the other.  keyType selects between them; see
+// NewCoinGeckoSource.
 type CoinGeckoSource struct {
 	httpClient *http.Client
 	baseURL    string // overridable for tests
 	coinID     string
 	quoteID    string
 	apiKey     string
+	keyHeader  string // request header to send apiKey in; empty when apiKey is empty
 	userAgent  string
 }
 
-// NewCoinGeckoSource constructs a source.  baseURL may be empty: if apiKey
-// is set the pro-api endpoint is used, otherwise the public endpoint.  Tests
-// inject a stub server's URL.
-func NewCoinGeckoSource(client *http.Client, baseURL, coinID, quoteID, apiKey, userAgent string) *CoinGeckoSource {
+// NewCoinGeckoSource constructs a source.
+//
+// keyType must be "demo" or "pro" when apiKey is non-empty; it picks both the
+// default endpoint (api.coingecko.com vs pro-api.coingecko.com) and the
+// request header (x-cg-demo-api-key vs x-cg-pro-api-key).  When apiKey is
+// empty, keyType is ignored and the public anonymous endpoint is used.
+//
+// baseURL may be empty to use the tier-appropriate default; tests inject a
+// stub server's URL while still exercising the header selection logic.
+func NewCoinGeckoSource(client *http.Client, baseURL, coinID, quoteID, apiKey, keyType, userAgent string) *CoinGeckoSource {
+	keyHeader := ""
+	if apiKey != "" {
+		if keyType == "pro" {
+			keyHeader = "x-cg-pro-api-key"
+		} else {
+			keyHeader = "x-cg-demo-api-key"
+		}
+	}
 	if baseURL == "" {
-		if apiKey != "" {
+		if keyType == "pro" {
 			baseURL = "https://pro-api.coingecko.com/api/v3"
 		} else {
 			baseURL = "https://api.coingecko.com/api/v3"
@@ -49,6 +65,7 @@ func NewCoinGeckoSource(client *http.Client, baseURL, coinID, quoteID, apiKey, u
 		coinID:     coinID,
 		quoteID:    quoteID,
 		apiKey:     apiKey,
+		keyHeader:  keyHeader,
 		userAgent:  userAgent,
 	}
 }
@@ -69,8 +86,8 @@ func (s *CoinGeckoSource) FetchRate(ctx context.Context) (*big.Rat, error) {
 	if s.userAgent != "" {
 		req.Header.Set("User-Agent", s.userAgent)
 	}
-	if s.apiKey != "" {
-		req.Header.Set("x-cg-pro-api-key", s.apiKey)
+	if s.apiKey != "" && s.keyHeader != "" {
+		req.Header.Set(s.keyHeader, s.apiKey)
 	}
 
 	resp, err := s.httpClient.Do(req)

--- a/api/inference/internal/pricefeed/factory.go
+++ b/api/inference/internal/pricefeed/factory.go
@@ -37,7 +37,7 @@ func BuildSources(cfg config.PriceFeedConfig) ([]Source, error) {
 	for _, name := range cfg.Sources {
 		switch name {
 		case "coingecko":
-			sources = append(sources, NewCoinGeckoSource(httpClient, "", coinGeckoCoinID, coinGeckoQuote, cfg.CoinGeckoAPIKey, cfg.UserAgent))
+			sources = append(sources, NewCoinGeckoSource(httpClient, "", coinGeckoCoinID, coinGeckoQuote, cfg.CoinGeckoAPIKey, cfg.CoinGeckoKeyType, cfg.UserAgent))
 		case "binance":
 			sources = append(sources, NewBinanceSource(httpClient, "", binanceSymbol, cfg.UserAgent))
 		default:

--- a/api/inference/internal/pricefeed/sources_test.go
+++ b/api/inference/internal/pricefeed/sources_test.go
@@ -20,7 +20,7 @@ func TestCoinGeckoSource_ParsesRate(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	s := NewCoinGeckoSource(&http.Client{Timeout: time.Second}, srv.URL, "0g", "usd", "", "test-ua")
+	s := NewCoinGeckoSource(&http.Client{Timeout: time.Second}, srv.URL, "0g", "usd", "", "", "test-ua")
 	got, err := s.FetchRate(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -38,10 +38,41 @@ func TestCoinGeckoSource_MissingCoin(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	s := NewCoinGeckoSource(&http.Client{Timeout: time.Second}, srv.URL, "0g", "usd", "", "test-ua")
+	s := NewCoinGeckoSource(&http.Client{Timeout: time.Second}, srv.URL, "0g", "usd", "", "", "test-ua")
 	_, err := s.FetchRate(context.Background())
 	if err == nil {
 		t.Error("expected error for missing coin in response")
+	}
+}
+
+func TestCoinGeckoSource_SendsKeyHeader(t *testing.T) {
+	tests := []struct {
+		name       string
+		keyType    string
+		wantHeader string
+	}{
+		{name: "demo", keyType: "demo", wantHeader: "x-cg-demo-api-key"},
+		{name: "pro", keyType: "pro", wantHeader: "x-cg-pro-api-key"},
+		{name: "default (empty keyType) routes to demo", keyType: "", wantHeader: "x-cg-demo-api-key"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotHeader, gotValue string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotHeader = tt.wantHeader
+				gotValue = r.Header.Get(tt.wantHeader)
+				_, _ = w.Write([]byte(`{"0g": {"usd": 0.001}}`))
+			}))
+			defer srv.Close()
+
+			s := NewCoinGeckoSource(&http.Client{Timeout: time.Second}, srv.URL, "0g", "usd", "secret-key", tt.keyType, "test-ua")
+			if _, err := s.FetchRate(context.Background()); err != nil {
+				t.Fatal(err)
+			}
+			if gotValue != "secret-key" {
+				t.Errorf("header %s = %q, want %q", gotHeader, gotValue, "secret-key")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- CoinGecko price-feed source previously hardcoded the Pro endpoint (`pro-api.coingecko.com`) and the `x-cg-pro-api-key` header whenever a key was configured, so the free **Demo** keys CoinGecko issues against `api.coingecko.com` with the `x-cg-demo-api-key` header were rejected with HTTP 400 and the bootstrap panicked at startup.
- Add a new `priceFeed.coinGeckoKeyType` config option (`"demo"` or `"pro"`) that selects the correct endpoint and header. Defaults to `"demo"` when a key is set, matching the free tier most operators will configure (30 req/min is plenty for the default update cadence). Pro-key operators add `coinGeckoKeyType: "pro"` to opt in.
- Extend `NewCoinGeckoSource` to accept the key type and store the chosen header on the source so it's sent on every request.

## Migration
- **Demo (free) key users**: just set `coinGeckoApiKey`; `coinGeckoKeyType` defaults to `"demo"`.
- **Pro key users**: add `coinGeckoKeyType: "pro"` under `priceFeed` in `config.yaml`. (Previously the only working mode, so existing Pro-key deployments must update their config when upgrading.)

```yaml
priceFeed:
  sources:
    - coingecko
    - binance
  coinGeckoApiKey: "CG-..."
  # coinGeckoKeyType: "pro"   # uncomment if your key is a paid Pro key
```

## Test plan
- [x] `go build ./...`
- [x] `go test ./inference/internal/pricefeed/... ./inference/config/...`
- [x] New table-driven test `TestCoinGeckoSource_SendsKeyHeader` covers demo / pro / default-empty cases and asserts the correct header is sent on the wire
- [ ] Manual: confirm bootstrap succeeds against `api.coingecko.com` with a real Demo key

🤖 Generated with [Claude Code](https://claude.com/claude-code)