### PR TITLE
Add HTTP error types and improve error handling across services

### DIFF
--- a/api/common/errors/errors.go
+++ b/api/common/errors/errors.go
@@ -3,6 +3,7 @@ package errors
 import (
 	"errors"
 	"fmt"
+	"net/http"
 )
 
 var (
@@ -23,4 +24,55 @@ func Wrapf(err error, format string, args ...interface{}) error {
 		err = fmt.Errorf("%s: %w", fmt.Sprintf(format, args...), err)
 	}
 	return err
+}
+
+// HTTPError associates an error with an HTTP status code. When returned to a
+// gin handler through Response, the status code is used instead of the default
+// 400 Bad Request. It implements Unwrap, so errors.Is / errors.As traverse
+// into the underlying cause.
+type HTTPError struct {
+	status int
+	err    error
+}
+
+func (e *HTTPError) Error() string { return e.err.Error() }
+func (e *HTTPError) Unwrap() error { return e.err }
+func (e *HTTPError) Status() int   { return e.status }
+
+// NewHTTPError wraps err with the given HTTP status code.
+func NewHTTPError(status int, err error) error {
+	if err == nil {
+		return nil
+	}
+	return &HTTPError{status: status, err: err}
+}
+
+// NewBadRequest returns an error that maps to HTTP 400 Bad Request.
+func NewBadRequest(format string, args ...interface{}) error {
+	return &HTTPError{status: http.StatusBadRequest, err: fmt.Errorf(format, args...)}
+}
+
+// NewUnauthorized returns an error that maps to HTTP 401 Unauthorized.
+func NewUnauthorized(format string, args ...interface{}) error {
+	return &HTTPError{status: http.StatusUnauthorized, err: fmt.Errorf(format, args...)}
+}
+
+// NewForbidden returns an error that maps to HTTP 403 Forbidden.
+func NewForbidden(format string, args ...interface{}) error {
+	return &HTTPError{status: http.StatusForbidden, err: fmt.Errorf(format, args...)}
+}
+
+// NewNotFound returns an error that maps to HTTP 404 Not Found.
+func NewNotFound(format string, args ...interface{}) error {
+	return &HTTPError{status: http.StatusNotFound, err: fmt.Errorf(format, args...)}
+}
+
+// NewConflict returns an error that maps to HTTP 409 Conflict.
+func NewConflict(format string, args ...interface{}) error {
+	return &HTTPError{status: http.StatusConflict, err: fmt.Errorf(format, args...)}
+}
+
+// NewInternal returns an error that maps to HTTP 500 Internal Server Error.
+func NewInternal(format string, args ...interface{}) error {
+	return &HTTPError{status: http.StatusInternalServerError, err: fmt.Errorf(format, args...)}
 }

--- a/api/common/errors/errors.go
+++ b/api/common/errors/errors.go
@@ -73,8 +73,19 @@ func NewConflict(format string, args ...interface{}) error {
 }
 
 // NewInternal returns an error that maps to HTTP 500 Internal Server Error.
+// The message will be sanitized to the generic status text before it reaches
+// the client — use NewServiceUnavailable / NewConflict / etc. when you want
+// an actionable message to be delivered.
 func NewInternal(format string, args ...interface{}) error {
 	return &HTTPError{status: http.StatusInternalServerError, err: fmt.Errorf(format, args...)}
+}
+
+// NewServiceUnavailable returns an error that maps to HTTP 503 Service
+// Unavailable — use for conditions that are expected to resolve on retry
+// (transient filesystem unavailability, upstream backpressure, warm-up).
+// The message is delivered to the client verbatim.
+func NewServiceUnavailable(format string, args ...interface{}) error {
+	return &HTTPError{status: http.StatusServiceUnavailable, err: fmt.Errorf(format, args...)}
 }
 
 // The wrappers below attach an HTTP status to an existing error while
@@ -96,4 +107,10 @@ func NotFound(err error) error { return NewHTTPError(http.StatusNotFound, err) }
 func Conflict(err error) error { return NewHTTPError(http.StatusConflict, err) }
 
 // Internal wraps err with HTTP 500 Internal Server Error.
+// The response body is sanitized before reaching the client (see Response).
 func Internal(err error) error { return NewHTTPError(http.StatusInternalServerError, err) }
+
+// ServiceUnavailable wraps err with HTTP 503 Service Unavailable.
+func ServiceUnavailable(err error) error {
+	return NewHTTPError(http.StatusServiceUnavailable, err)
+}

--- a/api/common/errors/errors.go
+++ b/api/common/errors/errors.go
@@ -76,3 +76,24 @@ func NewConflict(format string, args ...interface{}) error {
 func NewInternal(format string, args ...interface{}) error {
 	return &HTTPError{status: http.StatusInternalServerError, err: fmt.Errorf(format, args...)}
 }
+
+// The wrappers below attach an HTTP status to an existing error while
+// preserving the error chain (so errors.Is / errors.As continue to traverse
+// into the original cause). Prefer these over NewXxx("%s", err.Error()) when
+// you already have an error value — the format-string constructors flatten
+// the chain by design.
+
+// Unauthorized wraps err with HTTP 401 Unauthorized.
+func Unauthorized(err error) error { return NewHTTPError(http.StatusUnauthorized, err) }
+
+// Forbidden wraps err with HTTP 403 Forbidden.
+func Forbidden(err error) error { return NewHTTPError(http.StatusForbidden, err) }
+
+// NotFound wraps err with HTTP 404 Not Found.
+func NotFound(err error) error { return NewHTTPError(http.StatusNotFound, err) }
+
+// Conflict wraps err with HTTP 409 Conflict.
+func Conflict(err error) error { return NewHTTPError(http.StatusConflict, err) }
+
+// Internal wraps err with HTTP 500 Internal Server Error.
+func Internal(err error) error { return NewHTTPError(http.StatusInternalServerError, err) }

--- a/api/common/errors/response.go
+++ b/api/common/errors/response.go
@@ -6,7 +6,15 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// Response writes err to the gin context as a JSON error body. If err (or any
+// error in its chain) is an *HTTPError, its status code is used; otherwise the
+// default is 400 Bad Request.
 func Response(ctx *gin.Context, err error) {
-	ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	status := http.StatusBadRequest
+	var httpErr *HTTPError
+	if As(err, &httpErr) {
+		status = httpErr.Status()
+	}
+	ctx.JSON(status, gin.H{"error": err.Error()})
 	ctx.Abort()
 }

--- a/api/common/errors/response.go
+++ b/api/common/errors/response.go
@@ -11,11 +11,11 @@ import (
 // error in its chain) is an *HTTPError, its status code is used; otherwise the
 // default is 400 Bad Request.
 //
-// For 5xx responses the underlying error text is NOT sent to the client —
-// internal errors can contain driver messages, filesystem paths, schema
-// details, etc., which must not leak to unauthenticated callers. The full
-// error is logged server-side (via logrus, the project's standard logger)
-// and the client receives a generic status-text body.
+// Only 500 Internal Server Error is sanitized: its body is the generic status
+// text and the full error is logged server-side via logrus. Other 5xx codes
+// (503 Service Unavailable, 504 Gateway Timeout, etc.) have client-facing
+// semantics where the message is actionable — those are passed through as-is,
+// but still logged at Error level so operators see them too.
 func Response(ctx *gin.Context, err error) {
 	status := http.StatusBadRequest
 	var httpErr *HTTPError
@@ -30,7 +30,9 @@ func Response(ctx *gin.Context, err error) {
 			"path":   ctx.FullPath(),
 			"method": ctx.Request.Method,
 		}).Error("handler returned server error")
-		msg = http.StatusText(status)
+		if status == http.StatusInternalServerError {
+			msg = http.StatusText(status)
+		}
 	}
 
 	ctx.JSON(status, gin.H{"error": msg})

--- a/api/common/errors/response.go
+++ b/api/common/errors/response.go
@@ -4,17 +4,35 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	log "github.com/sirupsen/logrus"
 )
 
 // Response writes err to the gin context as a JSON error body. If err (or any
 // error in its chain) is an *HTTPError, its status code is used; otherwise the
 // default is 400 Bad Request.
