### PR TITLE
feat(inference): add Bybit price-feed source for 0G/USDT

### DIFF
--- a/api/inference/config/config.go
+++ b/api/inference/config/config.go
@@ -154,7 +154,7 @@ func (s *Service) IsUSDDenominated() bool {
 // wei prices are stored (in the in-memory cache and on-chain).
 type PriceFeedConfig struct {
 	// Sources lists the price-feed source identifiers to query in parallel.
-	// Known identifiers: "coingecko", "binance".
+	// Known identifiers: "coingecko", "binance", "bybit".
 	// The aggregator returns the median of healthy sources; at least MinQuorum
 	// sources must respond successfully for an update to proceed.
 	//

--- a/api/inference/internal/pricefeed/bybit.go
+++ b/api/inference/internal/pricefeed/bybit.go
@@ -1,0 +1,102 @@
+package pricefeed
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"strings"
+)
+
+// BybitSource queries Bybit's public spot ticker endpoint.
+// symbol is the Bybit instrument id (e.g. "0GUSDT"), using the same
+// concatenated convention as Binance — distinct from OKX's "0G-USDT"
+// or CoinGecko's coin-id "zero-gravity".
+//
+// Bybit's public market endpoints don't require an API key and are
+// generally available globally, making this a useful complement to
+// Binance (which returns 451 in sanctioned regions).
+type BybitSource struct {
+	httpClient *http.Client
+	baseURL    string
+	symbol     string
+	userAgent  string
+}
+
+// NewBybitSource constructs a source.  symbol is the Bybit spot
+// instrument id (e.g. "0GUSDT"); callers should uppercase it to match
+// Bybit's API.
+func NewBybitSource(client *http.Client, baseURL, symbol, userAgent string) *BybitSource {
+	if baseURL == "" {
+		baseURL = "https://api.bybit.com"
+	}
+	return &BybitSource{
+		httpClient: client,
+		baseURL:    baseURL,
+		symbol:     strings.ToUpper(symbol),
+		userAgent:  userAgent,
+	}
+}
+
+func (s *BybitSource) Name() string { return "bybit" }
+
+func (s *BybitSource) FetchRate(ctx context.Context) (*big.Rat, error) {
+	reqURL := fmt.Sprintf("%s/v5/market/tickers?category=spot&symbol=%s", s.baseURL, s.symbol)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("bybit: build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	if s.userAgent != "" {
+		req.Header.Set("User-Agent", s.userAgent)
+	}
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("bybit: http: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("bybit: unexpected status %d", resp.StatusCode)
+	}
+
+	// Response shape:
+	//   { "retCode": 0, "retMsg": "OK",
+	//     "result": { "category": "spot",
+	//                 "list": [ { "symbol": "0GUSDT", "lastPrice": "0.5658", ... } ] } }
+	// Bybit returns HTTP 200 with retCode != 0 for application-level
+	// errors (e.g. unknown symbol), so the body must be inspected.
+	var body struct {
+		RetCode int    `json:"retCode"`
+		RetMsg  string `json:"retMsg"`
+		Result  struct {
+			List []struct {
+				Symbol    string `json:"symbol"`
+				LastPrice string `json:"lastPrice"`
+			} `json:"list"`
+		} `json:"result"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxResponseBytes)).Decode(&body); err != nil {
+		return nil, fmt.Errorf("bybit: decode: %w", err)
+	}
+	if body.RetCode != 0 {
+		return nil, fmt.Errorf("bybit: api error retCode=%d retMsg=%q", body.RetCode, body.RetMsg)
+	}
+	if len(body.Result.List) == 0 {
+		return nil, fmt.Errorf("bybit: empty list for symbol %q", s.symbol)
+	}
+	if body.Result.List[0].LastPrice == "" {
+		return nil, fmt.Errorf("bybit: empty lastPrice in response")
+	}
+	rate, ok := new(big.Rat).SetString(body.Result.List[0].LastPrice)
+	if !ok {
+		return nil, fmt.Errorf("bybit: price %q not parseable", body.Result.List[0].LastPrice)
+	}
+	if rate.Sign() <= 0 {
+		return nil, fmt.Errorf("bybit: non-positive rate %s", body.Result.List[0].LastPrice)
+	}
+	return rate, nil
+}

--- a/api/inference/internal/pricefeed/factory.go
+++ b/api/inference/internal/pricefeed/factory.go
@@ -11,12 +11,13 @@ import (
 // 0G-specific symbol constants for each supported source.  These are facts
 // about where 0G trades, not operator choices — there's no sensible alternate
 // value for this broker (it prices 0G for on-chain settlement).  If 0G is
-// ever re-slugged on CoinGecko or relisted under a different pair on Binance,
-// update these in place.
+// ever re-slugged on CoinGecko or relisted under a different pair on an
+// exchange, update these in place.
 const (
-	coinGeckoCoinID     = "zero-gravity"
-	coinGeckoQuote      = "usd"
-	binanceSymbol       = "0GUSDT"
+	coinGeckoCoinID = "zero-gravity"
+	coinGeckoQuote  = "usd"
+	binanceSymbol   = "0GUSDT"
+	bybitSymbol     = "0GUSDT"
 )
 
 // BuildSources constructs Source implementations from a PriceFeedConfig.
@@ -40,6 +41,8 @@ func BuildSources(cfg config.PriceFeedConfig) ([]Source, error) {
 			sources = append(sources, NewCoinGeckoSource(httpClient, "", coinGeckoCoinID, coinGeckoQuote, cfg.CoinGeckoAPIKey, cfg.CoinGeckoKeyType, cfg.UserAgent))
 		case "binance":
 			sources = append(sources, NewBinanceSource(httpClient, "", binanceSymbol, cfg.UserAgent))
+		case "bybit":
+			sources = append(sources, NewBybitSource(httpClient, "", bybitSymbol, cfg.UserAgent))
 		default:
 			return nil, fmt.Errorf("pricefeed: unknown source %q", name)
 		}

--- a/api/inference/internal/pricefeed/sources_test.go
+++ b/api/inference/internal/pricefeed/sources_test.go
@@ -96,6 +96,67 @@ func TestBinanceSource_ParsesPrice(t *testing.T) {
 	}
 }
 
+func TestBybitSource_ParsesPrice(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("symbol") != "0GUSDT" {
+			t.Errorf("expected symbol=0GUSDT, got %s", r.URL.Query().Get("symbol"))
+		}
+		if r.URL.Query().Get("category") != "spot" {
+			t.Errorf("expected category=spot, got %s", r.URL.Query().Get("category"))
+		}
+		_, _ = w.Write([]byte(`{"retCode":0,"retMsg":"OK","result":{"category":"spot","list":[{"symbol":"0GUSDT","lastPrice":"0.5658"}]}}`))
+	}))
+	defer srv.Close()
+
+	s := NewBybitSource(&http.Client{Timeout: time.Second}, srv.URL, "0GUSDT", "test-ua")
+	got, err := s.FetchRate(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, _ := new(big.Rat).SetString("0.5658")
+	if got.Cmp(want) != 0 {
+		t.Errorf("rate = %s, want %s", got.FloatString(6), want.FloatString(6))
+	}
+}
+
+func TestBybitSource_RejectsApplicationError(t *testing.T) {
+	// Bybit signals errors with HTTP 200 + a non-zero retCode field, so the
+	// body must be inspected even when the transport succeeded.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"retCode":10001,"retMsg":"Invalid symbol","result":{"list":[]}}`))
+	}))
+	defer srv.Close()
+
+	s := NewBybitSource(&http.Client{Timeout: time.Second}, srv.URL, "0GUSDT", "test-ua")
+	if _, err := s.FetchRate(context.Background()); err == nil {
+		t.Error("expected error for non-zero retCode in response")
+	}
+}
+
+func TestBybitSource_RejectsEmptyList(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"retCode":0,"retMsg":"OK","result":{"category":"spot","list":[]}}`))
+	}))
+	defer srv.Close()
+
+	s := NewBybitSource(&http.Client{Timeout: time.Second}, srv.URL, "0GUSDT", "test-ua")
+	if _, err := s.FetchRate(context.Background()); err == nil {
+		t.Error("expected error for empty list")
+	}
+}
+
+func TestBybitSource_RejectsNonPositive(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"retCode":0,"retMsg":"OK","result":{"category":"spot","list":[{"symbol":"0GUSDT","lastPrice":"0"}]}}`))
+	}))
+	defer srv.Close()
+
+	s := NewBybitSource(&http.Client{Timeout: time.Second}, srv.URL, "0GUSDT", "test-ua")
+	if _, err := s.FetchRate(context.Background()); err == nil {
+		t.Error("expected error for zero price")
+	}
+}
+
 func TestBinanceSource_RejectsNonPositive(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(`{"symbol":"ZGUSDT","price":"0"}`))


