### PR TITLE
Fix Data Loss: preserve full messages array during JSONL→HF conversion

### DIFF
--- a/api/fine-tuning/internal/ctrl/task.go
+++ b/api/fine-tuning/internal/ctrl/task.go
@@ -694,23 +694,14 @@ if lines:
         messages_format = True
 
 if messages_format:
-    # Convert messages format to instruction/input/output
-    for line in lines:
+    # Preserve full messages array; trainer applies the model's chat template
+    data = {"messages": []}
+    for line_num, line in enumerate(lines, start=1):
         item = json.loads(line)
-        messages = item.get("messages", [])
-        # Extract user message as instruction, assistant message as output
-        instruction = ""
-        output = ""
-        for msg in messages:
-            role = msg.get("role", "")
-            content = msg.get("content", "")
-            if role == "user":
-                instruction = content
-            elif role == "assistant":
-                output = content
-        data["instruction"].append(instruction)
-        data["input"].append("")
-        data["output"].append(output)
+        messages = item.get("messages")
+        if not isinstance(messages, list):
+            raise ValueError(f"line {line_num}: messages must be a list")
+        data["messages"].append(messages)
 else:
     # Standard instruction/input/output format
     for line in lines:
@@ -722,7 +713,7 @@ else:
 # Create and save DatasetDict
 ds = DatasetDict({"train": Dataset.from_dict(data)})
 ds.save_to_disk(output_dir)
-print(f"Converted {len(data['instruction'])} examples to {output_dir}")
+print(f"Converted {len(lines)} examples to {output_dir}")
 `
 
 	// Save Python script to temp file

--- a/api/fine-tuning/internal/services/setup.go
+++ b/api/fine-tuning/internal/services/setup.go
@@ -392,21 +392,14 @@ if lines:
         text_format = True
 
 if messages_format:
-    for line in lines:
+    # Preserve full messages array; trainer applies the model's chat template
+    data = {"messages": []}
+    for line_num, line in enumerate(lines, start=1):
         item = json.loads(line)
-        messages = item.get("messages", [])
-        instruction = ""
-        output = ""
-        for msg in messages:
-            role = msg.get("role", "")
-            content = msg.get("content", "")
-            if role == "user":
-                instruction = content
-            elif role == "assistant":
-                output = content
-        data["instruction"].append(instruction)
-        data["input"].append("")
-        data["output"].append(output)
+        messages = item.get("messages")
+        if not isinstance(messages, list):
+            raise ValueError(f"line {line_num}: messages must be a list")
+        data["messages"].append(messages)
 elif text_format:
     data = {"text": []}
     for line in lines:


### PR DESCRIPTION
# Fix Data Loss: preserve full messages array during JSONL→HF conversion

## Summary

This PR fixes a data-loss issue in the JSONL → HuggingFace dataset conversion pipeline for `messages`-format chat datasets.

According to the [official 0G fine-tuning documentation](https://docs.0g.ai/developer-hub/building-on-0g/compute-network/fine-tuning#prepare-your-data) and the [broker user guide](https://github.com/0gfoundation/0g-serving-broker/blob/cd44c630dfafc97c61871fb0258b749f8290218a/api/fine-tuning/docs/USER_GUIDE_FINETUNE_AND_SERVE.md#L62-L65), the supported dataset structure includes conversational `messages` arrays.

However, the broker currently flattens `messages` datasets into Alpaca-style `instruction/input/output` rows. For simple single-turn rows, this strips the chat structure and bypasses the trainer's chat-template path. For rows with system prompts or multiple turns, it also silently drops training content.

This change preserves the full `messages` array through the generated HuggingFace dataset so the trainer can correctly use `tokenizer.apply_chat_template(...)` as originally intended.

---

# Problem

The documented dataset format supports chat-style training data through a `messages` array.

There are three important cases:

## 1. Single-turn chat rows

For simple rows like this:

```json
{"messages":[{"role":"user","content":"Hello"},{"role":"assistant","content":"Hi"}]}
```

the current converter preserves the visible text, but strips the `messages` structure and rewrites the row into Alpaca-style `instruction/input/output`:

```json
{"instruction":"Hello","input":"","output":"Hi"}
```

So the trainer no longer sees this as chat data and falls back to generic Alpaca formatting instead of the model's native chat format.

## 2. Rows with system prompts

For rows with a system prompt:

```json
{"messages":[{"role":"system","content":"You are helpful."},{"role":"user","content":"What is 0G?"},{"role":"assistant","content":"0G is decentralized AI infrastructure."}]}
```

the current converter drops the system message entirely and stores only:

```json
{"instruction":"What is 0G?","input":"","output":"0G is decentralized AI infrastructure."}
```

So important persona, context, or behavior instructions are lost before training.

## 3. Multi-turn chat rows

For multi-turn rows:

```json
{"messages":[{"role":"user","content":"What is 2+2?"},{"role":"assistant","content":"4"},{"role":"user","content":"Why?"},{"role":"assistant","content":"Because two pairs make four."}]}
```

the current converter overwrites `instruction` and `output` on each pass through the loop, so only the final user/assistant pair survives:

```json
{"instruction":"Why?","input":"","output":"Because two pairs make four."}
```

The earlier turns are lost before training.

## Where the data loss happens

The same conversion logic exists in both ingestion paths:

- [`ctrl/task.go` lines 696-713](https://github.com/0gfoundation/0g-serving-broker/blob/cd44c630dfafc97c61871fb0258b749f8290218a/api/fine-tuning/internal/ctrl/task.go#L696-L713) — runs on direct TEE upload
- [`services/setup.go` lines 394-409](https://github.com/0gfoundation/0g-serving-broker/blob/cd44c630dfafc97c61871fb0258b749f8290218a/api/fine-tuning/internal/services/setup.go#L394-L409) — runs on the 0G Storage download path

Both contain this pattern:

```python
for msg in messages:
    role = msg.get("role", "")
    content = msg.get("content", "")

    if role == "user":
        instruction = content        # overwrite, not append

    elif role == "assistant":
        output = content             # overwrite, not append