+//
+// For 5xx responses the underlying error text is NOT sent to the client —
+// internal errors can contain driver messages, filesystem paths, schema
+// details, etc., which must not leak to unauthenticated callers. The full
+// error is logged server-side (via logrus, the project's standard logger)
+// and the client receives a generic status-text body.
 func Response(ctx *gin.Context, err error) {
 	status := http.StatusBadRequest
 	var httpErr *HTTPError
 	if As(err, &httpErr) {
 		status = httpErr.Status()
 	}
-	ctx.JSON(status, gin.H{"error": err.Error()})
+
+	msg := err.Error()
+	if status >= 500 {
+		log.WithError(err).WithFields(log.Fields{
+			"status": status,
+			"path":   ctx.FullPath(),
+			"method": ctx.Request.Method,
+		}).Error("handler returned server error")
+		msg = http.StatusText(status)
+	}
+
+	ctx.JSON(status, gin.H{"error": msg})
 	ctx.Abort()
 }

--- a/api/common/errors/response_test.go
+++ b/api/common/errors/response_test.go
@@ -1,12 +1,15 @@
 package errors
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	log "github.com/sirupsen/logrus"
 )
 
 func TestResponse_StatusMapping(t *testing.T) {
@@ -16,23 +19,29 @@ func TestResponse_StatusMapping(t *testing.T) {
 		name       string
 		err        error
 		wantStatus int
+		// wantBody is compared to the JSON "error" field. For 5xx statuses
+		// the body is expected to be sanitized (generic status text) so the
+		// underlying error message is not leaked to the client.
+		wantBody string
 	}{
-		{"plain error defaults to 400", New("boom"), http.StatusBadRequest},
-		{"bad request", NewBadRequest("bad"), http.StatusBadRequest},
-		{"unauthorized", NewUnauthorized("no creds"), http.StatusUnauthorized},
-		{"forbidden", NewForbidden("nope"), http.StatusForbidden},
-		{"not found", NewNotFound("missing"), http.StatusNotFound},
-		{"conflict", NewConflict("busy"), http.StatusConflict},
-		{"internal", NewInternal("oops"), http.StatusInternalServerError},
-		{"wrapped unauthorized", Wrap(NewUnauthorized("bad sig"), "provider"), http.StatusUnauthorized},
-		{"wrap helper preserves chain status", Unauthorized(New("bad sig")), http.StatusUnauthorized},
-		{"wrap helper through Wrap", Wrap(Unauthorized(New("bad sig")), "provider"), http.StatusUnauthorized},
+		{"plain error defaults to 400", New("boom"), http.StatusBadRequest, "boom"},
+		{"bad request", NewBadRequest("bad"), http.StatusBadRequest, "bad"},
+		{"unauthorized", NewUnauthorized("no creds"), http.StatusUnauthorized, "no creds"},
+		{"forbidden", NewForbidden("nope"), http.StatusForbidden, "nope"},
+		{"not found", NewNotFound("missing"), http.StatusNotFound, "missing"},
+		{"conflict", NewConflict("busy"), http.StatusConflict, "busy"},
+		{"internal is sanitized", NewInternal("driver oops"), http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError)},
+		{"internal wrap is sanitized", Internal(New("schema column not found")), http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError)},
+		{"wrapped unauthorized", Wrap(NewUnauthorized("bad sig"), "provider"), http.StatusUnauthorized, "provider: bad sig"},
+		{"wrap helper preserves chain status", Unauthorized(New("bad sig")), http.StatusUnauthorized, "bad sig"},
+		{"wrap helper through Wrap", Wrap(Unauthorized(New("bad sig")), "provider"), http.StatusUnauthorized, "provider: bad sig"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rec := httptest.NewRecorder()
 			ctx, _ := gin.CreateTestContext(rec)
+			ctx.Request = httptest.NewRequest(http.MethodGet, "/test", nil)
 			Response(ctx, tt.err)
 			if rec.Code != tt.wantStatus {
 				t.Fatalf("status = %d, want %d", rec.Code, tt.wantStatus)
@@ -42,10 +51,49 @@ func TestResponse_StatusMapping(t *testing.T) {
 			if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
 				t.Fatalf("unmarshal body: %v", err)
 			}
-			if body["error"] != tt.err.Error() {
-				t.Fatalf("body error = %q, want %q", body["error"], tt.err.Error())
+			if body["error"] != tt.wantBody {
+				t.Fatalf("body error = %q, want %q", body["error"], tt.wantBody)
 			}
 		})
+	}
+}
+
+// TestResponse_5xxLogsServerSide verifies that a 5xx Response logs the full
+// underlying error to the server-side logger even though the client sees a
+// generic message. This guards against the "silent on the server, chatty on
+// the wire" failure mode.
+func TestResponse_5xxLogsServerSide(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var buf bytes.Buffer
+	prevOut := log.StandardLogger().Out
+	prevLevel := log.StandardLogger().Level
+	log.SetOutput(&buf)
+	log.SetLevel(log.InfoLevel)
+	t.Cleanup(func() {
+		log.SetOutput(prevOut)
+		log.SetLevel(prevLevel)
+	})
+
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = httptest.NewRequest(http.MethodGet, "/test", nil)
+
+	sensitive := "driver detail: connection refused at /var/lib/mysql.sock"
+	Response(ctx, NewInternal("%s", sensitive))
+
+	// Client sees sanitized body.
+	var body map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	if strings.Contains(body["error"], "driver detail") {
+		t.Fatalf("5xx body leaked internal detail: %q", body["error"])
+	}
+
+	// Server log captures the full error.
+	if !strings.Contains(buf.String(), sensitive) {
+		t.Fatalf("expected server log to contain %q, got %q", sensitive, buf.String())
 	}
 }
 

--- a/api/common/errors/response_test.go
+++ b/api/common/errors/response_test.go
@@ -32,6 +32,8 @@ func TestResponse_StatusMapping(t *testing.T) {
 		{"conflict", NewConflict("busy"), http.StatusConflict, "busy"},
 		{"internal is sanitized", NewInternal("driver oops"), http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError)},
 		{"internal wrap is sanitized", Internal(New("schema column not found")), http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError)},
+		{"service unavailable is actionable", NewServiceUnavailable("retry shortly"), http.StatusServiceUnavailable, "retry shortly"},
+		{"service unavailable wrap preserves message", ServiceUnavailable(New("upstream warming up")), http.StatusServiceUnavailable, "upstream warming up"},
 		{"wrapped unauthorized", Wrap(NewUnauthorized("bad sig"), "provider"), http.StatusUnauthorized, "provider: bad sig"},
 		{"wrap helper preserves chain status", Unauthorized(New("bad sig")), http.StatusUnauthorized, "bad sig"},
 		{"wrap helper through Wrap", Wrap(Unauthorized(New("bad sig")), "provider"), http.StatusUnauthorized, "provider: bad sig"},

--- a/api/common/errors/response_test.go
+++ b/api/common/errors/response_test.go
@@ -25,6 +25,8 @@ func TestResponse_StatusMapping(t *testing.T) {
 		{"conflict", NewConflict("busy"), http.StatusConflict},
 		{"internal", NewInternal("oops"), http.StatusInternalServerError},
 		{"wrapped unauthorized", Wrap(NewUnauthorized("bad sig"), "provider"), http.StatusUnauthorized},
+		{"wrap helper preserves chain status", Unauthorized(New("bad sig")), http.StatusUnauthorized},
+		{"wrap helper through Wrap", Wrap(Unauthorized(New("bad sig")), "provider"), http.StatusUnauthorized},
 	}
 
 	for _, tt := range tests {
@@ -44,5 +46,22 @@ func TestResponse_StatusMapping(t *testing.T) {
 				t.Fatalf("body error = %q, want %q", body["error"], tt.err.Error())
 			}
 		})
+	}
+}
+
+func TestWrapHelpersPreserveChain(t *testing.T) {
+	sentinel := New("sentinel")
+	cases := []error{
+		Unauthorized(sentinel),
+		Forbidden(sentinel),
+		NotFound(sentinel),
+		Conflict(sentinel),
+		Internal(sentinel),
+		Wrap(Unauthorized(sentinel), "provider"),
+	}
+	for _, err := range cases {
+		if !Is(err, sentinel) {
+			t.Fatalf("wrap helper broke error chain for %v", err)
+		}
 	}
 }