### PR DESCRIPTION
## Summary
- Add a third pricefeed `Source` alongside CoinGecko and Binance, querying Bybit's public spot ticker (`GET /v5/market/tickers?category=spot&symbol=0GUSDT`).
- Bybit requires no API key and is generally available globally, so operators running in regions where Binance returns HTTP 451 can meet the default `quorum=2` without having to drop Binance or lower the quorum.
- Registered in `BuildSources` under identifier `"bybit"`; the 0G symbol (`0GUSDT`) is hardcoded in `factory.go` next to the existing per-exchange constants, matching the convention established by Binance.

## Implementation notes
- Mirrors the Binance source structurally but with two Bybit-specific differences: (1) Bybit returns HTTP 200 with `retCode != 0` for application-level errors (e.g. unknown symbol), so the body is inspected even on a 2xx response; (2) the price lives at `result.list[0].lastPrice` rather than at the top level.
- Same defensive checks as the other sources: empty body, non-parseable rate, non-positive rate.

## Why Bybit and not OKX
Originally planned to use OKX, but a live check of `/api/v5/public/instruments?instType=SPOT` showed 0G is not listed on OKX — adding it would have produced a permanently-failing source. Of the verified-listed alternatives (Bybit / Gate.io / KuCoin / MEXC), Bybit has the broadest global availability and the cleanest JSON shape.

## Config
Enable the source by listing it under `priceFeed.sources`:

\`\`\`yaml
priceFeed:
  sources:
    - coingecko
    - binance
    - bybit
  coinGeckoApiKey: \"CG-...\"
\`\`\`

With three sources, `minQuorum` still defaults to 2, but any two healthy sources are now sufficient — Binance can fail in geo-restricted regions and bootstrap will still succeed.

## Test plan
- [x] \`go build ./...\`
- [x] \`go test ./inference/internal/pricefeed/... ./inference/config/...\`
- [x] New tests cover: happy path (asserts \`symbol\`/\`category\` query params + parses \`lastPrice\`); application-level error (non-zero \`retCode\`); empty \`result.list\`; non-positive price.
- [x] Live-verified against \`https://api.bybit.com/v5/market/tickers?category=spot&symbol=0GUSDT\` — returns the expected payload shape with a live 0G price.

🤖 Generated with [Claude Code](https://claude.com/claude-code)