data["instruction"].append(instruction)
data["output"].append(output)
```

There are two issues:

1. `instruction` and `output` are overwritten on every iteration, so only the last user and last assistant message survive for multi-turn rows.
2. There is no branch for `role == "system"`, so system messages are dropped entirely.

---

# Root Cause

The trainer already supports native chat-format datasets through the existing [`messages` branch in `train_lora.py`](https://github.com/0gfoundation/0g-serving-broker/blob/cd44c630dfafc97c61871fb0258b749f8290218a/api/fine-tuning/execution/transformer/transformer/train_lora.py#L170-L173), which correctly calls:

```python
tokenizer.apply_chat_template(...)
```

However, because the broker strips the `messages` column first, the trainer never reaches that path and instead falls into the current [Alpaca formatting branch](https://github.com/0gfoundation/0g-serving-broker/blob/cd44c630dfafc97c61871fb0258b749f8290218a/api/fine-tuning/execution/transformer/transformer/train_lora.py#L174-L183).

This causes two problems:

1. Silent loss of training data for system prompts and multi-turn conversations.
2. Chat datasets get trained using generic Alpaca formatting instead of the selected model's chat template.

---

# Fix

Instead of flattening chat conversations into Alpaca format, this PR preserves the original `messages` array as-is inside the generated dataset.

This allows the existing trainer logic to apply the selected model tokenizer's chat template when one is defined. For the currently supported Qwen instruct models, this means Qwen-native chat formatting.

No trainer changes were required.

Additionally:

- updated the final print statement in `ctrl/task.go`
- replaced the old `data['instruction']` reference with `len(lines)`
- non-list `messages` values now raise a line-numbered converter error instead of being silently treated as an empty message list.

---

# Why this commit matters

`tokenizer.apply_chat_template(...)` is the HuggingFace standard for formatting chat data.

Chat-tuned models that define a HuggingFace `chat_template` can use `tokenizer.apply_chat_template(...)` to format conversations in the model's expected format. The `chat_template` is typically stored in `tokenizer_config.json` and defines how that model expects roles, system prompts, and message boundaries to be rendered:

- which special tokens wrap each role
- where system prompts go
- how multi-turn boundaries are represented

This means the broker does not need to hardcode one prompt format. By preserving the `messages` array, the trainer can delegate formatting to the selected model's tokenizer template.

The tokenizer handles this when the selected model defines a compatible chat template.

So by preserving the `messages` array, chat-capable models with a tokenizer chat template can be fine-tuned using their native conversational format instead of a generic Alpaca format.

The correct trainer code already existed; the broker was simply blocking that execution path from being reached.

---

# Why This Matters

This change:

- preserves system prompts
- preserves multi-turn conversational context
- prevents silent training-data corruption
- activates `apply_chat_template(...)` correctly
- trains chat datasets using the selected tokenizer's chat formatting
- keeps Alpaca/text-format behavior unchanged for non-chat users

---

# Verification

## 1. Build Validation

```bash
cd api && go build ./fine-tuning/...
```

Result:

```bash
exit 0
```

---

## 2. Dataset Preservation & Chat Template Validation

Ran the patched converter against three representative `messages` inputs, then rendered each preserved row through the actual `Qwen/Qwen2.5-0.5B-Instruct` tokenizer using `apply_chat_template(...)`.

Setup:

```bash
python3 -m venv /tmp/template-test
/tmp/template-test/bin/pip install transformers jinja2
```

---

### Example A — Single-turn chat, no system prompt

Input:

```json
{"messages":[
  {"role":"user","content":"Hello"},
  {"role":"assistant","content":"Hi"}
]}
```

Current converter on `main`:

```json
{"instruction":"Hello","input":"","output":"Hi"}
```

In this case, the visible text survives, but it is stored in Alpaca shape. The trainer formats it as `### Instruction:` / `### Response:` instead of using Qwen's native chat tokens.