--- a/api/common/errors/response_test.go
+++ b/api/common/errors/response_test.go
@@ -1,0 +1,48 @@
+package errors
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestResponse_StatusMapping(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name       string
+		err        error
+		wantStatus int
+	}{
+		{"plain error defaults to 400", New("boom"), http.StatusBadRequest},
+		{"bad request", NewBadRequest("bad"), http.StatusBadRequest},
+		{"unauthorized", NewUnauthorized("no creds"), http.StatusUnauthorized},
+		{"forbidden", NewForbidden("nope"), http.StatusForbidden},
+		{"not found", NewNotFound("missing"), http.StatusNotFound},
+		{"conflict", NewConflict("busy"), http.StatusConflict},
+		{"internal", NewInternal("oops"), http.StatusInternalServerError},
+		{"wrapped unauthorized", Wrap(NewUnauthorized("bad sig"), "provider"), http.StatusUnauthorized},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			ctx, _ := gin.CreateTestContext(rec)
+			Response(ctx, tt.err)
+			if rec.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d", rec.Code, tt.wantStatus)
+			}
+
+			var body map[string]string
+			if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+				t.Fatalf("unmarshal body: %v", err)
+			}
+			if body["error"] != tt.err.Error() {
+				t.Fatalf("body error = %q, want %q", body["error"], tt.err.Error())
+			}
+		})
+	}
+}

--- a/api/fine-tuning/internal/ctrl/task.go
+++ b/api/fine-tuning/internal/ctrl/task.go
@@ -81,13 +81,30 @@ func (c *Ctrl) CreateTask(ctx context.Context, task *schema.Task) (*uuid.UUID, e
 
 func (c *Ctrl) CancelTask(ctx context.Context, task *schema.Task) error {
 	if err := c.validateSignature(task); err != nil {
-		return errors.NewUnauthorized("%s", err.Error())
+		return errors.Unauthorized(err)
+	}
+
+	// Resolve the task up front so we can distinguish "does not exist" (404)
+	// from "exists but cannot be cancelled in its current state" (409). Both
+	// surface as RowsAffected==0 from db.CancelTask, which is ambiguous.
+	existing, err := c.db.GetTask(task.ID)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return errors.NewNotFound("task %s not found", task.ID.String())
+		}
+		return errors.Internal(errors.Wrap(err, "load task"))
+	}
+	if existing.UserAddress != task.UserAddress {
+		return errors.NewForbidden("task does not belong to this user")
 	}
 
 	if err := c.db.CancelTask(task.ID, task.UserAddress); err != nil {
-		// Cancellation only succeeds from Init/SettingUp/SetUp; any other state
-		// (or missing task) is a conflict from the client's perspective.
-		return errors.NewConflict("%s", err.Error())
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			// Task exists and owner matches, so a missing row on UPDATE means
+			// the task is in a terminal/non-cancellable state.
+			return errors.NewConflict("task cannot be cancelled in its current state (%s)", existing.Progress)
+		}
+		return errors.Internal(errors.Wrap(err, "cancel task"))
 	}
 	return nil
 }
@@ -503,10 +520,13 @@ func (c *Ctrl) GetLoRAModel(id *uuid.UUID, userAddress string) (string, error) {
 	// Build paths
 	paths := utils.NewTaskPaths(filepath.Join(utils.GetDataDir(), id.String()))
 
-	// Return encrypted file path (created by finalizer)
+	// Return encrypted file path (created by finalizer).
+	// If progress is Delivered/UserAcknowledged/Finished (checked above) the
+	// finalizer should have written this file; its absence is a broker-side
+	// inconsistency, not a missing resource from the user's perspective.
 	encryptedFilePath := paths.Output + "_encrypted.data"
 	if _, err := os.Stat(encryptedFilePath); os.IsNotExist(err) {
-		return "", errors.NewNotFound("encrypted LoRA file not found. The task may not have completed encryption yet")
+		return "", errors.NewInternal("encrypted LoRA file missing for task %s in state %s", id.String(), progress)
 	}
 
 	return encryptedFilePath, nil

--- a/api/fine-tuning/internal/ctrl/task.go
+++ b/api/fine-tuning/internal/ctrl/task.go
@@ -529,11 +529,14 @@ func (c *Ctrl) GetLoRAModel(id *uuid.UUID, userAddress string) (string, error) {
 
 	// Return encrypted file path (created by finalizer).
 	// If progress is Delivered/UserAcknowledged/Finished (checked above) the
-	// finalizer should have written this file; its absence is a broker-side
-	// inconsistency, not a missing resource from the user's perspective.
+	// finalizer should have written this file. A missing file here is almost
+	// always transient — filesystem remount, cleanup race, cold distributed
+	// cache — and is safe for the client to retry, so surface it as 503
+	// Service Unavailable rather than 500 (which signals a broker bug and is
+	// treated as non-retriable by most SDKs).
 	encryptedFilePath := paths.Output + "_encrypted.data"
 	if _, err := os.Stat(encryptedFilePath); os.IsNotExist(err) {
-		return "", errors.NewInternal("encrypted LoRA file missing for task %s in state %s", id.String(), progress)
+		return "", errors.NewServiceUnavailable("encrypted LoRA not yet available for task %s (state %s); retry shortly", id.String(), progress)
 	}
 
 	return encryptedFilePath, nil

--- a/api/fine-tuning/internal/ctrl/task.go
+++ b/api/fine-tuning/internal/ctrl/task.go
@@ -101,8 +101,15 @@ func (c *Ctrl) CancelTask(ctx context.Context, task *schema.Task) error {
 	if err := c.db.CancelTask(task.ID, task.UserAddress); err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			// Task exists and owner matches, so a missing row on UPDATE means
-			// the task is in a terminal/non-cancellable state.
-			return errors.NewConflict("task cannot be cancelled in its current state (%s)", existing.Progress)
+			// the task is in a terminal/non-cancellable state. Re-read once so
+			// the message reflects the current progress rather than the value
+			// we read before the UPDATE (a concurrent writer may have advanced
+			// the state in between).
+			current := existing.Progress
+			if refreshed, rerr := c.db.GetTask(task.ID); rerr == nil {
+				current = refreshed.Progress
+			}
+			return errors.NewConflict("task cannot be cancelled in its current state (%s)", current)
 		}
 		return errors.Internal(errors.Wrap(err, "cancel task"))
 	}
@@ -150,7 +157,7 @@ func (c *Ctrl) GetTask(id *uuid.UUID) (schema.Task, error) {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return schema.Task{}, errors.NewNotFound("task %s not found", id.String())
 		}
-		return schema.Task{}, errors.Wrap(err, "get service from db")
+		return schema.Task{}, errors.Internal(errors.Wrap(err, "get service from db"))
 	}
 
 	return *schema.GenerateSchemaTask(&task), nil
