### PR TITLE
fix(inference): prevent double-charging users on broker restart

### DIFF
--- a/api/inference/internal/ctrl/settlement_tee.go
+++ b/api/inference/internal/ctrl/settlement_tee.go
@@ -134,9 +134,10 @@ func (c *Ctrl) ProcessSettlement(ctx context.Context) error {
 	return errors.Wrap(c.SettleFeesWithTEE(ctx), "settle fees with TEE")
 }
 
-// ResetSettlementState clears settling flags and skip_until for all
-// pending requests and users. Call this on startup to allow all
-// pending requests to be retried immediately.
+// ResetSettlementState clears skip_until throttles on requests and users
+// so pending work can be retried immediately after restart. The settling
+// flag is intentionally left untouched; see db.ResetSettlementState for
+// why (clearing it risks double-charging via contract replay).
 func (c *Ctrl) ResetSettlementState() error {
 	return c.db.ResetSettlementState()
 }

--- a/api/inference/internal/db/daily_stat.go
+++ b/api/inference/internal/db/daily_stat.go
@@ -31,9 +31,9 @@ func (d *DB) AccumulateAndDeleteRequests(requests []*model.Request) error {
 			`INSERT INTO daily_stat (date, total_requests, input_tokens, output_tokens)
 			 VALUES (UTC_DATE(), ?, ?, ?) AS new_vals
 			 ON DUPLICATE KEY UPDATE
-			   total_requests = total_requests + new_vals.total_requests,
-			   input_tokens = input_tokens + new_vals.input_tokens,
-			   output_tokens = output_tokens + new_vals.output_tokens`,
+			   total_requests = daily_stat.total_requests + new_vals.total_requests,
+			   input_tokens = daily_stat.input_tokens + new_vals.input_tokens,
+			   output_tokens = daily_stat.output_tokens + new_vals.output_tokens`,
 			totalRequests, inputTokens, outputTokens,
 		).Error; err != nil {
 			return fmt.Errorf("failed to accumulate daily stats: %w", err)

--- a/api/inference/internal/db/reconciliation.go
+++ b/api/inference/internal/db/reconciliation.go
@@ -60,18 +60,20 @@ func (d *DB) UpdatePendingSettlementStatus(id uint64, status string) error {
 		}).Error
 }
 
-// ResetSettlementState clears settling flags and skip_until for all unprocessed requests
-// and all user-level skip_until flags.
-// This should be called on startup to recover from incomplete settlements
-// and allow all pending requests to be retried immediately.
+// ResetSettlementState clears stale skip_until throttles on requests and users
+// so pending work can be retried immediately after restart.
+//
+// settling=true is deliberately NOT cleared here. The flag means a settlement
+// transaction may have been submitted to the contract, and the contract has no
+// replay protection — clearing it risks resubmitting the same fees and deducting
+// the user's balance a second time. Settled-but-not-cleaned rows must be
+// resolved by the reconciliation processor (or, as a stopgap, by a manual SQL
+// cleanup once the on-chain status is confirmed).
 func (d *DB) ResetSettlementState() error {
 	if err := d.db.Model(&model.Request{}).
 		Where("processed = ?", false).
-		Where("settling = ? OR skip_until IS NOT NULL", true).
-		Updates(map[string]interface{}{
-			"settling":   false,
-			"skip_until": nil,
-		}).Error; err != nil {
+		Where("skip_until IS NOT NULL").
+		Update("skip_until", nil).Error; err != nil {
 		return err
 	}
 

--- a/api/inference/internal/event/reconciliation_processor.go
+++ b/api/inference/internal/event/reconciliation_processor.go
@@ -23,6 +23,12 @@ const (
 	// DefaultExpiryBlocks is the number of blocks after which a pending settlement without a matching
 	// on-chain event is considered expired and its requests are released.
 	DefaultExpiryBlocks = uint64(200)
+	// MaxScanBlockRange caps the block window passed to a single FilterTEESettlementResult call.
+	// Public RPC nodes typically reject queries whose result set exceeds 10,000 logs; this
+	// value must be small enough that no single window can produce that many events even on
+	// high-traffic days. At ~1000 settlements/day across ~90,000 blocks/day, 50k blocks bounds
+	// any single call to a few hundred logs with comfortable headroom.
+	MaxScanBlockRange = uint64(50000)
 )
 
 // ReconciliationProcessor scans on-chain TEESettlementResult events and reconciles
@@ -98,32 +104,44 @@ func (r *ReconciliationProcessor) reconcile(ctx context.Context) {
 		return // Nothing new to process
 	}
 
+	// 4-5. Scan and process events in chunks bounded by MaxScanBlockRange so a
+	// single call cannot exceed the RPC's per-query log limit. Advance the cursor
+	// after every successful chunk so progress survives mid-loop failures.
 	fromBlock := cursor.LastBlockNumber + 1
+	for fromBlock <= safeBlock {
+		if ctx.Err() != nil {
+			return
+		}
+		toBlock := fromBlock + MaxScanBlockRange - 1
+		if toBlock > safeBlock {
+			toBlock = safeBlock
+		}
 
-	// 4. Scan events
-	events, err := r.scanEvents(ctx, fromBlock, safeBlock)
-	if err != nil {
-		r.logger.Errorf("Reconciliation: failed to scan events from block %d to %d: %v", fromBlock, safeBlock, err)
-		return
+		events, err := r.scanEvents(ctx, fromBlock, toBlock)
+		if err != nil {
+			r.logger.Errorf("Reconciliation: failed to scan events from block %d to %d: %v", fromBlock, toBlock, err)
+			return
+		}
+
+		if len(events) > 0 {
+			r.logger.Infof("Reconciliation: processing %d events from block %d to %d", len(events), fromBlock, toBlock)
+		}
+
+		for _, evt := range events {
+			r.processEvent(evt)
+		}
+
+		if err := r.db.UpdateReconciliationCursor(toBlock); err != nil {
+			r.logger.Errorf("Reconciliation: failed to update cursor to block %d: %v", toBlock, err)
+			return
+		}
+
+		fromBlock = toBlock + 1
 	}
 
-	if len(events) > 0 {
-		r.logger.Infof("Reconciliation: processing %d events from block %d to %d", len(events), fromBlock, safeBlock)
-	}
-
-	// 5. Process each event
-	for _, evt := range events {
-		r.processEvent(evt)
-	}
-
-	// 6. Expire stale pending settlements
+	// 6. Expire stale pending settlements once per tick, after all chunks scanned.
 	if safeBlock > r.expiryBlocks {
 		r.expireStaleSettlements(safeBlock - r.expiryBlocks)
-	}
-
-	// 7. Update cursor
-	if err := r.db.UpdateReconciliationCursor(safeBlock); err != nil {
-		r.logger.Errorf("Reconciliation: failed to update cursor to block %d: %v", safeBlock, err)
 	}
 }
 

--- a/api/inference/internal/event/settlement_processor.go
+++ b/api/inference/internal/event/settlement_processor.go
@@ -38,8 +38,9 @@ func NewSettlementProcessor(ctrl *ctrl.Ctrl, checkSettleInterval, forceSettleInt
 
 // Start implements controller-runtime/pkg/manager.Runnable interface
 func (s *SettlementProcessor) Start(ctx context.Context) error {
-	// Reset settlement state (settling flags + skip_until) so all pending
-	// requests are eligible for immediate settlement after restart
+	// Clear skip_until throttles so pending requests are eligible for immediate
+	// settlement after restart. The settling flag is intentionally preserved —
+	// see db.ResetSettlementState for the replay-protection rationale.
 	if err := s.ctrl.ResetSettlementState(); err != nil {
 		s.logger.Errorf("Failed to reset settlement state on startup: %s", err.Error())
 	}


### PR DESCRIPTION
## Summary

Three interlocking bugs caused settled-on-chain request rows to leak in the local DB and then be re-submitted to the contract after a restart, deducting the affected user's balance a second time. On-chain `BalanceUpdated` event reconstruction showed **~46 OG of confirmed double-charging on 2026-05-17 alone** (silent users with no compute that day still saw their balance reduced).

This PR fixes the three bugs together because they only become catastrophic in combination.

## The three bugs

### 1. `daily_stat.go` — SQL ambiguous-column failure

```sql
INSERT INTO daily_stat (date, total_requests, ...)
VALUES (UTC_DATE(), ?, ?, ?) AS new_vals
ON DUPLICATE KEY UPDATE
  total_requests = total_requests + new_vals.total_requests,  -- ambiguous in MySQL 8
  ...
```

Errors with `Error 1052 (23000): Column 'total_requests' in field list is ambiguous`. The whole `AccumulateAndDeleteRequests` transaction rolls back, leaving settled rows with `settling=true, processed=false` in the DB. ~6,500 such orphan rows accumulated on 2026-05-17 alone.

Fix: qualify the RHS column references with `daily_stat.col`.

### 2. `db/reconciliation.go` — `ResetSettlementState` cleared `settling=true`

On every startup, this function cleared `settling=true` on all `processed=false` rows. Combined with bug #1, orphan rows (already paid on-chain) were turned back into "settle me" candidates. The next settle cycle re-submitted them and the contract — which has no replay protection — deducted the user's balance again.

Fix: keep `settling=true` untouched on restart. It is the only safety latch indicating "this row may already be paid on-chain". `skip_until` throttles are still cleared as before.

### 3. `event/reconciliation_processor.go` — cursor stuck at 0

Initial cursor is 0. Each tick attempted to scan `[1, currentBlock]` for `TEESettlementResult` events in a single RPC call. Public RPCs return "result set exceeds the max limit of 10000 logs" and the cursor was only advanced on success — so it never moved. The safety net that should have cleaned up orphans was dormant from day one.

Fix: scan in chunks of `MaxScanBlockRange = 50000` blocks; advance the cursor after every successful chunk so progress is preserved across mid-loop failures.

## Verification

- `go build ./...` and `go vet ./inference/...` pass locally.
- On-chain proof of double-charging documented in the investigation report attached to ticket: silent user `0xFB000c994e48Bdc8f1a9F4796F9E0764d9f12Cd3` had exactly `-0.152058 OG` deducted three times (5/13, 5/17 15:18, 5/17 17:19) despite having no broker activity between 5/13 and 5/17.
- Across 50 silent SQL-bug users on 5/17, **47 had repeated balance reductions**; total confirmed over-charge on 5/17 alone is **~46.20 OG (~$22.65)**.

## Operational follow-up (not in this PR)

Existing orphan rows in any deployment should be cleaned once after rollout, e.g.:

```sql
DELETE FROM request WHERE settling = 1 AND processed = 0;
```

(Already executed on the affected production deployment — 6,489 rows removed.)

## Test plan

- [ ] Deploy to a non-production environment, restart broker, confirm no new `failed to delete N settled requests` errors.
- [ ] Confirm `INFO Reconciliation: processing N events from block X to Y` lines appear in event logs after first reconcile tick.
- [ ] Confirm `daily_stat` table starts receiving rows for the current date.
- [ ] Restart broker again with active settlements in flight; confirm no `BalanceUpdated` event fires for already-settled rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)