### PR TITLE
fix(middleware): make IP rate limit a no-op behind L4 proxy

### DIFF
--- a/api/common/middleware/ratelimit.go
+++ b/api/common/middleware/ratelimit.go
@@ -1,7 +1,6 @@
 package middleware
 
 import (
-	"net/http"
 	"strings"
 	"sync"
 	"time"
@@ -63,20 +62,12 @@ func (rl *RateLimiter) Allow(ip string) bool {
 	return limiter.Allow()
 }
 
-func RateLimitMiddleware(limiter *RateLimiter) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		ip := getClientIP(c)
-		
-		if !limiter.Allow(ip) {
-			c.JSON(http.StatusTooManyRequests, gin.H{
-				"error": "Too many requests. Please try again later.",
-			})
-			c.Abort()
-			return
-		}
-		
-		c.Next()
-	}
+// RateLimitMiddleware is a no-op. The broker runs behind an L4 TCP proxy that
+// hides the real client IP, so per-IP limiting would collapse all traffic into
+// a single global cap. PerUserRateLimiter (keyed by user address) is the
+// primary defense.
+func RateLimitMiddleware(_ *RateLimiter) gin.HandlerFunc {
+	return func(c *gin.Context) { c.Next() }
 }
 
 func getClientIP(c *gin.Context) string {


### PR DESCRIPTION
## Summary

- `RateLimitMiddleware` becomes a pass-through. The broker now runs behind `dstacktee/dstack-ingress` 2.x, which terminates TLS in **HAProxy TCP mode** and forwards a raw byte stream — no `X-Forwarded-For` / `X-Real-IP` headers reach the backend, and `RemoteAddr` is always the ingress container's IP.
- With per-IP limiting in place, every user's traffic would share a single bucket and trip the 10–15 RPS caps almost instantly. The middleware is now disabled at the source so all call sites (inference proxy, inference handler, fine-tuning handler) get the new behavior without further changes.
- **`PerUserRateLimiter`** (keyed by on-chain user address, set up at `inference/internal/proxy/proxy.go:76,376`) is unchanged and remains the primary defense. Authentication is signature-based and likewise unaffected.

The `RateLimiter` struct, `NewRateLimiter`, and `getClientIP` are kept so existing callers compile unmodified; they can be cleaned up in a follow-up.

## Why now

Phala team recommends migrating from `dstack-ingress:1.4` (nginx) to `:2.2` (haproxy) to address [CVE-2026-42945](https://www.cve.org/CVERecord?id=CVE-2026-42945) in `ngx_http_rewrite_module`. The deploy repo is being upgraded in parallel; this PR makes the broker correct in that topology.

## Test plan
- [ ] `go build ./...` — passes locally
- [ ] `go vet ./...` — passes locally
- [ ] Deploy on a testnet provider (e.g. compute-network-6) and confirm:
  - [ ] Sustained inference traffic from a single client no longer trips 429s after ~20 requests
  - [ ] `PerUserRateLimiter` still enforces RPM caps when a user exceeds them
  - [ ] `X-Rate-Limit-*` response headers (set from `PerUserRateLimiter.GetRemainingWithReset`) still populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)