@@ -159,7 +166,7 @@ func (c *Ctrl) GetTask(id *uuid.UUID) (schema.Task, error) {
 func (c *Ctrl) ListTask(ctx context.Context, userAddress string, latest, desc bool) ([]schema.Task, error) {
 	tasks, err := c.db.ListTask(userAddress, latest, desc)
 	if err != nil {
-		return nil, errors.Wrap(err, "get delivered tasks")
+		return nil, errors.Internal(errors.Wrap(err, "get delivered tasks"))
 	}
 	taskRes := make([]schema.Task, len(tasks))
 	for i := range tasks {
@@ -175,7 +182,7 @@ func (c *Ctrl) GetProgress(id *uuid.UUID, userAddress string) (string, error) {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return "", errors.NewNotFound("task %s not found", id.String())
 		}
-		return "", err
+		return "", errors.Internal(errors.Wrap(err, "get task"))
 	}
 
 	// Verify user owns this task
@@ -501,7 +508,7 @@ func (c *Ctrl) GetLoRAModel(id *uuid.UUID, userAddress string) (string, error) {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return "", errors.NewNotFound("task %s not found", id.String())
 		}
-		return "", errors.Wrap(err, "get task from db")
+		return "", errors.Internal(errors.Wrap(err, "get task from db"))
 	}
 
 	// Verify user owns this task

--- a/api/fine-tuning/internal/ctrl/task.go
+++ b/api/fine-tuning/internal/ctrl/task.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/google/uuid"
+	"gorm.io/gorm"
 
 	"github.com/0glabs/0g-serving-broker/common/errors"
 	constant "github.com/0glabs/0g-serving-broker/fine-tuning/const"
@@ -51,10 +52,10 @@ func (c *Ctrl) CreateTask(ctx context.Context, task *schema.Task) (*uuid.UUID, e
 		return nil, err
 	}
 	if count > int64(c.config.MaxTaskQueueSize) {
-		return nil, errors.New("task queue is full")
+		return nil, errors.NewConflict("task queue is full")
 	}
 	if count != 0 && !task.Wait {
-		return nil, errors.New("cannot create a new task while there are in-progress tasks")
+		return nil, errors.NewConflict("cannot create a new task while there are in-progress tasks")
 	}
 
 	dbTask := task.GenerateDBTask()
@@ -80,10 +81,15 @@ func (c *Ctrl) CreateTask(ctx context.Context, task *schema.Task) (*uuid.UUID, e
 
 func (c *Ctrl) CancelTask(ctx context.Context, task *schema.Task) error {
 	if err := c.validateSignature(task); err != nil {
-		return err
+		return errors.NewUnauthorized("%s", err.Error())
 	}
 
-	return c.db.CancelTask(task.ID, task.UserAddress)
+	if err := c.db.CancelTask(task.ID, task.UserAddress); err != nil {
+		// Cancellation only succeeds from Init/SettingUp/SetUp; any other state
+		// (or missing task) is a conflict from the client's perspective.
+		return errors.NewConflict("%s", err.Error())
+	}
+	return nil
 }
 
 func (*Ctrl) validateSignature(task *schema.Task) error {
@@ -124,6 +130,9 @@ func (*Ctrl) validateSignature(task *schema.Task) error {
 func (c *Ctrl) GetTask(id *uuid.UUID) (schema.Task, error) {
 	task, err := c.db.GetTask(id)
 	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return schema.Task{}, errors.NewNotFound("task %s not found", id.String())
+		}
 		return schema.Task{}, errors.Wrap(err, "get service from db")
 	}
 
@@ -146,12 +155,15 @@ func (c *Ctrl) ListTask(ctx context.Context, userAddress string, latest, desc bo
 func (c *Ctrl) GetProgress(id *uuid.UUID, userAddress string) (string, error) {
 	task, err := c.db.GetTask(id)
 	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return "", errors.NewNotFound("task %s not found", id.String())
+		}
 		return "", err
 	}
 
 	// Verify user owns this task
 	if task.UserAddress != userAddress {
-		return "", errors.New("unauthorized: task does not belong to this user")
+		return "", errors.NewForbidden("task does not belong to this user")
 	}
 
 	return filepath.Join(utils.GetDataDir(), id.String(), utils.TaskLogFileName), nil
@@ -464,17 +476,20 @@ func (c *Ctrl) VerifyUploadSignature(userAddress string, signature string, times
 // The file is encrypted with AES and the key is available through contract settlement
 func (c *Ctrl) GetLoRAModel(id *uuid.UUID, userAddress string) (string, error) {
 	if id == nil {
-		return "", errors.New("task ID cannot be nil")
+		return "", errors.NewBadRequest("task ID cannot be nil")
 	}
 
 	task, err := c.db.GetTask(id)
 	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return "", errors.NewNotFound("task %s not found", id.String())
+		}
 		return "", errors.Wrap(err, "get task from db")
 	}
 
 	// Verify user owns this task
 	if task.UserAddress != userAddress {
-		return "", errors.New("unauthorized: task does not belong to this user")
+		return "", errors.NewForbidden("task does not belong to this user")
 	}
 
 	// Check if task is delivered (encryption completed)
@@ -482,7 +497,7 @@ func (c *Ctrl) GetLoRAModel(id *uuid.UUID, userAddress string) (string, error) {
 	if progress != db.ProgressStateDelivered.String() &&
 		progress != db.ProgressStateUserAcknowledged.String() &&
 		progress != db.ProgressStateFinished.String() {
-		return "", errors.New("task is not ready for download. Please wait for 'Delivered' status")
+		return "", errors.NewConflict("task is not ready for download. Please wait for 'Delivered' status")
 	}
 
 	// Build paths
@@ -491,7 +506,7 @@ func (c *Ctrl) GetLoRAModel(id *uuid.UUID, userAddress string) (string, error) {
 	// Return encrypted file path (created by finalizer)
 	encryptedFilePath := paths.Output + "_encrypted.data"
 	if _, err := os.Stat(encryptedFilePath); os.IsNotExist(err) {
-		return "", errors.New("encrypted LoRA file not found. The task may not have completed encryption yet")
+		return "", errors.NewNotFound("encrypted LoRA file not found. The task may not have completed encryption yet")
 	}
 
 	return encryptedFilePath, nil

--- a/api/fine-tuning/internal/db/service.go
+++ b/api/fine-tuning/internal/db/service.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"gorm.io/gorm"
 )
 
 func (d *DB) AddTask(task *Task) error {
@@ -172,13 +173,15 @@ func (d *DB) CancelTask(id *uuid.UUID, userAddress string) error {
 		ProgressStateSetUp.String(),
 	}
 
-	ret := d.db.Model(&Task{}).Where("progress IN ? AND user_address = ?", validStates, userAddress).Update("progress", ProgressStateFailed.String())
+	ret := d.db.Model(&Task{}).Where("id = ? AND user_address = ? AND progress IN ?", id, userAddress, validStates).Update("progress", ProgressStateFailed.String())
 	if ret.Error != nil {
 		return ret.Error
 	}
 
 	if ret.RowsAffected == 0 {
-		return errors.New(fmt.Sprintf("Failed to cancel task: record not found."))
+		// Whether the row is truly absent or just in a non-cancellable state
+		// is resolved by the caller via a follow-up lookup (see ctrl.CancelTask).
+		return gorm.ErrRecordNotFound
 	}
 
 	return nil

--- a/api/fine-tuning/internal/db/service_test.go
+++ b/api/fine-tuning/internal/db/service_test.go
@@ -1,0 +1,153 @@
+//go:build integration
+
+package db
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/testcontainers/testcontainers-go"
+	tcmysql "github.com/testcontainers/testcontainers-go/modules/mysql"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+	"gorm.io/gorm/schema"
+)
+
+func setupTestDB(t *testing.T) *DB {
+	t.Helper()
+	ctx := context.Background()
+
+	container, err := tcmysql.Run(ctx, "mysql:8.0",
+		tcmysql.WithDatabase("testdb"),
+		tcmysql.WithUsername("test"),
+		tcmysql.WithPassword("test"),
+	)
+	if err != nil {
+		t.Fatalf("start mysql container: %v", err)
+	}
+	t.Cleanup(func() { testcontainers.CleanupContainer(t, container) })
+
+	host, err := container.Host(ctx)
+	if err != nil {
+		t.Fatalf("get container host: %v", err)
+	}
+	port, err := container.MappedPort(ctx, "3306/tcp")
+	if err != nil {
+		t.Fatalf("get container port: %v", err)
+	}
+
+	dsn := fmt.Sprintf("test:test@tcp(%s:%s)/testdb?charset=utf8mb4&parseTime=True&loc=Local", host, port.Port())
+	gdb, err := gorm.Open(mysql.Open(dsn), &gorm.Config{
+		NamingStrategy: schema.NamingStrategy{SingularTable: true},
+	})
+	if err != nil {
+		t.Fatalf("connect to mysql: %v", err)
+	}
+	if err := gdb.AutoMigrate(&Task{}); err != nil {
+		t.Fatalf("auto-migrate: %v", err)
+	}
+	return &DB{db: gdb}
+}
+
+func insertTask(t *testing.T, d *DB, userAddress, progress string) *uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	task := &Task{
+		ID:                  &id,
+		UserAddress:         userAddress,
+		UserPublicKey:       "0xpub",
+		PreTrainedModelHash: "0xmodel",
+		DatasetHash:         "0xdata",
+		TrainingParams:      "{}",
+		Fee:                 "0x0",
+		Nonce:               "0x0",
+		Signature:           "0xsig",
+		Progress:            progress,
+	}
+	if err := d.AddTask(task); err != nil {
+		t.Fatalf("seed task: %v", err)
+	}
+	return &id
+}
+
+// TestCancelTask_OnlyAffectsTargetedRow is a regression guard for a
+// data-integrity bug: an earlier version of DB.CancelTask's WHERE clause
+// omitted "id = ?", meaning a cancel request for task A would flip every
+// cancellable task owned by the same user (including sibling B) to Failed.
+// The fixed query targets a single row; this test asserts exactly that.
+func TestCancelTask_OnlyAffectsTargetedRow(t *testing.T) {
+	d := setupTestDB(t)
+
+	user := "0xUser"
+	// Three siblings owned by the same user, all in a cancellable state.
+	targetID := insertTask(t, d, user, ProgressStateInit.String())
+	siblingA := insertTask(t, d, user, ProgressStateSettingUp.String())
+	siblingB := insertTask(t, d, user, ProgressStateSetUp.String())
+	// A different user's task in a cancellable state — must also be untouched.
+	otherUserID := insertTask(t, d, "0xOther", ProgressStateInit.String())
+
+	if err := d.CancelTask(targetID, user); err != nil {
+		t.Fatalf("CancelTask: %v", err)
+	}
+
+	// Only the targeted task should be Failed; the others keep their state.
+	assertProgress(t, d, targetID, ProgressStateFailed.String())
+	assertProgress(t, d, siblingA, ProgressStateSettingUp.String())
+	assertProgress(t, d, siblingB, ProgressStateSetUp.String())
+	assertProgress(t, d, otherUserID, ProgressStateInit.String())
+}
+
+// TestCancelTask_RowsAffectedZeroReturnsRecordNotFound exercises the
+// sentinel contract with db/ctrl: RowsAffected==0 (task missing or in a
+// non-cancellable state) must surface as gorm.ErrRecordNotFound so callers
+// can distinguish it from driver errors.
+func TestCancelTask_RowsAffectedZeroReturnsRecordNotFound(t *testing.T) {
+	d := setupTestDB(t)
+
+	cases := []struct {
+		name string
+		seed func() *uuid.UUID
+	}{
+		{
+			name: "missing task",
+			seed: func() *uuid.UUID { id := uuid.New(); return &id },
+		},
+		{
+			name: "non-cancellable state (Trained)",
+			seed: func() *uuid.UUID {
+				return insertTask(t, d, "0xUser", ProgressStateTrained.String())
+			},
+		},
+		{
+			name: "wrong owner",
+			seed: func() *uuid.UUID {
+				return insertTask(t, d, "0xOwner", ProgressStateInit.String())
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			id := tc.seed()
+			err := d.CancelTask(id, "0xUser")
+			if err == nil {
+				t.Fatalf("want error, got nil")
+			}
+			if err != gorm.ErrRecordNotFound {
+				t.Fatalf("want gorm.ErrRecordNotFound, got %v", err)
+			}
+		})
+	}
+}
+
+func assertProgress(t *testing.T, d *DB, id *uuid.UUID, want string) {
+	t.Helper()
+	task, err := d.GetTask(id)
+	if err != nil {
+		t.Fatalf("GetTask(%s): %v", id, err)
+	}
+	if task.Progress != want {
+		t.Fatalf("task %s progress = %q, want %q", id, task.Progress, want)
+	}
+}

--- a/api/fine-tuning/internal/handler/handler.go
+++ b/api/fine-tuning/internal/handler/handler.go
@@ -45,10 +45,13 @@ func (h *Handler) Register(r *gin.Engine) {
 	group.GET("/model/desc/:name", h.GetModelDesc)
 }
 
+// handleBrokerError routes err to errors.Response, optionally prefixing it
+// with a short context string for server-side debuggability. Client body
+// semantics come from the error's HTTP status code, not from a synthetic
+// "Provider" prefix — bodies are uniform across all handlers.
 func handleBrokerError(ctx *gin.Context, err error, context string) {
-	info := "Provider"
 	if context != "" {
-		info += (": " + context)
+		err = errors.Wrap(err, context)
 	}
-	errors.Response(ctx, errors.Wrap(err, info))
+	errors.Response(ctx, err)
 }

--- a/api/fine-tuning/internal/handler/handler_test.go
+++ b/api/fine-tuning/internal/handler/handler_test.go
@@ -22,17 +22,19 @@ import (
 func TestHandleBrokerError_StatusCodes(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
+	const routeContext = "test route"
+
 	tests := []struct {
 		name       string
 		err        error
 		wantStatus int
 		// wantBodyContains is a substring that must appear in the JSON error
-		// field after the handler wraps with the "Provider: <context>" prefix.
-		// For 5xx the body is sanitized, so the field holds the generic text.
+		// field. For 5xx the body is sanitized, so the field holds the
+		// generic status-text rather than the underlying error message.
 		wantBodyContains string
-		// sanitized5xx indicates the response body is not expected to include
-		// the "Provider" prefix or the underlying error text — the handler
-		// swaps it for a generic status message and logs details server-side.
+		// sanitized5xx marks cases where the body must not include the
+		// underlying error text — the handler swaps it for a generic status
+		// message and logs details server-side.
 		sanitized5xx bool
 	}{
 		{
@@ -85,6 +87,9 @@ func TestHandleBrokerError_StatusCodes(t *testing.T) {
 			wantBodyContains: "invalid sig v",
 		},
 		{
+			// Sends a typed error through handleBrokerError's errors.Wrap and
+			// asserts the HTTPError status + underlying message both survive
+			// the wrap — this is the effective chain-preservation guarantee.
 			name:             "typed error survives errors.Wrap inside handleBrokerError",
 			err:              errors.NotFound(gorm.ErrRecordNotFound),
 			wantStatus:       http.StatusNotFound,
@@ -96,7 +101,7 @@ func TestHandleBrokerError_StatusCodes(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := gin.New()
 			r.GET("/boom", func(c *gin.Context) {
-				handleBrokerError(c, tt.err, "test route")
+				handleBrokerError(c, tt.err, routeContext)
 			})
 
 			req := httptest.NewRequest(http.MethodGet, "/boom", nil)
@@ -114,48 +119,23 @@ func TestHandleBrokerError_StatusCodes(t *testing.T) {
 			if !strings.Contains(body["error"], tt.wantBodyContains) {
 				t.Fatalf("body error %q does not contain %q", body["error"], tt.wantBodyContains)
 			}
+			// No handler should synthesise a "Provider" prefix — bodies must
+			// be uniform across direct errors.Response calls and handleBrokerError.
+			if strings.HasPrefix(body["error"], "Provider") {
+				t.Fatalf("body error %q contains legacy Provider prefix", body["error"])
+			}
 			if tt.sanitized5xx {
 				// 5xx responses must not leak the underlying error text.
 				if strings.Contains(body["error"], "broker inconsistency") {
 					t.Fatalf("5xx body leaked internal detail: %q", body["error"])
 				}
-				if strings.HasPrefix(body["error"], "Provider") {
-					t.Fatalf("5xx body should be generic, got %q", body["error"])
-				}
 			} else {
-				// handleBrokerError prefixes with "Provider" for continuity
-				// with how client-facing errors are currently labelled.
-				if !strings.HasPrefix(body["error"], "Provider") {
-					t.Fatalf("body error %q missing Provider prefix", body["error"])
+				// Non-5xx bodies should carry the handleBrokerError context
+				// so the caller can identify which handler failed.
+				if !strings.Contains(body["error"], routeContext) {
+					t.Fatalf("body error %q missing route context %q", body["error"], routeContext)
 				}
 			}
 		})
-	}
-}
-
-// TestHandleBrokerError_PreservesChain verifies that when a typed error is
-// wrapped by handleBrokerError (which calls errors.Wrap), the original error
-// is still reachable via errors.Is. This matters for the review finding that
-// NewXxx("%s", err.Error()) flattens the chain — the wrap helpers must not.
-func TestHandleBrokerError_PreservesChain(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-
-	sentinel := errors.New("sentinel cause")
-	wrapped := errors.Unauthorized(sentinel)
-
-	var captured error
-	r := gin.New()
-	r.GET("/boom", func(c *gin.Context) {
-		// Replicate what handleBrokerError does so we can capture the final
-		// error value that reaches errors.Response.
-		captured = errors.Wrap(wrapped, "Provider: test")
-		handleBrokerError(c, wrapped, "test")
-	})
-
-	req := httptest.NewRequest(http.MethodGet, "/boom", nil)
-	r.ServeHTTP(httptest.NewRecorder(), req)
-
-	if !errors.Is(captured, sentinel) {
-		t.Fatalf("sentinel cause lost through handler wrap chain")
 	}
 }

--- a/api/fine-tuning/internal/handler/handler_test.go
+++ b/api/fine-tuning/internal/handler/handler_test.go
@@ -81,6 +81,14 @@ func TestHandleBrokerError_StatusCodes(t *testing.T) {
 			sanitized5xx:     true,
 		},
 		{
+			// 503 is retry-friendly and must keep the actionable message so
+			// SDKs can distinguish "retry shortly" from a generic broker bug.
+			name:             "NewServiceUnavailable -> 503 (actionable body)",
+			err:              errors.NewServiceUnavailable("encrypted LoRA not yet available; retry shortly"),
+			wantStatus:       http.StatusServiceUnavailable,
+			wantBodyContains: "retry shortly",
+		},
+		{
 			name:             "chain-preserving wrap -> 401",
 			err:              errors.Unauthorized(errors.New("invalid sig v")),
 			wantStatus:       http.StatusUnauthorized,

--- a/api/fine-tuning/internal/handler/handler_test.go
+++ b/api/fine-tuning/internal/handler/handler_test.go
@@ -1,0 +1,145 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+
+	"github.com/0glabs/0g-serving-broker/common/errors"
+)
+
+// TestHandleBrokerError_StatusCodes exercises the handler -> errors.Response
+// plumbing end-to-end: a handler that calls handleBrokerError with a typed
+// error must surface the attached HTTP status through the gin response,
+// while plain errors still default to 400. This guards against regressions
+// where a call site forgets to route through errors.Response or drops the
+// error chain.
+func TestHandleBrokerError_StatusCodes(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name       string
+		err        error
+		wantStatus int
+		// wantBodyContains is a substring that must appear in the JSON error
+		// field after the handler wraps with the "Provider: <context>" prefix.
+		wantBodyContains string
+	}{
+		{
+			name:             "plain error defaults to 400",
+			err:              errors.New("oops"),
+			wantStatus:       http.StatusBadRequest,
+			wantBodyContains: "oops",
+		},
+		{
+			name:             "NewBadRequest -> 400",
+			err:              errors.NewBadRequest("bad input"),
+			wantStatus:       http.StatusBadRequest,
+			wantBodyContains: "bad input",
+		},
+		{
+			name:             "NewUnauthorized -> 401",
+			err:              errors.NewUnauthorized("bad signature"),
+			wantStatus:       http.StatusUnauthorized,
+			wantBodyContains: "bad signature",
+		},
+		{
+			name:             "NewForbidden -> 403",
+			err:              errors.NewForbidden("not your task"),
+			wantStatus:       http.StatusForbidden,
+			wantBodyContains: "not your task",
+		},
+		{
+			name:             "NewNotFound -> 404",
+			err:              errors.NewNotFound("task %s", "abc"),
+			wantStatus:       http.StatusNotFound,
+			wantBodyContains: "task abc",
+		},
+		{
+			name:             "NewConflict -> 409 (simulates terminal-state cancel)",
+			err:              errors.NewConflict("task cannot be cancelled in its current state (Trained)"),
+			wantStatus:       http.StatusConflict,
+			wantBodyContains: "Trained",
+		},
+		{
+			name:             "NewInternal -> 500",
+			err:              errors.NewInternal("broker inconsistency"),
+			wantStatus:       http.StatusInternalServerError,
+			wantBodyContains: "broker inconsistency",
+		},
+		{
+			name:             "chain-preserving wrap -> 401",
+			err:              errors.Unauthorized(errors.New("invalid sig v")),
+			wantStatus:       http.StatusUnauthorized,
+			wantBodyContains: "invalid sig v",
+		},
+		{
+			name:             "typed error survives errors.Wrap inside handleBrokerError",
+			err:              errors.NotFound(gorm.ErrRecordNotFound),
+			wantStatus:       http.StatusNotFound,
+			wantBodyContains: gorm.ErrRecordNotFound.Error(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := gin.New()
+			r.GET("/boom", func(c *gin.Context) {
+				handleBrokerError(c, tt.err, "test route")
+			})
+
+			req := httptest.NewRequest(http.MethodGet, "/boom", nil)
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, req)
+
+			if rec.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d (body=%s)", rec.Code, tt.wantStatus, rec.Body.String())
+			}
+
+			var body map[string]string
+			if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+				t.Fatalf("unmarshal body: %v (raw=%q)", err, rec.Body.String())
+			}
+			if !strings.Contains(body["error"], tt.wantBodyContains) {
+				t.Fatalf("body error %q does not contain %q", body["error"], tt.wantBodyContains)
+			}
+			// handleBrokerError always prefixes with "Provider" for context
+			// continuity with how client-facing errors are currently labelled.
+			if !strings.HasPrefix(body["error"], "Provider") {
+				t.Fatalf("body error %q missing Provider prefix", body["error"])
+			}
+		})
+	}
+}
+
+// TestHandleBrokerError_PreservesChain verifies that when a typed error is
+// wrapped by handleBrokerError (which calls errors.Wrap), the original error
+// is still reachable via errors.Is. This matters for the review finding that
+// NewXxx("%s", err.Error()) flattens the chain — the wrap helpers must not.
+func TestHandleBrokerError_PreservesChain(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	sentinel := errors.New("sentinel cause")
+	wrapped := errors.Unauthorized(sentinel)
+
+	var captured error
+	r := gin.New()
+	r.GET("/boom", func(c *gin.Context) {
+		// Replicate what handleBrokerError does so we can capture the final
+		// error value that reaches errors.Response.
+		captured = errors.Wrap(wrapped, "Provider: test")
+		handleBrokerError(c, wrapped, "test")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/boom", nil)
+	r.ServeHTTP(httptest.NewRecorder(), req)
+
+	if !errors.Is(captured, sentinel) {
+		t.Fatalf("sentinel cause lost through handler wrap chain")
+	}
+}

--- a/api/fine-tuning/internal/handler/handler_test.go
+++ b/api/fine-tuning/internal/handler/handler_test.go
@@ -28,7 +28,12 @@ func TestHandleBrokerError_StatusCodes(t *testing.T) {
 		wantStatus int
 		// wantBodyContains is a substring that must appear in the JSON error
 		// field after the handler wraps with the "Provider: <context>" prefix.
+		// For 5xx the body is sanitized, so the field holds the generic text.
 		wantBodyContains string
+		// sanitized5xx indicates the response body is not expected to include
+		// the "Provider" prefix or the underlying error text — the handler
+		// swaps it for a generic status message and logs details server-side.
+		sanitized5xx bool
 	}{
 		{
 			name:             "plain error defaults to 400",
@@ -67,10 +72,11 @@ func TestHandleBrokerError_StatusCodes(t *testing.T) {
 			wantBodyContains: "Trained",
 		},
 		{
-			name:             "NewInternal -> 500",
+			name:             "NewInternal -> 500 (body sanitized)",
 			err:              errors.NewInternal("broker inconsistency"),
 			wantStatus:       http.StatusInternalServerError,
-			wantBodyContains: "broker inconsistency",
+			wantBodyContains: http.StatusText(http.StatusInternalServerError),
+			sanitized5xx:     true,
 		},
 		{
 			name:             "chain-preserving wrap -> 401",
@@ -108,10 +114,20 @@ func TestHandleBrokerError_StatusCodes(t *testing.T) {
 			if !strings.Contains(body["error"], tt.wantBodyContains) {
 				t.Fatalf("body error %q does not contain %q", body["error"], tt.wantBodyContains)
 			}
-			// handleBrokerError always prefixes with "Provider" for context
-			// continuity with how client-facing errors are currently labelled.
-			if !strings.HasPrefix(body["error"], "Provider") {
-				t.Fatalf("body error %q missing Provider prefix", body["error"])
+			if tt.sanitized5xx {
+				// 5xx responses must not leak the underlying error text.
+				if strings.Contains(body["error"], "broker inconsistency") {
+					t.Fatalf("5xx body leaked internal detail: %q", body["error"])
+				}
+				if strings.HasPrefix(body["error"], "Provider") {
+					t.Fatalf("5xx body should be generic, got %q", body["error"])
+				}
+			} else {
+				// handleBrokerError prefixes with "Provider" for continuity
+				// with how client-facing errors are currently labelled.
+				if !strings.HasPrefix(body["error"], "Provider") {
+					t.Fatalf("body error %q missing Provider prefix", body["error"])
+				}
 			}
 		})
 	}

--- a/api/fine-tuning/internal/handler/task.go
+++ b/api/fine-tuning/internal/handler/task.go
@@ -269,23 +269,22 @@ func (h *Handler) DownloadLoRA(ctx *gin.Context) {
 func (h *Handler) UploadDataset(ctx *gin.Context) {
 	userAddress := ctx.Param("userAddress")
 
-	// Get and validate signature
+	// Absent/malformed signature and timestamp are request-shape problems —
+	// no credentials were presented at all, so 400 Bad Request is the correct
+	// classification (RFC 7235's 401 is for rejected credentials). 401 is
+	// reserved for the VerifyUploadSignature branch below.
 	signature := ctx.PostForm("signature")
 	if signature == "" {
-		errors.Response(ctx, errors.NewUnauthorized("Signature is required"))
+		errors.Response(ctx, errors.NewBadRequest("Signature is required"))
 		return
 	}
 
-	// Get and validate timestamp
 	timestampStr := ctx.PostForm("timestamp")
 	if timestampStr == "" {
-		errors.Response(ctx, errors.NewUnauthorized("Timestamp is required"))
+		errors.Response(ctx, errors.NewBadRequest("Timestamp is required"))
 		return
 	}
 
-	// Malformed timestamp is a client-side parse error, not an auth failure —
-	// the caller hasn't presented bad credentials, it sent a syntactically
-	// invalid field that feeds into the signature flow.
 	timestamp, err := strconv.ParseInt(timestampStr, 10, 64)
 	if err != nil {
 		errors.Response(ctx, errors.NewBadRequest("Invalid timestamp format"))

--- a/api/fine-tuning/internal/handler/task.go
+++ b/api/fine-tuning/internal/handler/task.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 
+	"github.com/0glabs/0g-serving-broker/common/errors"
 	"github.com/0glabs/0g-serving-broker/fine-tuning/schema"
 )
 
@@ -245,12 +246,6 @@ func (h *Handler) DownloadLoRA(ctx *gin.Context) {
 		return
 	}
 
-	// Check if file exists
-	if _, err := os.Stat(filePath); os.IsNotExist(err) {
-		ctx.JSON(http.StatusNotFound, gin.H{"error": "Encrypted LoRA not found. Task may not have completed encryption yet."})
-		return
-	}
-
 	ctx.Header("Content-Description", "File Transfer")
 	ctx.Header("Content-Disposition", fmt.Sprintf("attachment; filename=lora_encrypted_%s.data", id.String()))
 	ctx.Header("Content-Type", "application/octet-stream")
@@ -277,47 +272,50 @@ func (h *Handler) UploadDataset(ctx *gin.Context) {
 	// Get and validate signature
 	signature := ctx.PostForm("signature")
 	if signature == "" {
-		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "Signature is required"})
+		errors.Response(ctx, errors.NewUnauthorized("Signature is required"))
 		return
 	}
 
 	// Get and validate timestamp
 	timestampStr := ctx.PostForm("timestamp")
 	if timestampStr == "" {
-		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "Timestamp is required"})
+		errors.Response(ctx, errors.NewUnauthorized("Timestamp is required"))
 		return
 	}
 
+	// Malformed timestamp is a client-side parse error, not an auth failure —
+	// the caller hasn't presented bad credentials, it sent a syntactically
+	// invalid field that feeds into the signature flow.
 	timestamp, err := strconv.ParseInt(timestampStr, 10, 64)
 	if err != nil {
-		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid timestamp format"})
+		errors.Response(ctx, errors.NewBadRequest("Invalid timestamp format"))
 		return
 	}
 
 	// Verify signature with timestamp (prevents replay attacks)
 	if err := h.ctrl.VerifyUploadSignature(userAddress, signature, timestamp); err != nil {
 		h.logger.Warnf("signature verification failed for %s: %v", userAddress, err)
-		ctx.JSON(http.StatusUnauthorized, gin.H{"error": fmt.Sprintf("Authentication failed: %v", err)})
+		errors.Response(ctx, errors.Unauthorized(fmt.Errorf("Authentication failed: %w", err)))
 		return
 	}
 
 	file, err := ctx.FormFile("file")
 	if err != nil {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": "No file provided"})
+		errors.Response(ctx, errors.NewBadRequest("No file provided"))
 		return
 	}
 
 	// Check file size (max 100MB)
 	maxSize := int64(100 * 1024 * 1024)
 	if file.Size > maxSize {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": "File too large. Maximum size is 100MB"})
+		errors.Response(ctx, errors.NewBadRequest("File too large. Maximum size is 100MB"))
 		return
 	}
 
 	// Validate file extension
 	filename := strings.ToLower(file.Filename)
 	if !strings.HasSuffix(filename, ".jsonl") && !strings.HasSuffix(filename, ".json") {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": "Invalid file type. Only JSONL/JSON files are allowed"})
+		errors.Response(ctx, errors.NewBadRequest("Invalid file type. Only JSONL/JSON files are allowed"))
 		return
 	}
 

--- a/api/fine-tuning/internal/handler/task.go
+++ b/api/fine-tuning/internal/handler/task.go
@@ -236,7 +236,7 @@ func (h *Handler) DownloadLoRA(ctx *gin.Context) {
 
 	if err := h.ctrl.VerifyDownloadSignature(&id, userAddress, jsonData.Signature, jsonData.Timestamp); err != nil {
 		h.logger.Warnf("download signature verification failed for %s task %s: %v", userAddress, id.String(), err)
-		ctx.JSON(http.StatusUnauthorized, gin.H{"error": fmt.Sprintf("authentication failed: %v", err)})
+		errors.Response(ctx, errors.Unauthorized(fmt.Errorf("authentication failed: %w", err)))
 		return
 	}
 

--- a/api/fine-tuning/internal/handler/task.go
+++ b/api/fine-tuning/internal/handler/task.go
@@ -277,20 +277,20 @@ func (h *Handler) UploadDataset(ctx *gin.Context) {
 	// Get and validate signature
 	signature := ctx.PostForm("signature")
 	if signature == "" {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": "Signature is required"})
+		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "Signature is required"})
 		return
 	}
 
 	// Get and validate timestamp
 	timestampStr := ctx.PostForm("timestamp")
 	if timestampStr == "" {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": "Timestamp is required"})
+		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "Timestamp is required"})
 		return
 	}
 
 	timestamp, err := strconv.ParseInt(timestampStr, 10, 64)
 	if err != nil {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": "Invalid timestamp format"})
+		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid timestamp format"})
 		return
 	}
 

--- a/api/inference/internal/ctrl/proxy.go
+++ b/api/inference/internal/ctrl/proxy.go
@@ -267,11 +267,10 @@ func (c *Ctrl) handleBrokerError(ctx *gin.Context, err error, context string) {
 	if ignoreError, exists := ctx.Get("ignoreError"); !exists || !ignoreError.(bool) {
 		c.logger.Errorf("Proxy broker error in ctrl: %v, context: %s", err, context)
 	}
-	info := "Provider proxy: handle proxied service response"
 	if context != "" {
-		info += (", " + context)
+		err = errors.Wrap(err, context)
 	}
-	errors.Response(ctx, errors.Wrap(err, info))
+	errors.Response(ctx, err)
 }
 
 func (c *Ctrl) handleServiceError(ctx *gin.Context, statusCode int, body io.ReadCloser) {

--- a/api/inference/internal/handler/handler.go
+++ b/api/inference/internal/handler/handler.go
@@ -159,11 +159,14 @@ func (h *Handler) internalApiAuth() gin.HandlerFunc {
 	}
 }
 
+// handleBrokerError routes err to errors.Response, optionally prefixing it
+// with a short context string for server-side debuggability. Client body
+// semantics come from the error's HTTP status code, not from a synthetic
+// "Provider" prefix — bodies are uniform across all handlers.
 func handleBrokerError(ctx *gin.Context, err error, context string) {
-	info := "Provider"
 	if context != "" {
-		info += (": " + context)
+		err = errors.Wrap(err, context)
 	}
-	errors.Response(ctx, errors.Wrap(err, info))
+	errors.Response(ctx, err)
 }
 

--- a/api/inference/internal/handler/logs.go
+++ b/api/inference/internal/handler/logs.go
@@ -28,7 +28,7 @@ import (
 func (h *Handler) ListLogs(ctx *gin.Context) {
 	// Validate provider authentication
 	if err := h.ctrl.ValidateProviderAuth(ctx); err != nil {
-		handleBrokerError(ctx, errors.NewUnauthorized("%s", err.Error()), "authentication failed")
+		handleBrokerError(ctx, errors.Unauthorized(err), "authentication failed")
 		return
 	}
 
@@ -130,7 +130,7 @@ func (h *Handler) getComponentLogs(component string) []map[string]interface{} {
 func (h *Handler) GetLogFile(ctx *gin.Context) {
 	// Validate provider authentication
 	if err := h.ctrl.ValidateProviderAuth(ctx); err != nil {
-		handleBrokerError(ctx, errors.NewUnauthorized("%s", err.Error()), "authentication failed")
+		handleBrokerError(ctx, errors.Unauthorized(err), "authentication failed")
 		return
 	}
 

--- a/api/inference/internal/handler/logs.go
+++ b/api/inference/internal/handler/logs.go
@@ -28,7 +28,7 @@ import (
 func (h *Handler) ListLogs(ctx *gin.Context) {
 	// Validate provider authentication
 	if err := h.ctrl.ValidateProviderAuth(ctx); err != nil {
-		handleBrokerError(ctx, err, "authentication failed")
+		handleBrokerError(ctx, errors.NewUnauthorized("%s", err.Error()), "authentication failed")
 		return
 	}
 
@@ -130,7 +130,7 @@ func (h *Handler) getComponentLogs(component string) []map[string]interface{} {
 func (h *Handler) GetLogFile(ctx *gin.Context) {
 	// Validate provider authentication
 	if err := h.ctrl.ValidateProviderAuth(ctx); err != nil {
-		handleBrokerError(ctx, err, "authentication failed")
+		handleBrokerError(ctx, errors.NewUnauthorized("%s", err.Error()), "authentication failed")
 		return
 	}
 
@@ -163,7 +163,7 @@ func (h *Handler) GetLogFile(ctx *gin.Context) {
 	// Get log directory for the component
 	logDir := h.ctrl.GetComponentLogDir(component)
 	if logDir == "" {
-		handleBrokerError(ctx, errors.New("log directory not configured for component"), "")
+		handleBrokerError(ctx, errors.NewInternal("log directory not configured for component"), "")
 		return
 	}
 
@@ -181,7 +181,7 @@ func (h *Handler) GetLogFile(ctx *gin.Context) {
 
 	// Check if file exists
 	if _, err := os.Stat(fullPath); os.IsNotExist(err) {
-		handleBrokerError(ctx, errors.New("log file not found"), "")
+		handleBrokerError(ctx, errors.NewNotFound("log file not found"), "")
 		return
 	}
 

--- a/api/inference/internal/proxy/proxy.go
+++ b/api/inference/internal/proxy/proxy.go
@@ -602,9 +602,8 @@ func (p *Proxy) handleBrokerError(ctx *gin.Context, err error, context string) {
 	if !exists || !ok || !ignoreError {
 		p.logger.Errorf("Proxy broker error: %v, context: %s", err, context)
 	}
-	info := "Provider proxy: handle proxied service"
 	if context != "" {
-		info += (", " + context)
+		err = errors.Wrap(err, context)
 	}
-	errors.Response(ctx, errors.Wrap(err, info))
+	errors.Response(ctx, err)
 }


### PR DESCRIPTION
## Summary
This PR introduces a structured HTTP error type system (`HTTPError`) to the common errors package and refactors error handling across inference, fine-tuning, and database layers to use typed errors with appropriate HTTP status codes. This enables consistent, semantically correct error responses and improves debuggability through server-side logging of sensitive details.

## Key Changes

### Common Errors Package (`api/common/errors/`)
- **New `HTTPError` type**: Associates errors with HTTP status codes (400, 401, 403, 404, 409, 500, 503)
- **Constructor functions**: `NewBadRequest()`, `NewUnauthorized()`, `NewForbidden()`, `NewNotFound()`, `NewConflict()`, `NewInternal()`, `NewServiceUnavailable()`
- **Wrapper functions**: `Unauthorized()`, `Forbidden()`, `NotFound()`, `Conflict()`, `Internal()`, `ServiceUnavailable()` that preserve error chains for `errors.Is()`/`errors.As()`
- **Enhanced `Response()` handler**: 
  - Extracts HTTP status from `HTTPError` in the error chain (defaults to 400)
  - Sanitizes 500 Internal Server Error bodies to generic status text while logging full error server-side
  - Preserves actionable messages for other 5xx codes (503 Service Unavailable)
  - Logs all 5xx errors with request context (path, method)

### Fine-tuning Service (`api/fine-tuning/`)
- **`internal/ctrl/task.go`**: 
  - `CreateTask()`: Returns `NewConflict()` for queue-full and in-progress task conflicts
  - `CancelTask()`: Enhanced with pre-flight validation to distinguish 404 (task missing) from 409 (non-cancellable state); returns `NewNotFound()`, `NewForbidden()`, or `NewConflict()` as appropriate
  - `GetTask()`: Returns `NewNotFound()` for missing tasks, `Internal()` for driver errors
  - `ListTask()`, `GetProgress()`, `GetLoRAModel()`: Wrapped errors with appropriate HTTP types
  - Signature validation errors wrapped with `Unauthorized()`
  - Authorization failures return `NewForbidden()`

- **`internal/db/service.go`**: 
  - Fixed `CancelTask()` WHERE clause to include `id = ?` (regression guard: prevents cancelling sibling tasks)
  - Returns `gorm.ErrRecordNotFound` when no rows affected (consumed by ctrl layer for 404/409 disambiguation)

- **`internal/handler/task.go`**: 
  - Replaced inline `ctx.JSON()` calls with `errors.Response()` for consistent error handling
  - Signature verification failures now return `Unauthorized()` instead of inline 401
  - Removed redundant file-existence check (let `ctx.FileAttachment()` handle 404)
  - Dataset upload validation errors use `NewBadRequest()` for malformed requests

### Inference Service (`api/inference/`)
- **`internal/handler/handler.go`** and **`internal/handler/logs.go`**: 
  - Refactored `handleBrokerError()` to route through `errors.Response()` instead of synthesizing "Provider" prefix
  - Context string now wrapped into error chain via `errors.Wrap()` for server-side debuggability
  - Client body semantics come from error's HTTP status, not synthetic prefix
  - Authentication failures wrapped with `Unauthorized()`

- **`internal/ctrl/proxy.go`**: 
  - Same `handleBrokerError()` refactoring as handler layer
  - Preserves pricing unavailability detection for 503 responses

- **`internal/proxy/proxy.go`**: 
  - Updated `handleBrokerError()` to use `errors.Response()` pattern

## Testing
- **`api/fine-tuning/internal/db/service_test.go`** (integration): 
  - `TestCancelTask_OnlyAffectsTargetedRow`: Regression guard verifying WHERE clause targets single row
  - `TestCancelTask

https://claude.ai/code/session_01DZmUvKxCTn8zJZSeJjbPzm