Patched converter in this PR:

```json
{"messages":[
  {"role":"user","content":"Hello"},
  {"role":"assistant","content":"Hi"}
]}
```

Trainer rendering via `apply_chat_template(...)`:

```text
<|im_start|>system
You are Qwen, created by Alibaba Cloud. You are a helpful assistant.<|im_end|>
<|im_start|>user
Hello<|im_end|>
<|im_start|>assistant
Hi<|im_end|>
```

Result: content is preserved and rendered in Qwen's native chat format. Qwen's tokenizer injects its default system prompt when none is provided.

---

### Example B — Chat row with system prompt

Input:

```json
{"messages":[
  {"role":"system","content":"You are helpful."},
  {"role":"user","content":"What is 0G?"},
  {"role":"assistant","content":"0G is decentralized AI infrastructure."}
]}
```

Current converter on `main`:

```json
{"instruction":"What is 0G?","input":"","output":"0G is decentralized AI infrastructure."}
```

Only 2 of 3 messages survive. The system prompt is silently dropped.

Patched converter in this PR:

```json
{"messages":[
  {"role":"system","content":"You are helpful."},
  {"role":"user","content":"What is 0G?"},
  {"role":"assistant","content":"0G is decentralized AI infrastructure."}
]}
```

All 3 of 3 messages are preserved.

Trainer rendering via `apply_chat_template(...)`:

```text
<|im_start|>system
You are helpful.<|im_end|>
<|im_start|>user
What is 0G?<|im_end|>
<|im_start|>assistant
0G is decentralized AI infrastructure.<|im_end|>
```

Result: the user's system prompt now reaches the trainer.

---

### Example C — Multi-turn conversation

Input:

```json
{"messages":[
  {"role":"user","content":"What is 2+2?"},
  {"role":"assistant","content":"4"},
  {"role":"user","content":"Why?"},
  {"role":"assistant","content":"Because two pairs make four."}
]}
```

Current converter on `main`:

```json
{"instruction":"Why?","input":"","output":"Because two pairs make four."}
```

Only 2 of 4 messages survive. The first user/assistant turn is silently dropped, leaving the final `Why?` without its earlier context.

Patched converter in this PR:

```json
{"messages":[
  {"role":"user","content":"What is 2+2?"},
  {"role":"assistant","content":"4"},
  {"role":"user","content":"Why?"},
  {"role":"assistant","content":"Because two pairs make four."}
]}
```

All 4 of 4 messages are preserved.

Trainer rendering via `apply_chat_template(...)`:

```text
<|im_start|>system
You are Qwen, created by Alibaba Cloud. You are a helpful assistant.<|im_end|>
<|im_start|>user
What is 2+2?<|im_end|>
<|im_start|>assistant
4<|im_end|>
<|im_start|>user
Why?<|im_end|>
<|im_start|>assistant
Because two pairs make four.<|im_end|>
```

Result: the full conversation is preserved in order, with both turns intact and rendered in Qwen's native chat format.

---

## 3. Validation Behavior

Non-list `messages` values now raise explicit line-numbered errors instead of being silently treated as empty conversations:

```text
ValueError: line 1: messages must be a list
```

---

# Scope Note

Verified at the unit level:

- converter output for three representative `messages` inputs
- chat template rendering with the real `Qwen/Qwen2.5-0.5B-Instruct` tokenizer
- non-list `messages` validation
- Go build validation: `go build ./fine-tuning/...` → `exit 0`

Not run end-to-end through a live broker → trainer → LoRA pipeline, which would require a TEE, GPU, and testnet setup beyond a local clone.

---

# Impact

## Chat datasets

- ✅ Full conversation context preserved
- ✅ System prompts retained
- ✅ Multi-turn training restored
- ✅ Native tokenizer chat templates enabled
- ✅ Qwen-native formatting used instead of generic Alpaca formatting
- ✅ Non-list `messages` rows now fail with line-numbered errors

## Alpaca / instruction datasets

- ✅ Conversion branch unchanged
- ✅ No intended behavioral changes