### PR TITLE
fix(inference): allow fractional tier multipliers in tiered pricing

### DIFF
--- a/api/inference/config/config.go
+++ b/api/inference/config/config.go
@@ -271,9 +271,9 @@ type TieredPricingConfig struct {
 // The first tier whose MaxInputTokens >= promptTokens is selected.
 // Use MaxInputTokens: 0 to represent an unbounded upper tier.
 type PricingTier struct {
-	MaxInputTokens   int   `yaml:"maxInputTokens"`   // Upper bound of input tokens for this tier (0 = unlimited)
-	InputMultiplier  int64 `yaml:"inputMultiplier"`  // Multiplier for input price in this tier
-	OutputMultiplier int64 `yaml:"outputMultiplier"` // Multiplier for output price in this tier
+	MaxInputTokens   int     `yaml:"maxInputTokens"`   // Upper bound of input tokens for this tier (0 = unlimited)
+	InputMultiplier  float64 `yaml:"inputMultiplier"`  // Multiplier for input price in this tier (>= 1.0; fractional values like 1.333 are supported)
+	OutputMultiplier float64 `yaml:"outputMultiplier"` // Multiplier for output price in this tier (>= 1.0; fractional values like 1.166 are supported)
 }
 
 // WhitelistConfig defines configuration for whitelisted users that bypass billing
@@ -632,10 +632,10 @@ func loadConfig(config *Config) error {
 		}
 		for i, tier := range config.TieredPricing.Tiers {
 			if tier.InputMultiplier < 1 {
-				return fmt.Errorf("invalid config: tieredPricing.tiers[%d].inputMultiplier must be >= 1, got %d", i, tier.InputMultiplier)
+				return fmt.Errorf("invalid config: tieredPricing.tiers[%d].inputMultiplier must be >= 1, got %g", i, tier.InputMultiplier)
 			}
 			if tier.OutputMultiplier < 1 {
-				return fmt.Errorf("invalid config: tieredPricing.tiers[%d].outputMultiplier must be >= 1, got %d", i, tier.OutputMultiplier)
+				return fmt.Errorf("invalid config: tieredPricing.tiers[%d].outputMultiplier must be >= 1, got %g", i, tier.OutputMultiplier)
 			}
 			if tier.MaxInputTokens < 0 {
 				return fmt.Errorf("invalid config: tieredPricing.tiers[%d].maxInputTokens must be >= 0, got %d", i, tier.MaxInputTokens)

--- a/api/inference/internal/ctrl/chatbot.go
+++ b/api/inference/internal/ctrl/chatbot.go
@@ -455,7 +455,7 @@ func (c *Ctrl) finalizeResponseWithUsage(ctx context.Context, usage *Usage, outp
 // fallback (e.g., if the final tier has MaxInputTokens == 0, it always matches as the catch-all).
 // This function should only be called when len(c.tieredPricing.Tiers) > 0; config validation ensures
 // that enabled tiered pricing always has at least one tier with valid multipliers (>= 1).
-func (c *Ctrl) getTierMultipliers(promptTokens int) (int64, int64) {
+func (c *Ctrl) getTierMultipliers(promptTokens int) (float64, float64) {
 	for _, tier := range c.tieredPricing.Tiers {
 		if tier.MaxInputTokens == 0 || promptTokens <= tier.MaxInputTokens {
 			return tier.InputMultiplier, tier.OutputMultiplier
@@ -464,6 +464,18 @@ func (c *Ctrl) getTierMultipliers(promptTokens int) (int64, int64) {
 	// Fallback: promptTokens exceeds all bounded tiers, use the last tier
 	last := c.tieredPricing.Tiers[len(c.tieredPricing.Tiers)-1]
 	return last.InputMultiplier, last.OutputMultiplier
+}
+
+// applyMultiplier multiplies a wei-denominated big.Int by a fractional multiplier
+// and rounds to nearest integer. Uses 256-bit big.Float precision to avoid any
+// loss when the base value exceeds float64 mantissa range.
+func applyMultiplier(base *big.Int, mul float64) *big.Int {
+	bf := new(big.Float).SetPrec(256).SetInt(base)
+	bf.Mul(bf, big.NewFloat(mul))
+	// Round to nearest by adding 0.5 before truncation.
+	bf.Add(bf, big.NewFloat(0.5))
+	result, _ := bf.Int(nil)
+	return result
 }
 
 // updateAccountWithUsage updates the request with accurate token counts from the LLM response
@@ -477,17 +489,17 @@ func (c *Ctrl) updateAccountWithUsage(ctx context.Context, usage *Usage, outputP
 			if !ok {
 				return fmt.Errorf("tiered pricing: failed to parse inputPrice %q as big.Int", inputPrice)
 			}
-			inputPrice = new(big.Int).Mul(base, big.NewInt(inputMul)).String()
+			inputPrice = applyMultiplier(base, inputMul).String()
 		}
 		if outputMul > 1 {
 			base, ok := new(big.Int).SetString(outputPrice, 10)
 			if !ok {
 				return fmt.Errorf("tiered pricing: failed to parse outputPrice %q as big.Int", outputPrice)
 			}
-			outputPrice = new(big.Int).Mul(base, big.NewInt(outputMul)).String()
+			outputPrice = applyMultiplier(base, outputMul).String()
 		}
 		if inputMul > 1 || outputMul > 1 {
-			c.logger.Infof("Tiered pricing: prompt_tokens=%d, inputMultiplier=%d, outputMultiplier=%d, effectiveInputPrice=%s, effectiveOutputPrice=%s",
+			c.logger.Infof("Tiered pricing: prompt_tokens=%d, inputMultiplier=%g, outputMultiplier=%g, effectiveInputPrice=%s, effectiveOutputPrice=%s",
 				usage.PromptTokens, inputMul, outputMul, inputPrice, outputPrice)
 		}
 	}

--- a/api/inference/internal/handler/models.go
+++ b/api/inference/internal/handler/models.go
@@ -49,9 +49,9 @@ type ModelRateLimits struct {
 
 // ModelPricingTier represents a single tier in tiered pricing.
 type ModelPricingTier struct {
-	MaxInputTokens   int   `json:"max_input_tokens"`
-	InputMultiplier  int64 `json:"input_multiplier"`
-	OutputMultiplier int64 `json:"output_multiplier"`
+	MaxInputTokens   int     `json:"max_input_tokens"`
+	InputMultiplier  float64 `json:"input_multiplier"`
+	OutputMultiplier float64 `json:"output_multiplier"`
 }
 
 // ModelCacheTokenBilling holds cache token billing info for display.


### PR DESCRIPTION
## Summary

- `PricingTier.InputMultiplier` / `OutputMultiplier` were `int64`, so YAML values like `1.333` / `1.166` were silently truncated to `1`. The on-chain `additionalInfo` for tiered pricing therefore always carried `×1` on every tier — tiered pricing was effectively a no-op for any non-integer multiplier.
- Switched both fields to `float64` (on the YAML struct and the JSON-exposed `ModelPricingTier`), and added an `applyMultiplier` helper that scales `big.Int` prices by a `float64` multiplier through a 256-bit `big.Float` with round-to-nearest. Validation still rejects multipliers `< 1.0`.

## Repro (before fix)

`user_config`:

```yaml
tieredPricing:
  enabled: true
  tiers:
    - maxInputTokens: 32000
      inputMultiplier: 1
      outputMultiplier: 1
    - maxInputTokens: 0
      inputMultiplier: 1.333
      outputMultiplier: 1.166
```

Broker log when the service is synced on-chain:

```
[addOrUpdateService] Additional info JSON: {"tieredPricing":{"tiers":[
  {"inputMultiplier":1,"maxInputTokens":32000,"outputMultiplier":1},
  {"inputMultiplier":1,"maxInputTokens":0,"outputMultiplier":1}
]}}
```

Both tiers end up at `1` instead of `1.333` / `1.166`.

## After fix

- `1.333` round-trips through config → memory → on-chain JSON.
- `updateAccountWithUsage` applies the multiplier with full big-int precision (no float64 mantissa loss for wei-scale base prices).

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — all green
- [ ] Deploy to a provider with `tieredPricing.tiers[1].inputMultiplier: 1.333` and confirm:
  - on-chain `additionalInfo` carries `1.333`
  - effective input price on a >32K-token request equals `base × 1.333` (rounded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)