### PR TITLE
Migrate config to time.Duration and single-network schema (#507)

### DIFF
--- a/api/common/chain/blockchain.go
+++ b/api/common/chain/blockchain.go
@@ -11,13 +11,6 @@ import (
 	"github.com/0glabs/0g-serving-broker/common/config"
 )
 
-type BlockchainNetworkID string
-
-const (
-	EthereumHardhatID BlockchainNetworkID = "ethereumHardhat"
-	Ethereum0gID      BlockchainNetworkID = "ethereum0g"
-)
-
 type BlockchainNetwork interface {
 	URL() string
 	ChainID() *big.Int
@@ -25,28 +18,19 @@ type BlockchainNetwork interface {
 	Config() *config.NetworkConfig
 }
 
-type BlockchainNetworkInit func(conf *config.Networks) (BlockchainNetwork, error)
-
 type EthereumNetwork struct {
 	networkConfig *config.NetworkConfig
 }
 
-func newEthereumNetwork(conf *config.Networks, networkID BlockchainNetworkID) (BlockchainNetwork, error) {
-	networkConf, err := conf.GetNetworkConfig(string(networkID))
-	if err != nil {
-		return nil, err
+// NewEthereumNetwork builds a BlockchainNetwork from a single NetworkConfig.
+// Replaces the pre-#507 NewHardhatNetwork / New0gNetwork pair, which selected
+// from a Networks map keyed by a hardcoded id — that map only ever carried one
+// entry in production, and Hardhat/0g shared identical behaviour.
+func NewEthereumNetwork(cfg *config.NetworkConfig) (BlockchainNetwork, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("nil network config")
 	}
-	return &EthereumNetwork{
-		networkConfig: networkConf,
-	}, nil
-}
-
-func NewHardhatNetwork(conf *config.Networks) (BlockchainNetwork, error) {
-	return newEthereumNetwork(conf, EthereumHardhatID)
-}
-
-func New0gNetwork(conf *config.Networks) (BlockchainNetwork, error) {
-	return newEthereumNetwork(conf, Ethereum0gID)
+	return &EthereumNetwork{networkConfig: cfg}, nil
 }
 
 func (e *EthereumNetwork) URL() string {
@@ -125,6 +109,9 @@ func (e *EthereumWallet) Address() string {
 }
 
 func newEthereumWallets(pkStore *config.PrivateKeyStore) (BlockchainWallets, error) {
+	if pkStore == nil {
+		return nil, fmt.Errorf("private key store not initialized")
+	}
 	// Check private keystore value, create wallets from such
 	var processedWallets []BlockchainWallet
 	keys, err := pkStore.Fetch()

--- a/api/common/config/deprecation.go
+++ b/api/common/config/deprecation.go
@@ -1,0 +1,93 @@
+package config
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"gopkg.in/yaml.v2"
+)
+
+// DeprecationRemovalDate is the deadline after which all deprecated config
+// fallbacks introduced by issue #507 should be removed. Cleanup PR should land
+// on or after this date.
+const DeprecationRemovalDate = "2026-07-23"
+
+// WarnDeprecated emits a stderr warning for a deprecated yaml key. The warning
+// is intentionally written via the stdlib log package because loadConfig runs
+// before the project's structured logger is initialized.
+func WarnDeprecated(oldKey, newKey string) {
+	log.Printf("[CONFIG-DEPRECATED] %q is deprecated, will be removed after %s, use %q instead",
+		oldKey, DeprecationRemovalDate, newKey)
+}
+
+// WarnDeprecatedBothSet warns when a user provides both the deprecated key and
+// its replacement. The new key takes precedence.
+func WarnDeprecatedBothSet(oldKey, newKey string) {
+	log.Printf("[CONFIG-DEPRECATED] %q and %q are both set; %q (deprecated) is ignored",
+		oldKey, newKey, oldKey)
+}
+
+// RawYAMLKeys parses yaml into a generic map so callers can detect which keys
+// the user actually wrote (vs. which were left at their struct defaults). Used
+// by deprecated-field migration logic where "the old key was present" is the
+// trigger.
+//
+// Returns an empty map (not nil) if data is empty or unparseable, so callers
+// can dereference without nil checks.
+func RawYAMLKeys(data []byte) map[string]interface{} {
+	out := map[string]interface{}{}
+	if len(data) == 0 {
+		return out
+	}
+	// Best-effort: any error here will be surfaced again by the strict
+	// unmarshal that runs after this, so we don't propagate it.
+	_ = yaml.Unmarshal(data, &out)
+	return out
+}
+
+// RawHasKey reports whether the nested key path is present in raw. The path is
+// walked element by element; intermediate non-map values stop the walk and
+// return false.
+//
+// yaml.v2 decodes mappings into map[interface{}]interface{}, so this helper
+// handles both that shape and the top-level map[string]interface{}.
+func RawHasKey(raw map[string]interface{}, path ...string) bool {
+	if len(path) == 0 || raw == nil {
+		return false
+	}
+	var current interface{} = raw
+	for _, key := range path {
+		switch m := current.(type) {
+		case map[string]interface{}:
+			next, ok := m[key]
+			if !ok {
+				return false
+			}
+			current = next
+		case map[interface{}]interface{}:
+			next, ok := m[key]
+			if !ok {
+				return false
+			}
+			current = next
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// ReadConfigFile is a convenience wrapper that returns the config bytes and an
+// "is missing" flag, so callers can keep their existing "no file = use
+// defaults" semantics without duplicating os.IsNotExist boilerplate.
+func ReadConfigFile(path string) (data []byte, missing bool, err error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, true, nil
+		}
+		return nil, false, fmt.Errorf("read config %q: %w", path, err)
+	}
+	return b, false, nil
+}

--- a/api/common/config/deprecation.go
+++ b/api/common/config/deprecation.go
@@ -164,6 +164,76 @@ func unitName(d time.Duration) string {
 	}
 }
 
+// MigrateDurationFromInt is the migration helper for fields whose deprecated
+// form was an integer-with-unit-suffix yaml key (e.g. "offloadAfterMinutes")
+// and whose new form is a time.Duration under a renamed key (e.g.
+// "offloadAfter"). The behaviour is:
+//
+//   - if the user wrote only the new key (or neither), no-op
+//   - if the user wrote only the deprecated key, copy oldValue*unit into
+//     target and emit a deprecation warning
+//   - if both are present, the new key wins; a "both set" warning is emitted
+//     so operators can spot the inconsistency
+func MigrateDurationFromInt(raw map[string]interface{}, oldPath, newPath []string, target *time.Duration, oldValue int64, unit time.Duration) {
+	if !RawHasKey(raw, oldPath...) {
+		return
+	}
+	oldDotted := strings.Join(oldPath, ".")
+	newDotted := strings.Join(newPath, ".")
+	if RawHasKey(raw, newPath...) {
+		WarnDeprecatedBothSet(oldDotted, newDotted)
+		return
+	}
+	WarnDeprecated(oldDotted, newDotted)
+	*target = time.Duration(oldValue) * unit
+}
+
+// MigrateStringRename is the migration helper for keys that were simply
+// renamed (e.g. "database.provider" → "database.dsn"). New key wins when both
+// are present.
+func MigrateStringRename(raw map[string]interface{}, oldPath, newPath []string, target *string, oldValue string) {
+	if !RawHasKey(raw, oldPath...) {
+		return
+	}
+	oldDotted := strings.Join(oldPath, ".")
+	newDotted := strings.Join(newPath, ".")
+	if RawHasKey(raw, newPath...) {
+		WarnDeprecatedBothSet(oldDotted, newDotted)
+		return
+	}
+	WarnDeprecated(oldDotted, newDotted)
+	*target = oldValue
+}
+
+// PickLegacyNetwork chooses a single entry out of a legacy Networks map. For
+// 1-entry maps the only entry wins. For multi-entry maps (pre-#507 dev
+// configs that shipped with both ethereumHardhat and ethereum0g side by side)
+// the pre-#507 NETWORK env var is honored so existing CI/dev workflows keep
+// working during the deprecation window: NETWORK=hardhat selects the
+// ethereumHardhat entry, anything else selects ethereum0g. Both the NETWORK
+// coupling and this whole helper go away at the cleanup deadline.
+func PickLegacyNetwork(networks Networks) (*NetworkConfig, error) { //nolint:staticcheck // intentional reference to deprecated Networks for the #507 fallback window
+	if len(networks) == 0 {
+		return nil, fmt.Errorf("invalid config: 'networks' is set but empty")
+	}
+	if len(networks) == 1 {
+		for _, nc := range networks {
+			if nc == nil {
+				return nil, fmt.Errorf("invalid config: 'networks' entry has no value; either delete it or fill in url/chainID/privateKeys")
+			}
+			return nc, nil
+		}
+	}
+	wanted := "ethereum0g"
+	if os.Getenv("NETWORK") == "hardhat" {
+		wanted = "ethereumHardhat"
+	}
+	if nc, ok := networks[wanted]; ok && nc != nil {
+		return nc, nil
+	}
+	return nil, fmt.Errorf("invalid config: 'networks' contains %d entries; flatten to a single 'network' block (multi-network was never used in production)", len(networks))
+}
+
 // ReadConfigFile is a convenience wrapper that returns the config bytes and an
 // "is missing" flag, so callers can keep their existing "no file = use
 // defaults" semantics without duplicating os.IsNotExist boilerplate.

--- a/api/common/config/deprecation.go
+++ b/api/common/config/deprecation.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
+	"time"
 
 	"gopkg.in/yaml.v2"
 )
@@ -76,6 +78,71 @@ func RawHasKey(raw map[string]interface{}, path ...string) bool {
 		}
 	}
 	return true
+}
+
+// RawGet walks the same shape as RawHasKey and returns the value at the leaf
+// path along with a presence flag. Mirrors RawHasKey for symmetry; callers
+// that need both presence and value use RawGet to avoid two walks.
+func RawGet(raw map[string]interface{}, path ...string) (interface{}, bool) {
+	if len(path) == 0 || raw == nil {
+		return nil, false
+	}
+	var current interface{} = raw
+	for _, key := range path {
+		switch m := current.(type) {
+		case map[string]interface{}:
+			next, ok := m[key]
+			if !ok {
+				return nil, false
+			}
+			current = next
+		case map[interface{}]interface{}:
+			next, ok := m[key]
+			if !ok {
+				return nil, false
+			}
+			current = next
+		default:
+			return nil, false
+		}
+	}
+	return current, true
+}
+
+// MigrateIntegerSecondsDuration is the in-place migration helper for fields
+// that historically held an integer count of `unit` (e.g. seconds, minutes,
+// hours) and now hold a time.Duration. The yaml key is unchanged, so the
+// raw-yaml value's type tells us whether the user wrote the legacy integer
+// form or the new string form.
+//
+// If the raw value is a number, target is overwritten with value*unit and a
+// deprecation warning is emitted. Strings and missing keys are no-ops — the
+// new-style Duration value parsed by yaml.UnmarshalStrict is kept as-is.
+func MigrateIntegerSecondsDuration(raw map[string]interface{}, target *time.Duration, unit time.Duration, path ...string) {
+	v, ok := RawGet(raw, path...)
+	if !ok {
+		return
+	}
+	var n int64
+	switch x := v.(type) {
+	case int:
+		n = int64(x)
+	case int64:
+		n = x
+	case uint:
+		n = int64(x)
+	case uint64:
+		n = int64(x)
+	case float64:
+		// yaml.v2 sometimes decodes numbers as float64 for large values.
+		n = int64(x)
+	default:
+		return
+	}
+	*target = time.Duration(n) * unit
+	dotted := strings.Join(path, ".")
+	log.Printf("[CONFIG-DEPRECATED] %q is an integer (legacy %s); will be removed after %s, use a duration string e.g. \"30s\" / \"1h\"",
+		dotted, unit, DeprecationRemovalDate)
 }
 
 // ReadConfigFile is a convenience wrapper that returns the config bytes and an

--- a/api/common/config/deprecation.go
+++ b/api/common/config/deprecation.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -139,7 +140,14 @@ func MigrateIntegerSecondsDuration(raw map[string]interface{}, target *time.Dura
 	default:
 		return
 	}
+	// 0 has only one interpretation across both schemas (zero duration),
+	// so suppress the deprecation warning for this no-op case — it's
+	// noise that confuses operators who explicitly wrote `key: 0` to
+	// disable a feature.
 	*target = time.Duration(n) * unit
+	if n == 0 {
+		return
+	}
 	dotted := strings.Join(path, ".")
 	log.Printf("[CONFIG-DEPRECATED] %q is an integer count of %s (legacy form); will be removed after %s, use a duration string like \"30s\" / \"1h\" instead",
 		dotted, unitName(unit), DeprecationRemovalDate)
@@ -174,6 +182,12 @@ func unitName(d time.Duration) string {
 //     target and emit a deprecation warning
 //   - if both are present, the new key wins; a "both set" warning is emitted
 //     so operators can spot the inconsistency
+//
+// oldValue MUST come straight from the deprecated raw-integer struct field
+// (e.g. `cfg.LoRA.OffloadAfterMinutes`). DO NOT pass a pre-converted value
+// derived from the new Duration field (e.g.
+// `int64(cfg.LoRA.OffloadAfter/time.Minute)`) — that would silently apply
+// the unit multiplier twice on legacy yaml.
 func MigrateDurationFromInt(raw map[string]interface{}, oldPath, newPath []string, target *time.Duration, oldValue int64, unit time.Duration) {
 	if !RawHasKey(raw, oldPath...) {
 		return
@@ -231,7 +245,12 @@ func PickLegacyNetwork(networks Networks) (*NetworkConfig, error) { //nolint:sta
 	if nc, ok := networks[wanted]; ok && nc != nil {
 		return nc, nil
 	}
-	return nil, fmt.Errorf("invalid config: 'networks' contains %d entries; flatten to a single 'network' block (multi-network was never used in production)", len(networks))
+	keys := make([]string, 0, len(networks))
+	for k := range networks {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return nil, fmt.Errorf("invalid config: 'networks' has %d entries %v; tried to pick %q (NETWORK=%q) but it is absent or nil — flatten to a single 'network' block or rename one of the entries", len(networks), keys, wanted, os.Getenv("NETWORK"))
 }
 
 // ReadConfigFile is a convenience wrapper that returns the config bytes and an

--- a/api/common/config/deprecation.go
+++ b/api/common/config/deprecation.go
@@ -141,8 +141,27 @@ func MigrateIntegerSecondsDuration(raw map[string]interface{}, target *time.Dura
 	}
 	*target = time.Duration(n) * unit
 	dotted := strings.Join(path, ".")
-	log.Printf("[CONFIG-DEPRECATED] %q is an integer (legacy %s); will be removed after %s, use a duration string e.g. \"30s\" / \"1h\"",
-		dotted, unit, DeprecationRemovalDate)
+	log.Printf("[CONFIG-DEPRECATED] %q is an integer count of %s (legacy form); will be removed after %s, use a duration string like \"30s\" / \"1h\" instead",
+		dotted, unitName(unit), DeprecationRemovalDate)
+}
+
+func unitName(d time.Duration) string {
+	switch d {
+	case time.Nanosecond:
+		return "nanoseconds"
+	case time.Microsecond:
+		return "microseconds"
+	case time.Millisecond:
+		return "milliseconds"
+	case time.Second:
+		return "seconds"
+	case time.Minute:
+		return "minutes"
+	case time.Hour:
+		return "hours"
+	default:
+		return d.String()
+	}
 }
 
 // ReadConfigFile is a convenience wrapper that returns the config bytes and an

--- a/api/common/config/network.go
+++ b/api/common/config/network.go
@@ -2,19 +2,16 @@ package config
 
 import (
 	"errors"
-	"sort"
 	"strings"
 )
 
+// Networks is the legacy multi-network map. New code should use a single
+// *NetworkConfig instead — this type only exists so config files written
+// against the pre-#507 schema continue to unmarshal during the deprecation
+// window (see DeprecationRemovalDate).
+//
+// Deprecated: use NetworkConfig directly.
 type Networks map[string]*NetworkConfig
-
-// GetNetworkConfig finds a specified network config based on its name
-func (c Networks) GetNetworkConfig(name string) (*NetworkConfig, error) {
-	if network, ok := c[name]; ok {
-		return network, nil
-	}
-	return nil, errors.New("no supported network of name " + name + " was found. Ensure that the config for it exists.")
-}
 
 type NetworkConfig struct {
 	URL                 string   `mapstructure:"url" yaml:"url"`
@@ -42,25 +39,17 @@ func (l *PrivateKeyStore) Fetch() ([]string, error) {
 	return l.rawKeys, nil
 }
 
-// GetProviderPrivateKey returns the first available private key from any configured network.
-// Both fine-tuning and inference brokers use this to access the provider wallet key
-// for ECIES encryption/decryption of LoRA adapter secrets.
-func GetProviderPrivateKey(networks Networks) (string, error) {
-	names := make([]string, 0, len(networks))
-	for name := range networks {
-		names = append(names, name)
+// GetProviderPrivateKey returns the first available private key from the
+// configured network. Both fine-tuning and inference brokers use this to access
+// the provider wallet key for ECIES encryption/decryption of LoRA adapter
+// secrets.
+func GetProviderPrivateKey(network *NetworkConfig) (string, error) {
+	if network == nil || network.PrivateKeyStore == nil {
+		return "", errors.New("no provider private key found in network config")
 	}
-	sort.Strings(names)
-
-	for _, name := range names {
-		nc := networks[name]
-		if nc.PrivateKeyStore != nil {
-			keys, err := nc.PrivateKeyStore.Fetch()
-			if err != nil || len(keys) == 0 {
-				continue
-			}
-			return strings.TrimSpace(keys[0]), nil
-		}
+	keys, err := network.PrivateKeyStore.Fetch()
+	if err != nil || len(keys) == 0 {
+		return "", errors.New("no provider private key found in network config")
 	}
-	return "", errors.New("no provider private key found in any configured network")
+	return strings.TrimSpace(keys[0]), nil
 }

--- a/api/common/config/network.go
+++ b/api/common/config/network.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 )
 
@@ -45,11 +46,14 @@ func (l *PrivateKeyStore) Fetch() ([]string, error) {
 // secrets.
 func GetProviderPrivateKey(network *NetworkConfig) (string, error) {
 	if network == nil || network.PrivateKeyStore == nil {
-		return "", errors.New("no provider private key found in network config")
+		return "", errors.New("no provider private key found: network config has no PrivateKeyStore")
 	}
 	keys, err := network.PrivateKeyStore.Fetch()
-	if err != nil || len(keys) == 0 {
-		return "", errors.New("no provider private key found in network config")
+	if err != nil {
+		return "", fmt.Errorf("fetch provider private key: %w", err)
+	}
+	if len(keys) == 0 {
+		return "", errors.New("no provider private key found: PrivateKeyStore returned empty key list")
 	}
 	return strings.TrimSpace(keys[0]), nil
 }

--- a/api/common/config/network_test.go
+++ b/api/common/config/network_test.go
@@ -1,0 +1,61 @@
+package config
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestGetProviderPrivateKey_NilNetwork(t *testing.T) {
+	_, err := GetProviderPrivateKey(nil)
+	if err == nil {
+		t.Fatal("expected error for nil network")
+	}
+	if !strings.Contains(err.Error(), "no provider private key") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestGetProviderPrivateKey_NoStore(t *testing.T) {
+	_, err := GetProviderPrivateKey(&NetworkConfig{})
+	if err == nil {
+		t.Fatal("expected error when PrivateKeyStore is nil")
+	}
+	if !strings.Contains(err.Error(), "PrivateKeyStore") {
+		t.Errorf("error should name the missing piece; got: %v", err)
+	}
+}
+
+func TestGetProviderPrivateKey_EmptyStore(t *testing.T) {
+	n := &NetworkConfig{PrivateKeys: nil}
+	n.PrivateKeyStore = NewPrivateKeyStore(n)
+	_, err := GetProviderPrivateKey(n)
+	if err == nil {
+		t.Fatal("expected error when keystore is empty")
+	}
+	// Fetch() returns its own error; we must wrap it so the cause is
+	// visible to the caller via errors.Is / errors.Unwrap.
+	if !errors.Is(err, &emptyStoreError{}) && !strings.Contains(err.Error(), "no keys found") {
+		t.Errorf("error should expose the underlying Fetch() failure; got: %v", err)
+	}
+}
+
+// emptyStoreError is a sentinel for errors.Is comparison in the test above.
+// The current Fetch() implementation uses errors.New so errors.Is won't match
+// any concrete type — the test falls back to substring matching. The sentinel
+// exists so the test reads symmetrically with the wrapping intent.
+type emptyStoreError struct{}
+
+func (e *emptyStoreError) Error() string { return "no keys found" }
+
+func TestGetProviderPrivateKey_Happy(t *testing.T) {
+	n := &NetworkConfig{PrivateKeys: []string{"  0xabc  "}}
+	n.PrivateKeyStore = NewPrivateKeyStore(n)
+	got, err := GetProviderPrivateKey(n)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "0xabc" {
+		t.Errorf("got %q, want trimmed %q", got, "0xabc")
+	}
+}

--- a/api/config-example-all.yaml
+++ b/api/config-example-all.yaml
@@ -1,8 +1,7 @@
 database:
-  # Database configuration for the provider:
-  # The provider connects to the database server located at '0g-serving-provider-broker-db' on port 3306.
-  # Do not change this configuration if using docker compose to start service.
-  provider: provider:provider@tcp(0g-serving-provider-broker-db:3306)/provider?parseTime=true
+  # MySQL DSN. The broker connects to 0g-serving-provider-broker-db:3306 by
+  # default. Do not change if using docker compose to start service.
+  dsn: provider:provider@tcp(0g-serving-provider-broker-db:3306)/provider?parseTime=true
 
 contractAddress:
 
@@ -11,57 +10,27 @@ indexerStandardUrl: "https://indexer-storage-testnet-standard.0g.ai"
 indexerTurboUrl: "https://indexer-storage-testnet-turbo.0g.ai"
 
 event:
-  # The address and port where the provider service listens for events.
-  providerAddr: ":8088"
+  # Listen address for the event process's metrics HTTP server.
+  listenAddr: ":8088"
 
 interval:
-  # Buffer time for automatic settlements in seconds.
-  autoSettleBufferTime: 60
+  # Buffer time for automatic settlements (Go duration string).
+  autoSettleBufferTime: "60s"
 
-  # Interval for running the force settlement processor in seconds.
-  # Interval.ForceSettlementProcessor should larger than 60 to prevent overly frequent settlements
-  forceSettlementProcessor: 600
+  # Interval for running the force settlement processor.
+  # Must be > 1m to prevent overly frequent settlements.
+  forceSettlementProcessor: "10m"
 
-  # Interval for running the settlement processor in seconds.
-  settlementProcessor: 300
+  # Interval for running the settlement processor.
+  settlementProcessor: "5m"
 
-networks:
-  # Network configuration for ethereumHardhat, which is mainly used for development mode.
-  ethereumHardhat:
-    url: "http://localhost:8545"
-    chainID: 31337
-    privateKeys:
-      - ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
-      - 59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
-      - 5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a
-      - 7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6
-      - 47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a
-      - 8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba
-      - 92db14e403b83dfe3df233f83dfa3a0d7096f21ca9b0d6d6b8d88b2b4ec1564e
-      - 4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356
-      - dbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97
-      - 2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6
-      - f214f2b2cd398c806f84e317254e0f0b801d0643303237d97a22a48e01628897
-      - 701b615bbdfb9de65240bc28bd21bbc0d996645a3dd57e7b12bc2bdf6f192c82
-      - a267530f49f8280200edf313ee7af6b827f2a8bce2897751d06a843f644967b1
-      - 47c99abed3324a2707c28affff1267e45918ec8c3f20b8aa892e8b065d2942dd
-      - c526ee95bf44d8fc405a158bb884d9d1238d99f0612e9f33d006bb0789009aaa
-      - 8166f546bab6da521a8369cab06c5d2b9e46670292d85c875ee9ec20e84ffb61
-      - ea6c44ac03bff858b476bba40716402b03e41b8e97e276d1baec7c37d42484a0
-      - 689af8efa8c651a91ad287602527f3af2fe9f6501a7ac4b061667b5a93e037fd
-      - de9be858da4a475276426320d5e9262ecfc3ba460bfac56360bfa6c4c28b4ee0
-      - df57089febbacf7ba0bc227dafbffa9fc08a93fdc68e1e42411a14efcf23656e
-    transactionLimit: 9500000
-    gasEstimationBuffer: 0
-
-  # Network configuration for 0g blockchain
-  ethereum0g:
-    url: "https://evmrpc-testnet.0g.ai"
-    chainID: 16602
-    privateKeys:
-      - aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-    transactionLimit: 5000000
-    gasEstimationBuffer: 100000
+network:
+  url: "https://evmrpc-testnet.0g.ai"
+  chainID: 16602
+  privateKeys:
+    - aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  transactionLimit: 5000000
+  gasEstimationBuffer: 100000
 
 zkProver:
   # Host of zk prover broker.

--- a/api/controller/internal/ctrl/ctrl.go
+++ b/api/controller/internal/ctrl/ctrl.go
@@ -71,14 +71,13 @@ func NewCtrl(fullConfig *config.Config, logger log.Logger) (*Ctrl, error) {
 	if fullConfig.ContractAddress == "" {
 		return nil, fmt.Errorf("contract address is required for controller")
 	}
-	if len(fullConfig.Networks) == 0 {
-		return nil, fmt.Errorf("networks configuration is required for controller")
+	if fullConfig.Network.URL == "" {
+		return nil, fmt.Errorf("network configuration is required for controller")
 	}
 
 	servingContract, err := contract.NewServingContract(
 		common.HexToAddress(fullConfig.ContractAddress),
-		&fullConfig.Networks,
-		os.Getenv("NETWORK"),
+		&fullConfig.Network,
 		fullConfig.GasPrice,
 		fullConfig.MaxGasPrice,
 		logger,

--- a/api/fine-tuning/config/config.go
+++ b/api/fine-tuning/config/config.go
@@ -205,23 +205,6 @@ var (
 	once     sync.Once
 )
 
-// migrateDuration migrates a "field with unit suffix" deprecated form. See
-// the inference equivalent for details.
-func migrateDuration(raw map[string]interface{}, oldPath, newPath []string, target *time.Duration, oldValue int64, unit time.Duration) {
-	oldHere := config.RawHasKey(raw, oldPath...)
-	if !oldHere {
-		return
-	}
-	oldDotted := strings.Join(oldPath, ".")
-	newDotted := strings.Join(newPath, ".")
-	if config.RawHasKey(raw, newPath...) {
-		config.WarnDeprecatedBothSet(oldDotted, newDotted)
-		return
-	}
-	config.WarnDeprecated(oldDotted, newDotted)
-	*target = time.Duration(oldValue) * unit
-}
-
 // migrateDeprecated copies values from deprecated yaml keys to their
 // replacements. See the inference equivalent for the precedence rules.
 func migrateDeprecated(cfg *Config, raw map[string]interface{}) error {
@@ -229,10 +212,10 @@ func migrateDeprecated(cfg *Config, raw map[string]interface{}) error {
 	// integer-seconds semantics if the raw value is a number.
 	config.MigrateIntegerSecondsDuration(raw, &cfg.SettlementCheckInterval, time.Second, "settlementCheckInterval")
 
-	migrateDuration(raw,
+	config.MigrateDurationFromInt(raw,
 		[]string{"deliveredTaskAckTimeoutSecs"}, []string{"deliveredTaskAckTimeout"},
 		&cfg.DeliveredTaskAckTimeout, int64(cfg.DeliveredTaskAckTimeoutSecs), time.Second)
-	migrateDuration(raw,
+	config.MigrateDurationFromInt(raw,
 		[]string{"service", "fileRetentionHours"}, []string{"service", "fileRetention"},
 		&cfg.Service.FileRetention, int64(cfg.Service.FileRetentionHours), time.Hour)
 
@@ -241,7 +224,7 @@ func migrateDeprecated(cfg *Config, raw map[string]interface{}) error {
 			return fmt.Errorf("invalid config: both deprecated 'networks' and new 'network' are set in yaml; delete the 'networks' block to complete the migration")
 		}
 		config.WarnDeprecated("networks", "network")
-		picked, err := pickLegacyNetwork(cfg.Networks)
+		picked, err := config.PickLegacyNetwork(cfg.Networks) //nolint:staticcheck // intentional reference to deprecated Networks for the #507 fallback window
 		if err != nil {
 			return err
 		}
@@ -253,31 +236,6 @@ func migrateDeprecated(cfg *Config, raw map[string]interface{}) error {
 	}
 
 	return nil
-}
-
-// pickLegacyNetwork mirrors the inference helper of the same name — multi-entry
-// legacy Networks maps respect the pre-#507 NETWORK env var so dev/CI workflows
-// keep working during the deprecation window.
-func pickLegacyNetwork(networks config.Networks) (*config.NetworkConfig, error) { //nolint:staticcheck // intentional reference to deprecated Networks for the #507 fallback window
-	if len(networks) == 0 {
-		return nil, fmt.Errorf("invalid config: 'networks' is set but empty")
-	}
-	if len(networks) == 1 {
-		for _, nc := range networks {
-			if nc == nil {
-				return nil, fmt.Errorf("invalid config: 'networks' entry has no value; either delete it or fill in url/chainID/privateKeys")
-			}
-			return nc, nil
-		}
-	}
-	wanted := "ethereum0g"
-	if os.Getenv("NETWORK") == "hardhat" {
-		wanted = "ethereumHardhat"
-	}
-	if nc, ok := networks[wanted]; ok && nc != nil {
-		return nc, nil
-	}
-	return nil, fmt.Errorf("invalid config: 'networks' contains %d entries; flatten to a single 'network' block (multi-network was never used in production)", len(networks))
 }
 
 func loadConfig(cfg *Config) error {

--- a/api/fine-tuning/config/config.go
+++ b/api/fine-tuning/config/config.go
@@ -238,24 +238,46 @@ func migrateDeprecated(cfg *Config, raw map[string]interface{}) error {
 
 	if config.RawHasKey(raw, "networks") {
 		if config.RawHasKey(raw, "network") {
-			config.WarnDeprecatedBothSet("networks", "network")
-		} else {
-			config.WarnDeprecated("networks", "network")
-			switch len(cfg.Networks) {
-			case 0:
-				return fmt.Errorf("invalid config: 'networks' is set but empty")
-			case 1:
-				for _, nc := range cfg.Networks {
-					if nc != nil {
-						cfg.Network = *nc
-					}
-				}
-			default:
-				return fmt.Errorf("invalid config: 'networks' contains %d entries; flatten to a single 'network' block (multi-network was never used in production)", len(cfg.Networks))
+			return fmt.Errorf("invalid config: both deprecated 'networks' and new 'network' are set in yaml; delete the 'networks' block to complete the migration")
+		}
+		config.WarnDeprecated("networks", "network")
+		picked, err := pickLegacyNetwork(cfg.Networks)
+		if err != nil {
+			return err
+		}
+		cfg.Network = *picked
+	}
+
+	if (config.RawHasKey(raw, "network") || config.RawHasKey(raw, "networks")) && cfg.Network.URL == "" {
+		return fmt.Errorf("invalid config: network.url is empty after loading; check that the 'network' (or legacy 'networks') block carries a url value")
+	}
+
+	return nil
+}
+
+// pickLegacyNetwork mirrors the inference helper of the same name — multi-entry
+// legacy Networks maps respect the pre-#507 NETWORK env var so dev/CI workflows
+// keep working during the deprecation window.
+func pickLegacyNetwork(networks config.Networks) (*config.NetworkConfig, error) { //nolint:staticcheck // intentional reference to deprecated Networks for the #507 fallback window
+	if len(networks) == 0 {
+		return nil, fmt.Errorf("invalid config: 'networks' is set but empty")
+	}
+	if len(networks) == 1 {
+		for _, nc := range networks {
+			if nc == nil {
+				return nil, fmt.Errorf("invalid config: 'networks' entry has no value; either delete it or fill in url/chainID/privateKeys")
 			}
+			return nc, nil
 		}
 	}
-	return nil
+	wanted := "ethereum0g"
+	if os.Getenv("NETWORK") == "hardhat" {
+		wanted = "ethereumHardhat"
+	}
+	if nc, ok := networks[wanted]; ok && nc != nil {
+		return nc, nil
+	}
+	return nil, fmt.Errorf("invalid config: 'networks' contains %d entries; flatten to a single 'network' block (multi-network was never used in production)", len(networks))
 }
 
 func loadConfig(cfg *Config) error {

--- a/api/fine-tuning/config/config.go
+++ b/api/fine-tuning/config/config.go
@@ -135,7 +135,12 @@ type Config struct {
 	Database        struct {
 		FineTune string `yaml:"fineTune"`
 	} `yaml:"database"`
-	Networks                    config.Networks     `mapstructure:"networks" yaml:"networks"`
+	// Network is the canonical single-network config (introduced by #507).
+	Network config.NetworkConfig `mapstructure:"network" yaml:"network"`
+	// Networks is the legacy multi-network map kept for backwards
+	// compatibility. Deprecated: use Network instead. Removed after
+	// config.DeprecationRemovalDate.
+	Networks                    config.Networks     `mapstructure:"networks" yaml:"networks,omitempty"`
 	Images                      Images              `yaml:"images"`
 	StorageClientConfig         StorageClientConfig `mapstructure:"storageClient" yaml:"storageClient"`
 	ServingUrl                  string              `yaml:"servingUrl"`
@@ -187,21 +192,50 @@ var (
 	once     sync.Once
 )
 
-func loadConfig(config *Config) error {
+// migrateDeprecated copies values from deprecated yaml keys to their
+// replacements. See the inference equivalent for the precedence rules.
+func migrateDeprecated(cfg *Config, raw map[string]interface{}) error {
+	if config.RawHasKey(raw, "networks") {
+		if config.RawHasKey(raw, "network") {
+			config.WarnDeprecatedBothSet("networks", "network")
+		} else {
+			config.WarnDeprecated("networks", "network")
+			switch len(cfg.Networks) {
+			case 0:
+				return fmt.Errorf("invalid config: 'networks' is set but empty")
+			case 1:
+				for _, nc := range cfg.Networks {
+					if nc != nil {
+						cfg.Network = *nc
+					}
+				}
+			default:
+				return fmt.Errorf("invalid config: 'networks' contains %d entries; flatten to a single 'network' block (multi-network was never used in production)", len(cfg.Networks))
+			}
+		}
+	}
+	return nil
+}
+
+func loadConfig(cfg *Config) error {
 	configPath := "/etc/config/config.yaml"
 	if envPath := os.Getenv("CONFIG_FILE"); envPath != "" {
 		configPath = envPath
 	}
 
-	data, err := os.ReadFile(configPath)
+	data, missing, err := config.ReadConfigFile(configPath)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
 		return err
 	}
+	if missing {
+		return nil
+	}
 
-	return yaml.UnmarshalStrict(data, config)
+	raw := config.RawYAMLKeys(data)
+	if err := yaml.UnmarshalStrict(data, cfg); err != nil {
+		return err
+	}
+	return migrateDeprecated(cfg, raw)
 }
 
 func GetConfig() *Config {
@@ -248,9 +282,7 @@ func GetConfig() *Config {
 			log.Fatalf("Error loading configuration: %v", err)
 		}
 
-		for _, networkConf := range instance.Networks {
-			networkConf.PrivateKeyStore = config.NewPrivateKeyStore(networkConf)
-		}
+		instance.Network.PrivateKeyStore = config.NewPrivateKeyStore(&instance.Network)
 
 		validateCustomizedModels()
 	})

--- a/api/fine-tuning/config/config.go
+++ b/api/fine-tuning/config/config.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"gopkg.in/yaml.v2"
 
@@ -51,10 +52,11 @@ type Service struct {
 	// The fine-tuning broker pushes adapter keys here via POST /internal/v1/adapter-keys
 	// so the inference broker can decrypt adapters from 0G Storage.
 	InferenceServiceUrl string `yaml:"inferenceServiceUrl"`
-	// FileRetentionHours specifies how long to keep task files (dataset, output, encrypted LoRA)
-	// After this period, files will be automatically cleaned up
-	// Default: 72 hours (3 days)
-	FileRetentionHours int `yaml:"fileRetentionHours"`
+	// FileRetention is how long to keep task files (dataset, output,
+	// encrypted LoRA) before they are automatically cleaned up. Default 72h.
+	FileRetention time.Duration `yaml:"fileRetention"`
+	// Deprecated: use FileRetention. Removed after config.DeprecationRemovalDate.
+	FileRetentionHours int `yaml:"fileRetentionHours,omitempty"`
 	// DataDir specifies the root directory for storing task data (datasets, models, outputs)
 	// Default: /tmp (uses os.TempDir())
 	// Recommended: /dstack/persistent for large models to avoid memory pressure
@@ -146,24 +148,35 @@ type Config struct {
 	ServingUrl                  string              `yaml:"servingUrl"`
 	Service                     Service             `yaml:"service"`
 	ProviderOption              providers.Option    `mapstructure:"providerOption" yaml:"providerOption"`
-	Logger                      config.LoggerConfig `yaml:"logger"`
-	SettlementCheckIntervalSecs int64               `yaml:"settlementCheckInterval"`
-	BalanceThresholdInEther     int64               `yaml:"balanceThresholdInEther"`
-	GasPrice                    string              `yaml:"gasPrice"`
-	MaxGasPrice                 string              `yaml:"maxGasPrice"`
-	TrainingWorkerCount         int                 `yaml:"trainingWorkerCount"`
-	SetupWorkerCount            int                 `yaml:"setupWorkerCount"`
-	FinalizerWorkerCount        int                 `yaml:"finalizerWorkerCount"`
-	MaxSetupRetriesPerTask      uint                `yaml:"maxSetupRetriesPerTask"`
-	MaxExecutorRetriesPerTask   uint                `yaml:"maxExecutorRetriesPerTask"`
-	MaxFinalizerRetriesPerTask  uint                `yaml:"maxFinalizerRetriesPerTask"`
-	MaxSettlementRetriesPerTask uint                `yaml:"maxSettlementRetriesPerTask"`
-	SettlementBatchSize         uint                `yaml:"settlementBatchSize"`
-	DeliveredTaskAckTimeoutSecs uint                `yaml:"deliveredTaskAckTimeoutSecs"`
-	DataRetentionDays           uint                `yaml:"dataRetentionDays"`
-	MaxTaskQueueSize            uint                `yaml:"maxTaskQueueSize"`
-	RateLimitRPS                float64             `yaml:"rateLimitRPS"`   // Rate limit requests per second
-	RateLimitBurst              int                 `yaml:"rateLimitBurst"` // Rate limit burst size
+	Logger config.LoggerConfig `yaml:"logger"`
+
+	// SettlementCheckInterval is how often the settlement service polls.
+	// Was integer seconds pre-#507; loadConfig restores the legacy semantics
+	// when the raw yaml value is a number — see migrateDeprecated.
+	SettlementCheckInterval time.Duration `yaml:"settlementCheckInterval"`
+
+	BalanceThresholdInEther     int64  `yaml:"balanceThresholdInEther"`
+	GasPrice                    string `yaml:"gasPrice"`
+	MaxGasPrice                 string `yaml:"maxGasPrice"`
+	TrainingWorkerCount         int    `yaml:"trainingWorkerCount"`
+	SetupWorkerCount            int    `yaml:"setupWorkerCount"`
+	FinalizerWorkerCount        int    `yaml:"finalizerWorkerCount"`
+	MaxSetupRetriesPerTask      uint   `yaml:"maxSetupRetriesPerTask"`
+	MaxExecutorRetriesPerTask   uint   `yaml:"maxExecutorRetriesPerTask"`
+	MaxFinalizerRetriesPerTask  uint   `yaml:"maxFinalizerRetriesPerTask"`
+	MaxSettlementRetriesPerTask uint   `yaml:"maxSettlementRetriesPerTask"`
+	SettlementBatchSize         uint   `yaml:"settlementBatchSize"`
+
+	// DeliveredTaskAckTimeout is the time a Delivered task waits for user ack
+	// before being auto-finalized.
+	DeliveredTaskAckTimeout time.Duration `yaml:"deliveredTaskAckTimeout"`
+	// Deprecated: use DeliveredTaskAckTimeout. Removed after config.DeprecationRemovalDate.
+	DeliveredTaskAckTimeoutSecs uint `yaml:"deliveredTaskAckTimeoutSecs,omitempty"`
+
+	DataRetentionDays uint    `yaml:"dataRetentionDays"`
+	MaxTaskQueueSize  uint    `yaml:"maxTaskQueueSize"`
+	RateLimitRPS      float64 `yaml:"rateLimitRPS"`   // Rate limit requests per second
+	RateLimitBurst    int     `yaml:"rateLimitBurst"` // Rate limit burst size
 }
 
 type StorageClientConfig struct {
@@ -192,9 +205,37 @@ var (
 	once     sync.Once
 )
 
+// migrateDuration migrates a "field with unit suffix" deprecated form. See
+// the inference equivalent for details.
+func migrateDuration(raw map[string]interface{}, oldPath, newPath []string, target *time.Duration, oldValue int64, unit time.Duration) {
+	oldHere := config.RawHasKey(raw, oldPath...)
+	if !oldHere {
+		return
+	}
+	oldDotted := strings.Join(oldPath, ".")
+	newDotted := strings.Join(newPath, ".")
+	if config.RawHasKey(raw, newPath...) {
+		config.WarnDeprecatedBothSet(oldDotted, newDotted)
+		return
+	}
+	config.WarnDeprecated(oldDotted, newDotted)
+	*target = time.Duration(oldValue) * unit
+}
+
 // migrateDeprecated copies values from deprecated yaml keys to their
 // replacements. See the inference equivalent for the precedence rules.
 func migrateDeprecated(cfg *Config, raw map[string]interface{}) error {
+	// SettlementCheckInterval kept its yaml key; restore legacy
+	// integer-seconds semantics if the raw value is a number.
+	config.MigrateIntegerSecondsDuration(raw, &cfg.SettlementCheckInterval, time.Second, "settlementCheckInterval")
+
+	migrateDuration(raw,
+		[]string{"deliveredTaskAckTimeoutSecs"}, []string{"deliveredTaskAckTimeout"},
+		&cfg.DeliveredTaskAckTimeout, int64(cfg.DeliveredTaskAckTimeoutSecs), time.Second)
+	migrateDuration(raw,
+		[]string{"service", "fileRetentionHours"}, []string{"service", "fileRetention"},
+		&cfg.Service.FileRetention, int64(cfg.Service.FileRetentionHours), time.Hour)
+
 	if config.RawHasKey(raw, "networks") {
 		if config.RawHasKey(raw, "network") {
 			config.WarnDeprecatedBothSet("networks", "network")
@@ -260,7 +301,7 @@ func GetConfig() *Config {
 				Path:          "",
 				RotationCount: 50,
 			},
-			SettlementCheckIntervalSecs: 60,
+			SettlementCheckInterval:     60 * time.Second,
 			BalanceThresholdInEther:     1,
 			MaxGasPrice:                 "1000000000000",
 			TrainingWorkerCount:         1,
@@ -271,7 +312,7 @@ func GetConfig() *Config {
 			MaxFinalizerRetriesPerTask:  10,
 			MaxSettlementRetriesPerTask: 10,
 			SettlementBatchSize:         1,
-			DeliveredTaskAckTimeoutSecs: 60 * 60 * 48,
+			DeliveredTaskAckTimeout:     48 * time.Hour,
 			DataRetentionDays:           3,
 			MaxTaskQueueSize:            5,
 			RateLimitRPS:                0.1, // Default: 0.1 requests per second (1 request per 10 seconds) - suitable for file upload/download operations

--- a/api/fine-tuning/config/config.go
+++ b/api/fine-tuning/config/config.go
@@ -142,7 +142,7 @@ type Config struct {
 	// Networks is the legacy multi-network map kept for backwards
 	// compatibility. Deprecated: use Network instead. Removed after
 	// config.DeprecationRemovalDate.
-	Networks                    config.Networks     `mapstructure:"networks" yaml:"networks,omitempty"`
+	Networks config.Networks `mapstructure:"networks" yaml:"networks,omitempty"` //nolint:staticcheck // intentional reference to deprecated Networks for the #507 fallback window
 	Images                      Images              `yaml:"images"`
 	StorageClientConfig         StorageClientConfig `mapstructure:"storageClient" yaml:"storageClient"`
 	ServingUrl                  string              `yaml:"servingUrl"`

--- a/api/fine-tuning/config/deprecation_test.go
+++ b/api/fine-tuning/config/deprecation_test.go
@@ -1,0 +1,212 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// writeTestConfig is the parallel of inference/config's helper. Each test
+// renders its own yaml fragment and points loadConfig at it via CONFIG_FILE.
+func writeTestConfig(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return configPath
+}
+
+// loadFromYAML wraps loadConfig with a temporary config file containing
+// `body`. Returns a fresh Config; defaults from GetConfig are not applied
+// because the singleton is intentionally bypassed for migration tests.
+func loadFromYAML(t *testing.T, body string) (*Config, error) {
+	t.Helper()
+	path := writeTestConfig(t, body)
+	t.Setenv("CONFIG_FILE", path)
+	cfg := &Config{}
+	return cfg, loadConfig(cfg)
+}
+
+// --- Networks → Network migration ------------------------------------------
+
+func TestLoadConfig_Migrate_NetworksToNetwork_Single(t *testing.T) {
+	cfg, err := loadFromYAML(t, `
+networks:
+  ethereum0g:
+    url: "https://evmrpc.0g.ai"
+    chainID: 16661
+    privateKeys: ["0xabc"]
+`)
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	if cfg.Network.URL != "https://evmrpc.0g.ai" {
+		t.Errorf("Network.URL = %q", cfg.Network.URL)
+	}
+	if cfg.Network.ChainID != 16661 {
+		t.Errorf("Network.ChainID = %d", cfg.Network.ChainID)
+	}
+}
+
+func TestLoadConfig_Migrate_BothSet_Errors(t *testing.T) {
+	_, err := loadFromYAML(t, `
+network:
+  url: "https://new.0g.ai"
+networks:
+  ethereum0g:
+    url: "https://old.0g.ai"
+`)
+	if err == nil {
+		t.Fatal("expected error when both 'network' and 'networks' are set")
+	}
+	if !strings.Contains(err.Error(), "both deprecated 'networks' and new 'network'") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadConfig_Migrate_NetworksWithNilEntryErrors(t *testing.T) {
+	_, err := loadFromYAML(t, `
+networks:
+  ethereum0g:
+`)
+	if err == nil {
+		t.Fatal("expected error when 'networks' entry has no value")
+	}
+	if !strings.Contains(err.Error(), "entry has no value") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadConfig_Migrate_NetworkWithoutURLErrors(t *testing.T) {
+	_, err := loadFromYAML(t, `
+network:
+  chainID: 16661
+  privateKeys: ["0xabc"]
+`)
+	if err == nil {
+		t.Fatal("expected error when 'network' has no url")
+	}
+	if !strings.Contains(err.Error(), "network.url is empty") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadConfig_Migrate_MultiEntryNetworks_NetworkEnvSelects(t *testing.T) {
+	t.Setenv("NETWORK", "hardhat")
+	cfg, err := loadFromYAML(t, `
+networks:
+  ethereumHardhat:
+    url: "http://localhost:8545"
+    chainID: 31337
+  ethereum0g:
+    url: "https://evmrpc.0g.ai"
+    chainID: 16661
+`)
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	if cfg.Network.URL != "http://localhost:8545" {
+		t.Errorf("Network.URL = %q; expected hardhat entry when NETWORK=hardhat", cfg.Network.URL)
+	}
+}
+
+func TestLoadConfig_Migrate_MultiEntryNetworks_DefaultsTo0g(t *testing.T) {
+	t.Setenv("NETWORK", "")
+	cfg, err := loadFromYAML(t, `
+networks:
+  ethereumHardhat:
+    url: "http://localhost:8545"
+  ethereum0g:
+    url: "https://evmrpc.0g.ai"
+    chainID: 16661
+`)
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	if cfg.Network.URL != "https://evmrpc.0g.ai" {
+		t.Errorf("Network.URL = %q; expected ethereum0g by default", cfg.Network.URL)
+	}
+}
+
+// --- Duration field migration ----------------------------------------------
+
+func TestLoadConfig_Migrate_SettlementCheckIntervalFromInt(t *testing.T) {
+	// SettlementCheckInterval kept its yaml key; integer is treated as
+	// legacy seconds.
+	cfg, err := loadFromYAML(t, `
+network:
+  url: "https://x"
+settlementCheckInterval: 120
+`)
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	if cfg.SettlementCheckInterval != 120*time.Second {
+		t.Errorf("SettlementCheckInterval = %s, want 2m", cfg.SettlementCheckInterval)
+	}
+}
+
+func TestLoadConfig_Migrate_SettlementCheckIntervalDurationString(t *testing.T) {
+	cfg, err := loadFromYAML(t, `
+network:
+  url: "https://x"
+settlementCheckInterval: "5m"
+`)
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	if cfg.SettlementCheckInterval != 5*time.Minute {
+		t.Errorf("SettlementCheckInterval = %s, want 5m", cfg.SettlementCheckInterval)
+	}
+}
+
+func TestLoadConfig_Migrate_DeliveredTaskAckTimeoutSecs(t *testing.T) {
+	cfg, err := loadFromYAML(t, `
+network:
+  url: "https://x"
+deliveredTaskAckTimeoutSecs: 21600
+`)
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	if cfg.DeliveredTaskAckTimeout != 6*time.Hour {
+		t.Errorf("DeliveredTaskAckTimeout = %s, want 6h", cfg.DeliveredTaskAckTimeout)
+	}
+}
+
+func TestLoadConfig_Migrate_FileRetentionHours(t *testing.T) {
+	cfg, err := loadFromYAML(t, `
+network:
+  url: "https://x"
+service:
+  fileRetentionHours: 72
+`)
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	if cfg.Service.FileRetention != 72*time.Hour {
+		t.Errorf("Service.FileRetention = %s, want 72h", cfg.Service.FileRetention)
+	}
+}
+
+func TestLoadConfig_NewDurationKeysPreferred(t *testing.T) {
+	// When both old and new duration keys are present the new key wins
+	// and a warning is emitted (we don't capture stderr here; we just
+	// assert the value).
+	cfg, err := loadFromYAML(t, `
+network:
+  url: "https://x"
+deliveredTaskAckTimeout: "1h"
+deliveredTaskAckTimeoutSecs: 9999
+`)
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	if cfg.DeliveredTaskAckTimeout != time.Hour {
+		t.Errorf("DeliveredTaskAckTimeout = %s, want 1h (new key wins)", cfg.DeliveredTaskAckTimeout)
+	}
+}

--- a/api/fine-tuning/contract/contract.go
+++ b/api/fine-tuning/contract/contract.go
@@ -43,10 +43,8 @@ type RetryOption struct {
 	MaxGasPrice      *big.Int
 }
 
-func NewServingContract(servingAddress common.Address, conf *config.Networks, gasPrice, maxGasPrice string, logger log.Logger) (*ServingContract, error) {
-	var networkConfig client.BlockchainNetwork
-	var err error
-	networkConfig, err = client.New0gNetwork(conf)
+func NewServingContract(servingAddress common.Address, conf *config.NetworkConfig, gasPrice, maxGasPrice string, logger log.Logger) (*ServingContract, error) {
+	networkConfig, err := client.NewEthereumNetwork(conf)
 	if err != nil {
 		return nil, err
 	}

--- a/api/fine-tuning/integration/prod/config.example.yaml
+++ b/api/fine-tuning/integration/prod/config.example.yaml
@@ -3,14 +3,13 @@
 # DO NOT commit actual credentials to the repository
 
 # Network configuration
-networks:
-  ethereum0g:
-    url: "https://evmrpc-testnet.0g.ai"
-    chainID: 16602
-    privateKeys:
-      - "${PRIVATE_KEY}"  # Set via environment variable or replace with actual key
-    transactionLimit: 1000000
-    gasEstimationBuffer: 10000
+network:
+  url: "https://evmrpc-testnet.0g.ai"
+  chainID: 16602
+  privateKeys:
+    - "${PRIVATE_KEY}"  # Set via environment variable or replace with actual key
+  transactionLimit: 1000000
+  gasEstimationBuffer: 10000
 
 # Service configuration
 service:
@@ -64,8 +63,8 @@ service:
   # Skip 0G Storage upload - encrypt locally for direct TEE download
   skipStorageUpload: false
 
-  # File retention (hours) - how long to keep files before cleanup
-  fileRetentionHours: 72
+  # How long to keep files before cleanup (Go duration string)
+  fileRetention: "72h"
 
 # 0G Storage client configuration
 storageClient:
@@ -97,6 +96,6 @@ maxExecutorRetriesPerTask: 3
 maxFinalizerRetriesPerTask: 10
 maxSettlementRetriesPerTask: 10
 settlementBatchSize: 1
-deliveredTaskAckTimeoutSecs: 21600
+deliveredTaskAckTimeout: "6h"
 dataRetentionDays: 3
 maxTaskQueueSize: 5

--- a/api/fine-tuning/internal/contract/provider_contract.go
+++ b/api/fine-tuning/internal/contract/provider_contract.go
@@ -16,7 +16,7 @@ type ProviderContract struct {
 }
 
 func NewProviderContract(conf *config.Config, teeSignerAddress common.Address, logger log.Logger) (*ProviderContract, error) {
-	contract, err := contract.NewServingContract(common.HexToAddress(conf.ContractAddress), &conf.Networks, conf.GasPrice, conf.MaxGasPrice, logger)
+	contract, err := contract.NewServingContract(common.HexToAddress(conf.ContractAddress), &conf.Network, conf.GasPrice, conf.MaxGasPrice, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/api/fine-tuning/internal/services/finalizer.go
+++ b/api/fine-tuning/internal/services/finalizer.go
@@ -124,7 +124,7 @@ func (f *Finalizer) Execute(ctx context.Context, task *db.Task, paths *utils.Tas
 	// Step 3: Encrypt AES key with provider wallet's ECIES public key
 	// and push to the inference broker via HTTP.
 	var providerEncKey []byte
-	providerPrivKey, privKeyErr := commonconfig.GetProviderPrivateKey(f.config.Networks)
+	providerPrivKey, privKeyErr := commonconfig.GetProviderPrivateKey(&f.config.Network)
 	if privKeyErr != nil {
 		f.logger.Warnf("Could not get provider private key for ECIES encryption: %v", privKeyErr)
 	} else {
@@ -248,7 +248,7 @@ func (f *Finalizer) doPushAdapterKey(parentCtx context.Context, url string, body
 // This follows the same pattern as user session authentication.
 func (f *Finalizer) addWalletSignature(req *http.Request, body []byte, taskID string) error {
 	// Get provider private key
-	providerKey, err := commonconfig.GetProviderPrivateKey(f.config.Networks)
+	providerKey, err := commonconfig.GetProviderPrivateKey(&f.config.Network)
 	if err != nil {
 		return errors.Wrap(err, "get provider private key for signing")
 	}

--- a/api/fine-tuning/internal/services/settlement.go
+++ b/api/fine-tuning/internal/services/settlement.go
@@ -35,7 +35,7 @@ type SettlementConfig struct {
 	Service                 config.Service
 	MaxNumRetriesPerTask    uint
 	SettlementBatchSize     uint
-	DeliveredTaskAckTimeout uint
+	DeliveredTaskAckTimeout time.Duration
 	DataRetentionDays       uint
 }
 
@@ -45,11 +45,11 @@ func NewSettlement(db *db.DB, contract *providercontract.ProviderContract, confi
 		contract:   contract,
 		teeService: teeService,
 		config: SettlementConfig{
-			CheckInterval:           time.Duration(config.SettlementCheckIntervalSecs) * time.Second,
+			CheckInterval:           config.SettlementCheckInterval,
 			Service:                 config.Service,
 			MaxNumRetriesPerTask:    config.MaxSettlementRetriesPerTask,
 			SettlementBatchSize:     config.SettlementBatchSize,
-			DeliveredTaskAckTimeout: config.DeliveredTaskAckTimeoutSecs,
+			DeliveredTaskAckTimeout: config.DeliveredTaskAckTimeout,
 			DataRetentionDays:       config.DataRetentionDays,
 		},
 		logger: logger,
@@ -153,7 +153,9 @@ func (s *Settlement) processPendingUserAckTasks(ctx context.Context) []db.Task {
 		s.logger.Errorf("error getting lock time from contract: %v", err)
 	}
 
-	ackTimeout := int64(s.config.DeliveredTaskAckTimeout)
+	// lockTime and task.DeliverTime are Unix seconds; convert Duration to
+	// seconds before comparison.
+	ackTimeout := int64(s.config.DeliveredTaskAckTimeout / time.Second)
 	if ackTimeout > lockTime/2 {
 		ackTimeout = lockTime / 2
 	}

--- a/api/fine-tuning/internal/storage/client.go
+++ b/api/fine-tuning/internal/storage/client.go
@@ -39,7 +39,7 @@ type Client struct {
 }
 
 func New(config *config.Config, logger log.Logger) (*Client, error) {
-	zgConfig, err := chain.New0gNetwork(&config.Networks)
+	zgConfig, err := chain.NewEthereumNetwork(&config.Network)
 	if err != nil {
 		panic(err)
 	}

--- a/api/inference/cmd/event/main.go
+++ b/api/inference/cmd/event/main.go
@@ -58,7 +58,7 @@ func Main() {
 	cfg := &rest.Config{}
 	mgr, err := controller.NewManager(cfg, controller.Options{
 		Metrics: metricserver.Options{
-			BindAddress: conf.Event.ProviderAddr,
+			BindAddress: conf.Event.ListenAddr,
 		},
 	})
 	if err != nil {

--- a/api/inference/cmd/event/main.go
+++ b/api/inference/cmd/event/main.go
@@ -43,10 +43,10 @@ func Main() {
 	// contract.LockTime is a time.Duration; AutoSettleBufferTime is now also
 	// a Duration. The pre-#507 checks compared integer seconds.
 	if conf.Interval.AutoSettleBufferTime > contract.LockTime {
-		panic(errors.New("Interval.AutoSettleBufferTime grater than refund LockTime"))
+		panic(errors.New("Interval.AutoSettleBufferTime greater than refund LockTime"))
 	}
 	if conf.Interval.AutoSettleBufferTime > conf.Interval.ForceSettlementProcessor {
-		panic(errors.New("Interval.AutoSettleBufferTime grater than forceSettlement Interval"))
+		panic(errors.New("Interval.AutoSettleBufferTime greater than forceSettlement Interval"))
 	}
 	if contract.LockTime-conf.Interval.AutoSettleBufferTime < time.Minute {
 		panic(errors.New("Interval.AutoSettleBufferTime is too large, which could lead to overly frequent settlements"))

--- a/api/inference/cmd/event/main.go
+++ b/api/inference/cmd/event/main.go
@@ -2,6 +2,7 @@ package event
 
 import (
 	"os"
+	"time"
 
 	"k8s.io/client-go/rest"
 	controller "sigs.k8s.io/controller-runtime"
@@ -39,16 +40,18 @@ func Main() {
 	if err != nil {
 		panic(err)
 	}
-	if conf.Interval.AutoSettleBufferTime > int(contract.LockTime) {
+	// contract.LockTime is a time.Duration; AutoSettleBufferTime is now also
+	// a Duration. The pre-#507 checks compared integer seconds.
+	if conf.Interval.AutoSettleBufferTime > contract.LockTime {
 		panic(errors.New("Interval.AutoSettleBufferTime grater than refund LockTime"))
 	}
 	if conf.Interval.AutoSettleBufferTime > conf.Interval.ForceSettlementProcessor {
 		panic(errors.New("Interval.AutoSettleBufferTime grater than forceSettlement Interval"))
 	}
-	if int(contract.LockTime)-conf.Interval.AutoSettleBufferTime < 60 {
+	if contract.LockTime-conf.Interval.AutoSettleBufferTime < time.Minute {
 		panic(errors.New("Interval.AutoSettleBufferTime is too large, which could lead to overly frequent settlements"))
 	}
-	if conf.Interval.ForceSettlementProcessor < 60 {
+	if conf.Interval.ForceSettlementProcessor < time.Minute {
 		panic(errors.New("Interval.ForceSettlementProcessor is too small, which could lead to overly frequent settlements"))
 	}
 
@@ -99,7 +102,7 @@ func Main() {
 		if err := mgr.Add(reconciliationProcessor); err != nil {
 			panic(err)
 		}
-		logger.Infof("Starting reconciliation processor: interval=%ds", conf.Interval.ReconciliationProcessor)
+		logger.Infof("Starting reconciliation processor: interval=%s", conf.Interval.ReconciliationProcessor)
 	}
 
 	// Add revenue transfer processor if configured
@@ -115,7 +118,7 @@ func Main() {
 			panic(err)
 		}
 		if revenueTransferProcessor != nil {
-			logger.Infof("Starting revenue transfer processor: target=%s, interval=%ds, reserve=%s",
+			logger.Infof("Starting revenue transfer processor: target=%s, interval=%s, reserve=%s",
 				conf.RevenueTransfer.TargetAddress,
 				conf.RevenueTransfer.Interval,
 				conf.RevenueTransfer.ReserveAmount,

--- a/api/inference/cmd/server/main.go
+++ b/api/inference/cmd/server/main.go
@@ -252,9 +252,9 @@ func Main() {
 
 	// Initialize async processing if enabled
 	if config.Async.Enabled {
-		resultTTL := time.Duration(config.Async.ResultTTLMinutes) * time.Minute
-		cleanupInterval := time.Duration(config.Async.CleanupIntervalSeconds) * time.Second
-		jobTimeout := time.Duration(config.Async.JobTimeoutMinutes) * time.Minute
+		resultTTL := config.Async.ResultTTL
+		cleanupInterval := config.Async.CleanupInterval
+		jobTimeout := config.Async.JobTimeout
 		if err := ctrl.InitAsyncProcessing(
 			config.Async.MaxConcurrentJobs,
 			config.Async.MaxQueueSize,

--- a/api/inference/cmd/server/main.go
+++ b/api/inference/cmd/server/main.go
@@ -217,7 +217,7 @@ func Main() {
 	var loraCancel context.CancelFunc
 	var eventWatcher *lorapkg.EventWatcher
 	if config.LoRA.Enable {
-		loraManager, err := lorapkg.NewManager(config.LoRA, config.Networks, db, logger)
+		loraManager, err := lorapkg.NewManager(config.LoRA, &config.Network, db, logger)
 		if err != nil {
 			panic(err)
 		}

--- a/api/inference/config/config.go
+++ b/api/inference/config/config.go
@@ -323,11 +323,22 @@ type LoRAConfig struct {
 type Config struct {
 	AllowOrigins    []string `yaml:"allowOrigins"`
 	ContractAddress string   `yaml:"contractAddress"`
-	Database        struct {
-		Provider string `yaml:"provider"`
+	Database struct {
+		// DSN is the MySQL connection string used by the broker process.
+		DSN string `yaml:"dsn"`
+		// Provider was the misleading legacy name for DSN ("Provider" is the
+		// project's GPU-side actor, not a database vendor).
+		// Deprecated: use DSN. Removed after config.DeprecationRemovalDate.
+		Provider string `yaml:"provider,omitempty"`
 	} `yaml:"database"`
 	Event struct {
-		ProviderAddr string `yaml:"providerAddr"`
+		// ListenAddr is the metrics HTTP server bind address used by the
+		// event process (e.g. ":8088").
+		ListenAddr string `yaml:"listenAddr"`
+		// ProviderAddr was the misleading legacy name (it is not a Provider
+		// address — it is a local listen address).
+		// Deprecated: use ListenAddr. Removed after config.DeprecationRemovalDate.
+		ProviderAddr string `yaml:"providerAddr,omitempty"`
 	} `yaml:"event"`
 	GasPrice    string `yaml:"gasPrice"`
 	MaxGasPrice string `yaml:"maxGasPrice"`
@@ -368,7 +379,11 @@ type Config struct {
 		EventAddress string `yaml:"eventAddress"`
 	} `yaml:"monitor"`
 	ZK struct {
-		Provider      string `yaml:"provider"`
+		// URL is the ZK service endpoint.
+		URL string `yaml:"url"`
+		// Provider was the misleading legacy name for URL.
+		// Deprecated: use URL. Removed after config.DeprecationRemovalDate.
+		Provider      string `yaml:"provider,omitempty"`
 		RequestLength int    `yaml:"requestLength"`
 	} `yaml:"zk"`
 	ChatCacheExpiration time.Duration           `yaml:"chatCacheExpiration"`
@@ -602,6 +617,23 @@ func migrateDuration(raw map[string]interface{}, oldPath, newPath []string, targ
 	*target = time.Duration(oldValue) * unit
 }
 
+// migrateStringRename migrates a renamed string yaml key. New key wins when
+// both are set.
+func migrateStringRename(raw map[string]interface{}, oldPath, newPath []string, target *string, oldValue string) {
+	oldHere := config.RawHasKey(raw, oldPath...)
+	if !oldHere {
+		return
+	}
+	oldDotted := strings.Join(oldPath, ".")
+	newDotted := strings.Join(newPath, ".")
+	if config.RawHasKey(raw, newPath...) {
+		config.WarnDeprecatedBothSet(oldDotted, newDotted)
+		return
+	}
+	config.WarnDeprecated(oldDotted, newDotted)
+	*target = oldValue
+}
+
 // migrateDeprecated copies values from deprecated yaml keys to their
 // replacements when the user has populated the deprecated form. Each call to
 // config.WarnDeprecated emits a one-shot stderr line so operators see exactly
@@ -644,6 +676,18 @@ func migrateDeprecated(cfg *Config, raw map[string]interface{}) error {
 	migrateDuration(raw,
 		[]string{"providerHttp", "responseHeaderTimeoutMinutes"}, []string{"providerHttp", "responseHeaderTimeout"},
 		&cfg.ProviderHttp.ResponseHeaderTimeout, cfg.ProviderHttp.ResponseHeaderTimeoutMinutes, time.Minute)
+
+	// Rename: database.provider → database.dsn
+	migrateStringRename(raw, []string{"database", "provider"}, []string{"database", "dsn"},
+		&cfg.Database.DSN, cfg.Database.Provider)
+
+	// Rename: event.providerAddr → event.listenAddr
+	migrateStringRename(raw, []string{"event", "providerAddr"}, []string{"event", "listenAddr"},
+		&cfg.Event.ListenAddr, cfg.Event.ProviderAddr)
+
+	// Rename: zk.provider → zk.url
+	migrateStringRename(raw, []string{"zk", "provider"}, []string{"zk", "url"},
+		&cfg.ZK.URL, cfg.ZK.Provider)
 
 	// Networks (map) → Network (single).
 	if config.RawHasKey(raw, "networks") {
@@ -797,14 +841,16 @@ func GetConfig() *Config {
 			AllowOrigins:    []string{"*"},
 			ContractAddress: "0x47340d900bdFec2BD393c626E12ea0656F938d84",
 			Database: struct {
-				Provider string `yaml:"provider"`
+				DSN      string `yaml:"dsn"`
+				Provider string `yaml:"provider,omitempty"`
 			}{
-				Provider: "root:123456@tcp(mysql:3306)/provider?parseTime=true",
+				DSN: "root:123456@tcp(mysql:3306)/provider?parseTime=true",
 			},
 			Event: struct {
-				ProviderAddr string `yaml:"providerAddr"`
+				ListenAddr   string `yaml:"listenAddr"`
+				ProviderAddr string `yaml:"providerAddr,omitempty"`
 			}{
-				ProviderAddr: ":8088",
+				ListenAddr: ":8088",
 			},
 			GasPrice:    "2000000007",
 			MaxGasPrice: "",
@@ -841,10 +887,11 @@ func GetConfig() *Config {
 				EventAddress: "0g-serving-provider-event:3081",
 			},
 			ZK: struct {
-				Provider      string `yaml:"provider"`
+				URL           string `yaml:"url"`
+				Provider      string `yaml:"provider,omitempty"`
 				RequestLength int    `yaml:"requestLength"`
 			}{
-				Provider:      "nginx:3001",
+				URL:           "nginx:3001",
 				RequestLength: 40,
 			},
 			LoRA: LoRAConfig{

--- a/api/inference/config/config.go
+++ b/api/inference/config/config.go
@@ -373,7 +373,7 @@ type Config struct {
 	// Networks is the legacy multi-network map kept for backwards
 	// compatibility. Deprecated: use Network instead. Removed after
 	// config.DeprecationRemovalDate.
-	Networks config.Networks `mapstructure:"networks" yaml:"networks,omitempty"`
+	Networks config.Networks `mapstructure:"networks" yaml:"networks,omitempty"` //nolint:staticcheck // intentional reference to deprecated Networks for the #507 fallback window
 	Monitor  struct {
 		Enable       bool   `yaml:"enable"`
 		EventAddress string `yaml:"eventAddress"`

--- a/api/inference/config/config.go
+++ b/api/inference/config/config.go
@@ -598,42 +598,6 @@ var (
 	once     sync.Once
 )
 
-// migrateDuration migrates a "field with unit suffix" deprecated form: the old
-// yaml key (e.g. offloadAfterMinutes) holds an integer count of `unit`, and the
-// new key (e.g. offloadAfter) holds a time.Duration. Precedence: new key wins
-// when both are present.
-func migrateDuration(raw map[string]interface{}, oldPath, newPath []string, target *time.Duration, oldValue int, unit time.Duration) {
-	oldHere := config.RawHasKey(raw, oldPath...)
-	if !oldHere {
-		return
-	}
-	oldDotted := strings.Join(oldPath, ".")
-	newDotted := strings.Join(newPath, ".")
-	if config.RawHasKey(raw, newPath...) {
-		config.WarnDeprecatedBothSet(oldDotted, newDotted)
-		return
-	}
-	config.WarnDeprecated(oldDotted, newDotted)
-	*target = time.Duration(oldValue) * unit
-}
-
-// migrateStringRename migrates a renamed string yaml key. New key wins when
-// both are set.
-func migrateStringRename(raw map[string]interface{}, oldPath, newPath []string, target *string, oldValue string) {
-	oldHere := config.RawHasKey(raw, oldPath...)
-	if !oldHere {
-		return
-	}
-	oldDotted := strings.Join(oldPath, ".")
-	newDotted := strings.Join(newPath, ".")
-	if config.RawHasKey(raw, newPath...) {
-		config.WarnDeprecatedBothSet(oldDotted, newDotted)
-		return
-	}
-	config.WarnDeprecated(oldDotted, newDotted)
-	*target = oldValue
-}
-
 // migrateDeprecated copies values from deprecated yaml keys to their
 // replacements when the user has populated the deprecated form. Each call to
 // config.WarnDeprecated emits a one-shot stderr line so operators see exactly
@@ -655,38 +619,38 @@ func migrateDeprecated(cfg *Config, raw map[string]interface{}) error {
 	// Suffixed fields (Minutes/Seconds): old yaml key was kept as a separate
 	// deprecated struct field; copy it over if the user still has the old
 	// form. New key wins if both are set.
-	migrateDuration(raw,
+	config.MigrateDurationFromInt(raw,
 		[]string{"lora", "offloadAfterMinutes"}, []string{"lora", "offloadAfter"},
-		&cfg.LoRA.OffloadAfter, cfg.LoRA.OffloadAfterMinutes, time.Minute)
-	migrateDuration(raw,
+		&cfg.LoRA.OffloadAfter, int64(cfg.LoRA.OffloadAfterMinutes), time.Minute)
+	config.MigrateDurationFromInt(raw,
 		[]string{"lora", "pollBlockIntervalSeconds"}, []string{"lora", "pollBlockInterval"},
-		&cfg.LoRA.PollBlockInterval, cfg.LoRA.PollBlockIntervalSeconds, time.Second)
-	migrateDuration(raw,
+		&cfg.LoRA.PollBlockInterval, int64(cfg.LoRA.PollBlockIntervalSeconds), time.Second)
+	config.MigrateDurationFromInt(raw,
 		[]string{"async", "resultTTLMinutes"}, []string{"async", "resultTTL"},
-		&cfg.Async.ResultTTL, cfg.Async.ResultTTLMinutes, time.Minute)
-	migrateDuration(raw,
+		&cfg.Async.ResultTTL, int64(cfg.Async.ResultTTLMinutes), time.Minute)
+	config.MigrateDurationFromInt(raw,
 		[]string{"async", "cleanupIntervalSeconds"}, []string{"async", "cleanupInterval"},
-		&cfg.Async.CleanupInterval, cfg.Async.CleanupIntervalSeconds, time.Second)
-	migrateDuration(raw,
+		&cfg.Async.CleanupInterval, int64(cfg.Async.CleanupIntervalSeconds), time.Second)
+	config.MigrateDurationFromInt(raw,
 		[]string{"async", "jobTimeoutMinutes"}, []string{"async", "jobTimeout"},
-		&cfg.Async.JobTimeout, cfg.Async.JobTimeoutMinutes, time.Minute)
-	migrateDuration(raw,
+		&cfg.Async.JobTimeout, int64(cfg.Async.JobTimeoutMinutes), time.Minute)
+	config.MigrateDurationFromInt(raw,
 		[]string{"providerHttp", "totalTimeoutMinutes"}, []string{"providerHttp", "totalTimeout"},
-		&cfg.ProviderHttp.TotalTimeout, cfg.ProviderHttp.TotalTimeoutMinutes, time.Minute)
-	migrateDuration(raw,
+		&cfg.ProviderHttp.TotalTimeout, int64(cfg.ProviderHttp.TotalTimeoutMinutes), time.Minute)
+	config.MigrateDurationFromInt(raw,
 		[]string{"providerHttp", "responseHeaderTimeoutMinutes"}, []string{"providerHttp", "responseHeaderTimeout"},
-		&cfg.ProviderHttp.ResponseHeaderTimeout, cfg.ProviderHttp.ResponseHeaderTimeoutMinutes, time.Minute)
+		&cfg.ProviderHttp.ResponseHeaderTimeout, int64(cfg.ProviderHttp.ResponseHeaderTimeoutMinutes), time.Minute)
 
 	// Rename: database.provider → database.dsn
-	migrateStringRename(raw, []string{"database", "provider"}, []string{"database", "dsn"},
+	config.MigrateStringRename(raw, []string{"database", "provider"}, []string{"database", "dsn"},
 		&cfg.Database.DSN, cfg.Database.Provider)
 
 	// Rename: event.providerAddr → event.listenAddr
-	migrateStringRename(raw, []string{"event", "providerAddr"}, []string{"event", "listenAddr"},
+	config.MigrateStringRename(raw, []string{"event", "providerAddr"}, []string{"event", "listenAddr"},
 		&cfg.Event.ListenAddr, cfg.Event.ProviderAddr)
 
 	// Rename: zk.provider → zk.url
-	migrateStringRename(raw, []string{"zk", "provider"}, []string{"zk", "url"},
+	config.MigrateStringRename(raw, []string{"zk", "provider"}, []string{"zk", "url"},
 		&cfg.ZK.URL, cfg.ZK.Provider)
 
 	// Networks (map) → Network (single).
@@ -695,11 +659,13 @@ func migrateDeprecated(cfg *Config, raw map[string]interface{}) error {
 			// Both keys explicitly set in yaml is genuinely ambiguous:
 			// the legacy block usually carries url/chainID while the new
 			// block often only carries privateKeys mid-migration.
-			// Refuse to guess.
+			// Refuse to guess. (Scalar renames above stay lenient — a
+			// single deprecated string field can't lose complementary
+			// data the way a structured Networks block can.)
 			return fmt.Errorf("invalid config: both deprecated 'networks' and new 'network' are set in yaml; delete the 'networks' block to complete the migration")
 		}
 		config.WarnDeprecated("networks", "network")
-		picked, err := pickLegacyNetwork(cfg.Networks)
+		picked, err := config.PickLegacyNetwork(cfg.Networks) //nolint:staticcheck // intentional reference to deprecated Networks for the #507 fallback window
 		if err != nil {
 			return err
 		}
@@ -715,34 +681,6 @@ func migrateDeprecated(cfg *Config, raw map[string]interface{}) error {
 	}
 
 	return nil
-}
-
-// pickLegacyNetwork chooses a single entry out of a legacy Networks map. For
-// 1-entry maps the only entry wins. For multi-entry (pre-#507 multi-network
-// configs that shipped with both ethereumHardhat and ethereum0g) we honor the
-// pre-#507 NETWORK env var so existing dev workflows keep working through the
-// deprecation window: NETWORK=hardhat → ethereumHardhat, otherwise →
-// ethereum0g. The selection is removed entirely at the cleanup deadline.
-func pickLegacyNetwork(networks config.Networks) (*config.NetworkConfig, error) { //nolint:staticcheck // intentional reference to deprecated Networks for the #507 fallback window
-	if len(networks) == 0 {
-		return nil, fmt.Errorf("invalid config: 'networks' is set but empty")
-	}
-	if len(networks) == 1 {
-		for _, nc := range networks {
-			if nc == nil {
-				return nil, fmt.Errorf("invalid config: 'networks' entry has no value; either delete it or fill in url/chainID/privateKeys")
-			}
-			return nc, nil
-		}
-	}
-	wanted := "ethereum0g"
-	if os.Getenv("NETWORK") == "hardhat" {
-		wanted = "ethereumHardhat"
-	}
-	if nc, ok := networks[wanted]; ok && nc != nil {
-		return nc, nil
-	}
-	return nil, fmt.Errorf("invalid config: 'networks' contains %d entries; flatten to a single 'network' block (multi-network was never used in production)", len(networks))
 }
 
 func loadConfig(cfg *Config) error {

--- a/api/inference/config/config.go
+++ b/api/inference/config/config.go
@@ -294,20 +294,30 @@ type WhitelistConfig struct {
 // via ServerlessLLM, with per-user access control and automatic adapter
 // lifecycle management driven by on-chain events.
 type LoRAConfig struct {
-	Enable                   bool   `yaml:"enable"`
-	BaseModel                string `yaml:"baseModel"`           // Base model name (e.g., "Qwen2.5-7B")
-	LoraModulesDir           string `yaml:"loraModulesDir"`      // Local directory for LoRA adapter files
-	SllmUrl                  string `yaml:"sllmUrl"`             // ServerlessLLM HTTP endpoint (default: http://sllm:8343)
-	OffloadAfterMinutes      int    `yaml:"offloadAfterMinutes"` // Idle time before offloading adapter from ServerlessLLM
-	EnableColdStorage        bool   `yaml:"enableColdStorage"`   // Enable offload to 0G Storage
-	FineTuningContractAddr   string `yaml:"fineTuningContractAddress"`
-	ChainRpcUrl              string `yaml:"chainRpcUrl"`
-	PollBlockIntervalSeconds int    `yaml:"pollBlockIntervalSeconds"` // How often to poll for new on-chain events
-	StorageIndexerUrl        string `yaml:"storageIndexerUrl"`        // 0G Storage indexer URL for downloading adapters
-	StorageTurbo             bool   `yaml:"storageTurbo"`             // Use turbo indexer for 0G Storage
-	AutoDeploy               bool   `yaml:"autoDeploy"`               // If true, auto-deploy adapters to vLLM on acknowledge; if false, download only (user must call deploy API)
-	FineTuningProviderAddr   string `yaml:"fineTuningProviderAddr"`   // Override FT provider address for event filtering (default: inference provider address)
-	EciesPrivateKey          string `yaml:"-"`                        // Override ECIES private key for adapter decryption (2-CVM setup). Set via env var LORA_ECIES_PRIVATE_KEY.
+	Enable         bool   `yaml:"enable"`
+	BaseModel      string `yaml:"baseModel"`      // Base model name (e.g., "Qwen2.5-7B")
+	LoraModulesDir string `yaml:"loraModulesDir"` // Local directory for LoRA adapter files
+	SllmUrl        string `yaml:"sllmUrl"`        // ServerlessLLM HTTP endpoint (default: http://sllm:8343)
+	// OffloadAfter is the idle time before offloading an adapter from ServerlessLLM.
+	OffloadAfter time.Duration `yaml:"offloadAfter"`
+	// OffloadAfterMinutes is the legacy integer-minutes form.
+	// Deprecated: use OffloadAfter. Removed after config.DeprecationRemovalDate.
+	OffloadAfterMinutes int `yaml:"offloadAfterMinutes,omitempty"`
+
+	EnableColdStorage      bool   `yaml:"enableColdStorage"`         // Enable offload to 0G Storage
+	FineTuningContractAddr string `yaml:"fineTuningContractAddress"` //nolint:revive
+	ChainRpcUrl            string `yaml:"chainRpcUrl"`
+	// PollBlockInterval is how often the watcher polls for new on-chain events.
+	PollBlockInterval time.Duration `yaml:"pollBlockInterval"`
+	// PollBlockIntervalSeconds is the legacy integer-seconds form.
+	// Deprecated: use PollBlockInterval. Removed after config.DeprecationRemovalDate.
+	PollBlockIntervalSeconds int `yaml:"pollBlockIntervalSeconds,omitempty"`
+
+	StorageIndexerUrl      string `yaml:"storageIndexerUrl"`      // 0G Storage indexer URL for downloading adapters
+	StorageTurbo           bool   `yaml:"storageTurbo"`           // Use turbo indexer for 0G Storage
+	AutoDeploy             bool   `yaml:"autoDeploy"`             // If true, auto-deploy adapters to vLLM on acknowledge; if false, download only (user must call deploy API)
+	FineTuningProviderAddr string `yaml:"fineTuningProviderAddr"` // Override FT provider address for event filtering (default: inference provider address)
+	EciesPrivateKey        string `yaml:"-"`                      // Override ECIES private key for adapter decryption (2-CVM setup). Set via env var LORA_ECIES_PRIVATE_KEY.
 }
 
 type Config struct {
@@ -321,11 +331,16 @@ type Config struct {
 	} `yaml:"event"`
 	GasPrice    string `yaml:"gasPrice"`
 	MaxGasPrice string `yaml:"maxGasPrice"`
-	Interval    struct {
-		AutoSettleBufferTime     int `yaml:"autoSettleBufferTime"`
-		ForceSettlementProcessor int `yaml:"forceSettlementProcessor"`
-		SettlementProcessor      int `yaml:"settlementProcessor"`
-		ReconciliationProcessor  int `yaml:"reconciliationProcessor"`
+	Interval struct {
+		// All four fields used to be integer seconds; they are now
+		// time.Duration (parsed from yaml strings like "60s" / "10m").
+		// loadConfig restores the legacy integer-seconds semantics when
+		// it detects the raw yaml value is a number — see
+		// migrateDeprecated.
+		AutoSettleBufferTime     time.Duration `yaml:"autoSettleBufferTime"`
+		ForceSettlementProcessor time.Duration `yaml:"forceSettlementProcessor"`
+		SettlementProcessor      time.Duration `yaml:"settlementProcessor"`
+		ReconciliationProcessor  time.Duration `yaml:"reconciliationProcessor"`
 	} `yaml:"interval"`
 	Settlement struct {
 		// MinSettlementFee is the minimum accumulated fee (in neuron) per user
@@ -336,9 +351,9 @@ type Config struct {
 		MinSettlementFee string `yaml:"minSettlementFee"`
 	} `yaml:"settlement"`
 	RevenueTransfer struct {
-		TargetAddress string `yaml:"targetAddress"`
-		ReserveAmount string `yaml:"reserveAmount"`
-		Interval      int    `yaml:"interval"`
+		TargetAddress string        `yaml:"targetAddress"`
+		ReserveAmount string        `yaml:"reserveAmount"`
+		Interval      time.Duration `yaml:"interval"`
 	} `yaml:"revenueTransfer"`
 	Service Service    `yaml:"service"`
 	LoRA    LoRAConfig `yaml:"lora"`
@@ -386,19 +401,38 @@ type ConcurrencyLimitConfig struct {
 
 // AsyncConfig defines configuration for async job processing.
 type AsyncConfig struct {
-	Enabled                bool `yaml:"enabled"`                // Enable async endpoints (default: true)
-	MaxConcurrentJobs      int  `yaml:"maxConcurrentJobs"`      // Max concurrent worker goroutines (default: 10)
-	MaxQueueSize           int  `yaml:"maxQueueSize"`           // Max pending jobs waiting for a worker (default: 100)
-	ResultTTLMinutes       int  `yaml:"resultTTLMinutes"`       // How long to keep completed results (default: 30)
-	CleanupIntervalSeconds int  `yaml:"cleanupIntervalSeconds"` // Interval for expired job cleanup (default: 60)
-	JobTimeoutMinutes      int  `yaml:"jobTimeoutMinutes"`      // Per-job HTTP request timeout (default: 15)
+	Enabled           bool `yaml:"enabled"`           // Enable async endpoints (default: true)
+	MaxConcurrentJobs int  `yaml:"maxConcurrentJobs"` // Max concurrent worker goroutines (default: 10)
+	MaxQueueSize      int  `yaml:"maxQueueSize"`      // Max pending jobs waiting for a worker (default: 100)
+
+	// ResultTTL: how long to keep completed results.
+	ResultTTL time.Duration `yaml:"resultTTL"`
+	// Deprecated: use ResultTTL. Removed after config.DeprecationRemovalDate.
+	ResultTTLMinutes int `yaml:"resultTTLMinutes,omitempty"`
+
+	// CleanupInterval: interval for expired job cleanup.
+	CleanupInterval time.Duration `yaml:"cleanupInterval"`
+	// Deprecated: use CleanupInterval. Removed after config.DeprecationRemovalDate.
+	CleanupIntervalSeconds int `yaml:"cleanupIntervalSeconds,omitempty"`
+
+	// JobTimeout: per-job HTTP request timeout.
+	JobTimeout time.Duration `yaml:"jobTimeout"`
+	// Deprecated: use JobTimeout. Removed after config.DeprecationRemovalDate.
+	JobTimeoutMinutes int `yaml:"jobTimeoutMinutes,omitempty"`
 }
 
 // ProviderHttpConfig defines HTTP client timeouts for broker→provider communication.
 // Providers can tune these values based on their GPU capacity and model complexity.
 type ProviderHttpConfig struct {
-	TotalTimeoutMinutes          int `yaml:"totalTimeoutMinutes"`          // Overall HTTP request timeout (default: 15)
-	ResponseHeaderTimeoutMinutes int `yaml:"responseHeaderTimeoutMinutes"` // Max time to wait for provider to start responding (default: 15)
+	// TotalTimeout: overall HTTP request timeout.
+	TotalTimeout time.Duration `yaml:"totalTimeout"`
+	// Deprecated: use TotalTimeout. Removed after config.DeprecationRemovalDate.
+	TotalTimeoutMinutes int `yaml:"totalTimeoutMinutes,omitempty"`
+
+	// ResponseHeaderTimeout: max time to wait for provider to start responding.
+	ResponseHeaderTimeout time.Duration `yaml:"responseHeaderTimeout"`
+	// Deprecated: use ResponseHeaderTimeout. Removed after config.DeprecationRemovalDate.
+	ResponseHeaderTimeoutMinutes int `yaml:"responseHeaderTimeoutMinutes,omitempty"`
 }
 
 type LogPathsConfig struct {
@@ -549,6 +583,25 @@ var (
 	once     sync.Once
 )
 
+// migrateDuration migrates a "field with unit suffix" deprecated form: the old
+// yaml key (e.g. offloadAfterMinutes) holds an integer count of `unit`, and the
+// new key (e.g. offloadAfter) holds a time.Duration. Precedence: new key wins
+// when both are present.
+func migrateDuration(raw map[string]interface{}, oldPath, newPath []string, target *time.Duration, oldValue int, unit time.Duration) {
+	oldHere := config.RawHasKey(raw, oldPath...)
+	if !oldHere {
+		return
+	}
+	oldDotted := strings.Join(oldPath, ".")
+	newDotted := strings.Join(newPath, ".")
+	if config.RawHasKey(raw, newPath...) {
+		config.WarnDeprecatedBothSet(oldDotted, newDotted)
+		return
+	}
+	config.WarnDeprecated(oldDotted, newDotted)
+	*target = time.Duration(oldValue) * unit
+}
+
 // migrateDeprecated copies values from deprecated yaml keys to their
 // replacements when the user has populated the deprecated form. Each call to
 // config.WarnDeprecated emits a one-shot stderr line so operators see exactly
@@ -557,6 +610,41 @@ var (
 // Precedence rule: if the user wrote both the old and the new key, the new
 // key wins and a separate "both set" warning is emitted.
 func migrateDeprecated(cfg *Config, raw map[string]interface{}) error {
+	// Interval / RevenueTransfer.Interval kept their yaml keys but flipped
+	// from int (implicit seconds) to time.Duration. When the raw yaml value
+	// is a number, migrate it to seconds; otherwise the new-style string
+	// value already parsed by UnmarshalStrict is correct.
+	config.MigrateIntegerSecondsDuration(raw, &cfg.Interval.AutoSettleBufferTime, time.Second, "interval", "autoSettleBufferTime")
+	config.MigrateIntegerSecondsDuration(raw, &cfg.Interval.ForceSettlementProcessor, time.Second, "interval", "forceSettlementProcessor")
+	config.MigrateIntegerSecondsDuration(raw, &cfg.Interval.SettlementProcessor, time.Second, "interval", "settlementProcessor")
+	config.MigrateIntegerSecondsDuration(raw, &cfg.Interval.ReconciliationProcessor, time.Second, "interval", "reconciliationProcessor")
+	config.MigrateIntegerSecondsDuration(raw, &cfg.RevenueTransfer.Interval, time.Second, "revenueTransfer", "interval")
+
+	// Suffixed fields (Minutes/Seconds): old yaml key was kept as a separate
+	// deprecated struct field; copy it over if the user still has the old
+	// form. New key wins if both are set.
+	migrateDuration(raw,
+		[]string{"lora", "offloadAfterMinutes"}, []string{"lora", "offloadAfter"},
+		&cfg.LoRA.OffloadAfter, cfg.LoRA.OffloadAfterMinutes, time.Minute)
+	migrateDuration(raw,
+		[]string{"lora", "pollBlockIntervalSeconds"}, []string{"lora", "pollBlockInterval"},
+		&cfg.LoRA.PollBlockInterval, cfg.LoRA.PollBlockIntervalSeconds, time.Second)
+	migrateDuration(raw,
+		[]string{"async", "resultTTLMinutes"}, []string{"async", "resultTTL"},
+		&cfg.Async.ResultTTL, cfg.Async.ResultTTLMinutes, time.Minute)
+	migrateDuration(raw,
+		[]string{"async", "cleanupIntervalSeconds"}, []string{"async", "cleanupInterval"},
+		&cfg.Async.CleanupInterval, cfg.Async.CleanupIntervalSeconds, time.Second)
+	migrateDuration(raw,
+		[]string{"async", "jobTimeoutMinutes"}, []string{"async", "jobTimeout"},
+		&cfg.Async.JobTimeout, cfg.Async.JobTimeoutMinutes, time.Minute)
+	migrateDuration(raw,
+		[]string{"providerHttp", "totalTimeoutMinutes"}, []string{"providerHttp", "totalTimeout"},
+		&cfg.ProviderHttp.TotalTimeout, cfg.ProviderHttp.TotalTimeoutMinutes, time.Minute)
+	migrateDuration(raw,
+		[]string{"providerHttp", "responseHeaderTimeoutMinutes"}, []string{"providerHttp", "responseHeaderTimeout"},
+		&cfg.ProviderHttp.ResponseHeaderTimeout, cfg.ProviderHttp.ResponseHeaderTimeoutMinutes, time.Minute)
+
 	// Networks (map) → Network (single).
 	if config.RawHasKey(raw, "networks") {
 		if config.RawHasKey(raw, "network") {
@@ -721,15 +809,15 @@ func GetConfig() *Config {
 			GasPrice:    "2000000007",
 			MaxGasPrice: "",
 			Interval: struct {
-				AutoSettleBufferTime     int `yaml:"autoSettleBufferTime"`
-				ForceSettlementProcessor int `yaml:"forceSettlementProcessor"`
-				SettlementProcessor      int `yaml:"settlementProcessor"`
-				ReconciliationProcessor  int `yaml:"reconciliationProcessor"`
+				AutoSettleBufferTime     time.Duration `yaml:"autoSettleBufferTime"`
+				ForceSettlementProcessor time.Duration `yaml:"forceSettlementProcessor"`
+				SettlementProcessor      time.Duration `yaml:"settlementProcessor"`
+				ReconciliationProcessor  time.Duration `yaml:"reconciliationProcessor"`
 			}{
-				AutoSettleBufferTime:     60,
-				ForceSettlementProcessor: 600,
-				SettlementProcessor:      300,
-				ReconciliationProcessor:  60,
+				AutoSettleBufferTime:     60 * time.Second,
+				ForceSettlementProcessor: 10 * time.Minute,
+				SettlementProcessor:      5 * time.Minute,
+				ReconciliationProcessor:  60 * time.Second,
 			},
 			Settlement: struct {
 				MinSettlementFee string `yaml:"minSettlementFee"`
@@ -737,13 +825,13 @@ func GetConfig() *Config {
 				MinSettlementFee: "4000000000000000",
 			},
 			RevenueTransfer: struct {
-				TargetAddress string `yaml:"targetAddress"`
-				ReserveAmount string `yaml:"reserveAmount"`
-				Interval      int    `yaml:"interval"`
+				TargetAddress string        `yaml:"targetAddress"`
+				ReserveAmount string        `yaml:"reserveAmount"`
+				Interval      time.Duration `yaml:"interval"`
 			}{
 				TargetAddress: "",
 				ReserveAmount: "10000000000000000000",
-				Interval:      3600,
+				Interval:      time.Hour,
 			},
 			Monitor: struct {
 				Enable       bool   `yaml:"enable"`
@@ -760,13 +848,13 @@ func GetConfig() *Config {
 				RequestLength: 40,
 			},
 			LoRA: LoRAConfig{
-				Enable:                   false,
-				LoraModulesDir:           "/data/lora-modules",
-				SllmUrl:                  "http://sllm:8343",
-				OffloadAfterMinutes:      60,
-				EnableColdStorage:        false,
-				PollBlockIntervalSeconds: 5,
-				StorageTurbo:             false,
+				Enable:            false,
+				LoraModulesDir:    "/data/lora-modules",
+				SllmUrl:           "http://sllm:8343",
+				OffloadAfter:      60 * time.Minute,
+				EnableColdStorage: false,
+				PollBlockInterval: 5 * time.Second,
+				StorageTurbo:      false,
 			},
 			ChatCacheExpiration: time.Minute * 20,
 			NvGPU:               false,
@@ -827,16 +915,16 @@ func GetConfig() *Config {
 				PerUserIPMBurst:      0,
 			},
 			Async: AsyncConfig{
-				Enabled:                true,
-				MaxConcurrentJobs:      10,
-				MaxQueueSize:           100,
-				ResultTTLMinutes:       30,
-				CleanupIntervalSeconds: 60,
-				JobTimeoutMinutes:      15,
+				Enabled:           true,
+				MaxConcurrentJobs: 10,
+				MaxQueueSize:      100,
+				ResultTTL:         30 * time.Minute,
+				CleanupInterval:   60 * time.Second,
+				JobTimeout:        15 * time.Minute,
 			},
 			ProviderHttp: ProviderHttpConfig{
-				TotalTimeoutMinutes:          15,
-				ResponseHeaderTimeoutMinutes: 15,
+				TotalTimeout:          15 * time.Minute,
+				ResponseHeaderTimeout: 15 * time.Minute,
 			},
 		}
 

--- a/api/inference/config/config.go
+++ b/api/inference/config/config.go
@@ -340,9 +340,14 @@ type Config struct {
 		ReserveAmount string `yaml:"reserveAmount"`
 		Interval      int    `yaml:"interval"`
 	} `yaml:"revenueTransfer"`
-	Service  Service         `yaml:"service"`
-	LoRA     LoRAConfig      `yaml:"lora"`
-	Networks config.Networks `mapstructure:"networks" yaml:"networks"`
+	Service Service    `yaml:"service"`
+	LoRA    LoRAConfig `yaml:"lora"`
+	// Network is the canonical single-network config (introduced by #507).
+	Network config.NetworkConfig `mapstructure:"network" yaml:"network"`
+	// Networks is the legacy multi-network map kept for backwards
+	// compatibility. Deprecated: use Network instead. Removed after
+	// config.DeprecationRemovalDate.
+	Networks config.Networks `mapstructure:"networks" yaml:"networks,omitempty"`
 	Monitor  struct {
 		Enable       bool   `yaml:"enable"`
 		EventAddress string `yaml:"eventAddress"`
@@ -544,93 +549,133 @@ var (
 	once     sync.Once
 )
 
-func loadConfig(config *Config) error {
+// migrateDeprecated copies values from deprecated yaml keys to their
+// replacements when the user has populated the deprecated form. Each call to
+// config.WarnDeprecated emits a one-shot stderr line so operators see exactly
+// which keys still need to move before the removal deadline.
+//
+// Precedence rule: if the user wrote both the old and the new key, the new
+// key wins and a separate "both set" warning is emitted.
+func migrateDeprecated(cfg *Config, raw map[string]interface{}) error {
+	// Networks (map) → Network (single).
+	if config.RawHasKey(raw, "networks") {
+		if config.RawHasKey(raw, "network") {
+			config.WarnDeprecatedBothSet("networks", "network")
+		} else {
+			config.WarnDeprecated("networks", "network")
+			switch len(cfg.Networks) {
+			case 0:
+				return fmt.Errorf("invalid config: 'networks' is set but empty")
+			case 1:
+				for _, nc := range cfg.Networks {
+					if nc != nil {
+						cfg.Network = *nc
+					}
+				}
+			default:
+				return fmt.Errorf("invalid config: 'networks' contains %d entries; flatten to a single 'network' block (multi-network was never used in production)", len(cfg.Networks))
+			}
+		}
+	}
+	return nil
+}
+
+func loadConfig(cfg *Config) error {
 	configPath := "/etc/config/config.yaml"
 	if envPath := os.Getenv("CONFIG_FILE"); envPath != "" {
 		configPath = envPath
 	}
 
 	// Always set ConfigFile so Controller knows the path
-	config.Controller.ConfigFile = configPath
+	cfg.Controller.ConfigFile = configPath
 
-	data, err := os.ReadFile(configPath)
+	data, missing, err := config.ReadConfigFile(configPath)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
+		return err
+	}
+	if missing {
+		return nil
+	}
+
+	// Two-phase parse: the raw map lets migration logic detect which keys
+	// the user actually wrote (vs. which came from struct defaults). See
+	// migrateDeprecated.
+	raw := config.RawYAMLKeys(data)
+
+	if err := yaml.UnmarshalStrict(data, cfg); err != nil {
 		return err
 	}
 
-	if err := yaml.UnmarshalStrict(data, config); err != nil {
+	if err := migrateDeprecated(cfg, raw); err != nil {
 		return err
 	}
 
-	if config.Service.ModelInfo != nil {
-		if err := config.Service.ModelInfo.Validate(config.Service.Type); err != nil {
+	if cfg.Service.ModelInfo != nil {
+		if err := cfg.Service.ModelInfo.Validate(cfg.Service.Type); err != nil {
 			return fmt.Errorf("invalid config: %w", err)
 		}
 	}
 
 	// Normalize and validate provider type
-	if config.Service.ProviderType == "" {
-		config.Service.ProviderType = constant.ProviderTypeDecentralized
+	if cfg.Service.ProviderType == "" {
+		cfg.Service.ProviderType = constant.ProviderTypeDecentralized
 	}
-	if config.Service.ProviderType != constant.ProviderTypeDecentralized && config.Service.ProviderType != constant.ProviderTypeCentralized {
-		return fmt.Errorf("invalid config: service.providerType must be '%s' or '%s', got '%s'", constant.ProviderTypeDecentralized, constant.ProviderTypeCentralized, config.Service.ProviderType)
+	if cfg.Service.ProviderType != constant.ProviderTypeDecentralized && cfg.Service.ProviderType != constant.ProviderTypeCentralized {
+		return fmt.Errorf("invalid config: service.providerType must be '%s' or '%s', got '%s'", constant.ProviderTypeDecentralized, constant.ProviderTypeCentralized, cfg.Service.ProviderType)
 	}
-	if config.Service.ProviderType == constant.ProviderTypeCentralized {
-		if config.Service.ProviderIdentity == "" {
+	if cfg.Service.ProviderType == constant.ProviderTypeCentralized {
+		if cfg.Service.ProviderIdentity == "" {
 			return fmt.Errorf("invalid config: service.providerIdentity is required when providerType is 'centralized'")
 		}
-		config.Service.ProviderIdentity = strings.ToLower(config.Service.ProviderIdentity)
-		if !validProviderIdentity.MatchString(config.Service.ProviderIdentity) {
-			return fmt.Errorf("invalid config: service.providerIdentity must be lowercase alphanumeric with optional hyphens (e.g., 'openai', 'anthropic'), got '%s'", config.Service.ProviderIdentity)
+		cfg.Service.ProviderIdentity = strings.ToLower(cfg.Service.ProviderIdentity)
+		if !validProviderIdentity.MatchString(cfg.Service.ProviderIdentity) {
+			return fmt.Errorf("invalid config: service.providerIdentity must be lowercase alphanumeric with optional hyphens (e.g., 'openai', 'anthropic'), got '%s'", cfg.Service.ProviderIdentity)
 		}
 		// Centralized providers always behave as TargetSeparated (shared external backend)
-		config.Service.TargetSeparated = true
+		cfg.Service.TargetSeparated = true
 		// Require HTTPS for centralized providers — routing proof relies on
 		// resp.TLS which is only populated for HTTPS connections.
-		if config.Service.TargetURL != "" && !strings.HasPrefix(strings.ToLower(config.Service.TargetURL), "https://") {
-			return fmt.Errorf("invalid config: service.targetUrl must use HTTPS for centralized providers (routing proof requires TLS), got '%s'", config.Service.TargetURL)
+		if cfg.Service.TargetURL != "" && !strings.HasPrefix(strings.ToLower(cfg.Service.TargetURL), "https://") {
+			return fmt.Errorf("invalid config: service.targetUrl must use HTTPS for centralized providers (routing proof requires TLS), got '%s'", cfg.Service.TargetURL)
 		}
 	}
 
 	// Normalize and validate price denomination / priceFeed configuration.
-	if config.Service.PriceDenomination == "" {
-		config.Service.PriceDenomination = constant.PriceDenominationNative
+	if cfg.Service.PriceDenomination == "" {
+		cfg.Service.PriceDenomination = constant.PriceDenominationNative
 	}
-	config.Service.PriceDenomination = strings.ToUpper(config.Service.PriceDenomination)
-	switch config.Service.PriceDenomination {
+	cfg.Service.PriceDenomination = strings.ToUpper(cfg.Service.PriceDenomination)
+	switch cfg.Service.PriceDenomination {
 	case constant.PriceDenominationNative:
-		if config.Service.InputPriceUSDPerMillionTokens != "" || config.Service.OutputPriceUSDPerMillionTokens != "" {
+		if cfg.Service.InputPriceUSDPerMillionTokens != "" || cfg.Service.OutputPriceUSDPerMillionTokens != "" {
 			return fmt.Errorf("invalid config: service.inputPriceUSDPerMillionTokens / service.outputPriceUSDPerMillionTokens must be empty when priceDenomination is '%s'", constant.PriceDenominationNative)
 		}
 	case constant.PriceDenominationUSD:
-		if config.Service.InputPriceUSDPerMillionTokens == "" || config.Service.OutputPriceUSDPerMillionTokens == "" {
+		if cfg.Service.InputPriceUSDPerMillionTokens == "" || cfg.Service.OutputPriceUSDPerMillionTokens == "" {
 			return fmt.Errorf("invalid config: service.inputPriceUSDPerMillionTokens and service.outputPriceUSDPerMillionTokens are required when priceDenomination is '%s'", constant.PriceDenominationUSD)
 		}
-		if err := validateUSDPriceString("service.inputPriceUSDPerMillionTokens", config.Service.InputPriceUSDPerMillionTokens); err != nil {
+		if err := validateUSDPriceString("service.inputPriceUSDPerMillionTokens", cfg.Service.InputPriceUSDPerMillionTokens); err != nil {
 			return err
 		}
-		if err := validateUSDPriceString("service.outputPriceUSDPerMillionTokens", config.Service.OutputPriceUSDPerMillionTokens); err != nil {
+		if err := validateUSDPriceString("service.outputPriceUSDPerMillionTokens", cfg.Service.OutputPriceUSDPerMillionTokens); err != nil {
 			return err
 		}
-		if config.Service.InputPrice != "" || config.Service.OutputPrice != "" {
+		if cfg.Service.InputPrice != "" || cfg.Service.OutputPrice != "" {
 			return fmt.Errorf("invalid config: service.inputPrice / service.outputPrice must be empty when priceDenomination is '%s' (use the USD fields)", constant.PriceDenominationUSD)
 		}
-		if err := validatePriceFeedConfig(&config.PriceFeed); err != nil {
+		if err := validatePriceFeedConfig(&cfg.PriceFeed); err != nil {
 			return err
 		}
 	default:
-		return fmt.Errorf("invalid config: service.priceDenomination must be '%s' or '%s', got '%s'", constant.PriceDenominationNative, constant.PriceDenominationUSD, config.Service.PriceDenomination)
+		return fmt.Errorf("invalid config: service.priceDenomination must be '%s' or '%s', got '%s'", constant.PriceDenominationNative, constant.PriceDenominationUSD, cfg.Service.PriceDenomination)
 	}
 
 	// Validate tiered pricing configuration
-	if config.TieredPricing.Enabled {
-		if len(config.TieredPricing.Tiers) == 0 {
+	if cfg.TieredPricing.Enabled {
+		if len(cfg.TieredPricing.Tiers) == 0 {
 			return fmt.Errorf("invalid config: tieredPricing.tiers must not be empty when tieredPricing is enabled")
 		}
-		for i, tier := range config.TieredPricing.Tiers {
+		for i, tier := range cfg.TieredPricing.Tiers {
 			if tier.InputMultiplier < 1 {
 				return fmt.Errorf("invalid config: tieredPricing.tiers[%d].inputMultiplier must be >= 1, got %d", i, tier.InputMultiplier)
 			}
@@ -641,12 +686,12 @@ func loadConfig(config *Config) error {
 				return fmt.Errorf("invalid config: tieredPricing.tiers[%d].maxInputTokens must be >= 0, got %d", i, tier.MaxInputTokens)
 			}
 			// MaxInputTokens == 0 (unbounded) must be the last tier
-			if tier.MaxInputTokens == 0 && i != len(config.TieredPricing.Tiers)-1 {
+			if tier.MaxInputTokens == 0 && i != len(cfg.TieredPricing.Tiers)-1 {
 				return fmt.Errorf("invalid config: tieredPricing.tiers[%d].maxInputTokens=0 (unbounded) must be the last tier", i)
 			}
 			// Ensure ascending order
 			if i > 0 && tier.MaxInputTokens != 0 {
-				prev := config.TieredPricing.Tiers[i-1]
+				prev := cfg.TieredPricing.Tiers[i-1]
 				if prev.MaxInputTokens != 0 && tier.MaxInputTokens <= prev.MaxInputTokens {
 					return fmt.Errorf("invalid config: tieredPricing.tiers must be ordered by maxInputTokens ascending, tiers[%d]=%d <= tiers[%d]=%d",
 						i, tier.MaxInputTokens, i-1, prev.MaxInputTokens)
@@ -799,9 +844,7 @@ func GetConfig() *Config {
 			panic(err)
 		}
 
-		for _, networkConf := range instance.Networks {
-			networkConf.PrivateKeyStore = config.NewPrivateKeyStore(networkConf)
-		}
+		instance.Network.PrivateKeyStore = config.NewPrivateKeyStore(&instance.Network)
 	})
 
 	return instance

--- a/api/inference/config/config.go
+++ b/api/inference/config/config.go
@@ -692,24 +692,57 @@ func migrateDeprecated(cfg *Config, raw map[string]interface{}) error {
 	// Networks (map) → Network (single).
 	if config.RawHasKey(raw, "networks") {
 		if config.RawHasKey(raw, "network") {
-			config.WarnDeprecatedBothSet("networks", "network")
-		} else {
-			config.WarnDeprecated("networks", "network")
-			switch len(cfg.Networks) {
-			case 0:
-				return fmt.Errorf("invalid config: 'networks' is set but empty")
-			case 1:
-				for _, nc := range cfg.Networks {
-					if nc != nil {
-						cfg.Network = *nc
-					}
-				}
-			default:
-				return fmt.Errorf("invalid config: 'networks' contains %d entries; flatten to a single 'network' block (multi-network was never used in production)", len(cfg.Networks))
+			// Both keys explicitly set in yaml is genuinely ambiguous:
+			// the legacy block usually carries url/chainID while the new
+			// block often only carries privateKeys mid-migration.
+			// Refuse to guess.
+			return fmt.Errorf("invalid config: both deprecated 'networks' and new 'network' are set in yaml; delete the 'networks' block to complete the migration")
+		}
+		config.WarnDeprecated("networks", "network")
+		picked, err := pickLegacyNetwork(cfg.Networks)
+		if err != nil {
+			return err
+		}
+		cfg.Network = *picked
+	}
+
+	// Validate that, after any migration, we have a usable Network. Catches
+	// the silent-empty cases: `networks: { foo: }` (nil entry) and
+	// `networks: { foo: {} }` (empty struct). Skips when neither yaml key
+	// was present — defaults / programmatic setup are out of scope.
+	if (config.RawHasKey(raw, "network") || config.RawHasKey(raw, "networks")) && cfg.Network.URL == "" {
+		return fmt.Errorf("invalid config: network.url is empty after loading; check that the 'network' (or legacy 'networks') block carries a url value")
+	}
+
+	return nil
+}
+
+// pickLegacyNetwork chooses a single entry out of a legacy Networks map. For
+// 1-entry maps the only entry wins. For multi-entry (pre-#507 multi-network
+// configs that shipped with both ethereumHardhat and ethereum0g) we honor the
+// pre-#507 NETWORK env var so existing dev workflows keep working through the
+// deprecation window: NETWORK=hardhat → ethereumHardhat, otherwise →
+// ethereum0g. The selection is removed entirely at the cleanup deadline.
+func pickLegacyNetwork(networks config.Networks) (*config.NetworkConfig, error) { //nolint:staticcheck // intentional reference to deprecated Networks for the #507 fallback window
+	if len(networks) == 0 {
+		return nil, fmt.Errorf("invalid config: 'networks' is set but empty")
+	}
+	if len(networks) == 1 {
+		for _, nc := range networks {
+			if nc == nil {
+				return nil, fmt.Errorf("invalid config: 'networks' entry has no value; either delete it or fill in url/chainID/privateKeys")
 			}
+			return nc, nil
 		}
 	}
-	return nil
+	wanted := "ethereum0g"
+	if os.Getenv("NETWORK") == "hardhat" {
+		wanted = "ethereumHardhat"
+	}
+	if nc, ok := networks[wanted]; ok && nc != nil {
+		return nc, nil
+	}
+	return nil, fmt.Errorf("invalid config: 'networks' contains %d entries; flatten to a single 'network' block (multi-network was never used in production)", len(networks))
 }
 
 func loadConfig(cfg *Config) error {

--- a/api/inference/config/deprecation_test.go
+++ b/api/inference/config/deprecation_test.go
@@ -52,8 +52,10 @@ networks:
 func TestLoadConfig_Migrate_MultiEntryNetworks_UnknownKeysError(t *testing.T) {
 	// Multi-entry legacy config with no ethereum0g (and NETWORK env unset
 	// so the ethereumHardhat fallback doesn't apply either) has no
-	// principled selection — must fail rather than guess.
-	t.Setenv("NETWORK", "")
+	// principled selection — must fail rather than guess. The error
+	// message must list the actual keys and the NETWORK value so the
+	// operator can act without re-reading the source.
+	t.Setenv("NETWORK", "staging")
 	_, err := loadFromYAML(t, `
 networks:
   alpha:
@@ -64,8 +66,10 @@ networks:
 	if err == nil {
 		t.Fatal("expected error for multi-entry networks map without canonical keys")
 	}
-	if !strings.Contains(err.Error(), "2 entries") {
-		t.Errorf("unexpected error: %v", err)
+	for _, expected := range []string{"alpha", "beta", "staging", "ethereum0g"} {
+		if !strings.Contains(err.Error(), expected) {
+			t.Errorf("error message should mention %q; got: %v", expected, err)
+		}
 	}
 }
 
@@ -233,6 +237,24 @@ revenueTransfer:
 	}
 	if cfg.RevenueTransfer.Interval != 2*time.Hour {
 		t.Errorf("RevenueTransfer.Interval = %s", cfg.RevenueTransfer.Interval)
+	}
+}
+
+func TestLoadConfig_Migrate_IntegerZero_NoWarning(t *testing.T) {
+	// `key: 0` is the same in both schemas (zero duration); the migration
+	// helper should not emit a deprecation warning that would confuse
+	// operators who explicitly wrote 0 to disable a feature. We don't
+	// capture stderr here, but we do assert the resulting value is zero
+	// and that the call returns successfully.
+	cfg, err := loadFromYAML(t, `
+interval:
+  reconciliationProcessor: 0
+`)
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	if cfg.Interval.ReconciliationProcessor != 0 {
+		t.Errorf("ReconciliationProcessor = %s, want 0", cfg.Interval.ReconciliationProcessor)
 	}
 }
 

--- a/api/inference/config/deprecation_test.go
+++ b/api/inference/config/deprecation_test.go
@@ -49,24 +49,28 @@ networks:
 	}
 }
 
-func TestLoadConfig_Migrate_NetworksMultipleEntries(t *testing.T) {
+func TestLoadConfig_Migrate_MultiEntryNetworks_UnknownKeysError(t *testing.T) {
+	// Multi-entry legacy config with no ethereum0g (and NETWORK env unset
+	// so the ethereumHardhat fallback doesn't apply either) has no
+	// principled selection — must fail rather than guess.
+	t.Setenv("NETWORK", "")
 	_, err := loadFromYAML(t, `
 networks:
-  ethereum0g:
-    url: "https://evmrpc.0g.ai"
-  ethereumHardhat:
-    url: "http://localhost:8545"
+  alpha:
+    url: "https://alpha.example"
+  beta:
+    url: "https://beta.example"
 `)
 	if err == nil {
-		t.Fatal("expected error for multi-entry networks map")
+		t.Fatal("expected error for multi-entry networks map without canonical keys")
 	}
 	if !strings.Contains(err.Error(), "2 entries") {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
 
-func TestLoadConfig_Migrate_NetworkPreferredOverNetworks(t *testing.T) {
-	cfg, err := loadFromYAML(t, `
+func TestLoadConfig_Migrate_BothSet_Errors(t *testing.T) {
+	_, err := loadFromYAML(t, `
 network:
   url: "https://new.0g.ai"
   chainID: 99
@@ -75,11 +79,91 @@ networks:
     url: "https://old.0g.ai"
     chainID: 1
 `)
+	if err == nil {
+		t.Fatal("expected error when both 'network' and 'networks' are set")
+	}
+	if !strings.Contains(err.Error(), "both deprecated 'networks' and new 'network'") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadConfig_Migrate_NetworksWithNilEntryErrors(t *testing.T) {
+	_, err := loadFromYAML(t, `
+networks:
+  ethereum0g:
+`)
+	if err == nil {
+		t.Fatal("expected error when 'networks' entry has no value")
+	}
+	if !strings.Contains(err.Error(), "entry has no value") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadConfig_Migrate_NetworksWithEmptyEntryErrors(t *testing.T) {
+	_, err := loadFromYAML(t, `
+networks:
+  ethereum0g: {}
+`)
+	if err == nil {
+		t.Fatal("expected error when 'networks' entry has no url")
+	}
+	if !strings.Contains(err.Error(), "network.url is empty") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadConfig_Migrate_NetworkWithoutURLErrors(t *testing.T) {
+	_, err := loadFromYAML(t, `
+network:
+  chainID: 16661
+  privateKeys: ["0xabc"]
+`)
+	if err == nil {
+		t.Fatal("expected error when 'network' has no url")
+	}
+	if !strings.Contains(err.Error(), "network.url is empty") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadConfig_Migrate_MultiEntryNetworks_NetworkEnvSelects(t *testing.T) {
+	// Pre-#507 dev workflow: NETWORK=hardhat selects ethereumHardhat from
+	// a multi-entry Networks map. Honored during the deprecation window.
+	t.Setenv("NETWORK", "hardhat")
+	cfg, err := loadFromYAML(t, `
+networks:
+  ethereumHardhat:
+    url: "http://localhost:8545"
+    chainID: 31337
+  ethereum0g:
+    url: "https://evmrpc.0g.ai"
+    chainID: 16661
+`)
 	if err != nil {
 		t.Fatalf("loadConfig: %v", err)
 	}
-	if cfg.Network.URL != "https://new.0g.ai" {
-		t.Errorf("Network.URL = %q; expected new key to win", cfg.Network.URL)
+	if cfg.Network.URL != "http://localhost:8545" {
+		t.Errorf("Network.URL = %q; expected hardhat entry to win when NETWORK=hardhat", cfg.Network.URL)
+	}
+}
+
+func TestLoadConfig_Migrate_MultiEntryNetworks_DefaultsTo0g(t *testing.T) {
+	t.Setenv("NETWORK", "")
+	cfg, err := loadFromYAML(t, `
+networks:
+  ethereumHardhat:
+    url: "http://localhost:8545"
+    chainID: 31337
+  ethereum0g:
+    url: "https://evmrpc.0g.ai"
+    chainID: 16661
+`)
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	if cfg.Network.URL != "https://evmrpc.0g.ai" {
+		t.Errorf("Network.URL = %q; expected ethereum0g entry to win by default", cfg.Network.URL)
 	}
 }
 

--- a/api/inference/config/deprecation_test.go
+++ b/api/inference/config/deprecation_test.go
@@ -1,0 +1,272 @@
+package config
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// minimalServiceConfig is the smallest service: stanza that satisfies
+// loadConfig's validation. Migration tests prepend deprecation-relevant yaml
+// to this so each test case stays focused.
+const minimalServiceConfig = `
+service:
+  servingUrl: "http://example.com"
+  targetUrl: "http://backend:8000"
+  inputPrice: "1000"
+  outputPrice: "2000"
+  type: "chatbot"
+  model: "test"
+  verifiability: "TeeML"
+`
+
+func loadFromYAML(t *testing.T, body string) (*Config, error) {
+	t.Helper()
+	path := writeTestConfig(t, minimalServiceConfig+body)
+	t.Setenv("CONFIG_FILE", path)
+	cfg := &Config{}
+	return cfg, loadConfig(cfg)
+}
+
+// --- Networks migration -----------------------------------------------------
+
+func TestLoadConfig_Migrate_NetworksToNetwork_Single(t *testing.T) {
+	cfg, err := loadFromYAML(t, `
+networks:
+  ethereum0g:
+    url: "https://evmrpc.0g.ai"
+    chainID: 16661
+    privateKeys: ["0xabc"]
+`)
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	if cfg.Network.URL != "https://evmrpc.0g.ai" {
+		t.Errorf("Network.URL = %q", cfg.Network.URL)
+	}
+	if cfg.Network.ChainID != 16661 {
+		t.Errorf("Network.ChainID = %d", cfg.Network.ChainID)
+	}
+}
+
+func TestLoadConfig_Migrate_NetworksMultipleEntries(t *testing.T) {
+	_, err := loadFromYAML(t, `
+networks:
+  ethereum0g:
+    url: "https://evmrpc.0g.ai"
+  ethereumHardhat:
+    url: "http://localhost:8545"
+`)
+	if err == nil {
+		t.Fatal("expected error for multi-entry networks map")
+	}
+	if !strings.Contains(err.Error(), "2 entries") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadConfig_Migrate_NetworkPreferredOverNetworks(t *testing.T) {
+	cfg, err := loadFromYAML(t, `
+network:
+  url: "https://new.0g.ai"
+  chainID: 99
+networks:
+  ethereum0g:
+    url: "https://old.0g.ai"
+    chainID: 1
+`)
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	if cfg.Network.URL != "https://new.0g.ai" {
+		t.Errorf("Network.URL = %q; expected new key to win", cfg.Network.URL)
+	}
+}
+
+func TestLoadConfig_NetworkOnly_NoMigration(t *testing.T) {
+	cfg, err := loadFromYAML(t, `
+network:
+  url: "https://evmrpc.0g.ai"
+  chainID: 16661
+`)
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	if cfg.Network.URL != "https://evmrpc.0g.ai" {
+		t.Errorf("Network.URL = %q", cfg.Network.URL)
+	}
+}
+
+// --- Time field migration (Approach A: same yaml key, type change) ----------
+
+func TestLoadConfig_Migrate_IntervalIntegerToDuration(t *testing.T) {
+	cfg, err := loadFromYAML(t, `
+interval:
+  autoSettleBufferTime: 30
+  forceSettlementProcessor: 600
+  settlementProcessor: 300
+  reconciliationProcessor: 90
+revenueTransfer:
+  interval: 7200
+`)
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	checks := []struct {
+		name string
+		got  time.Duration
+		want time.Duration
+	}{
+		{"AutoSettleBufferTime", cfg.Interval.AutoSettleBufferTime, 30 * time.Second},
+		{"ForceSettlementProcessor", cfg.Interval.ForceSettlementProcessor, 600 * time.Second},
+		{"SettlementProcessor", cfg.Interval.SettlementProcessor, 300 * time.Second},
+		{"ReconciliationProcessor", cfg.Interval.ReconciliationProcessor, 90 * time.Second},
+		{"RevenueTransfer.Interval", cfg.RevenueTransfer.Interval, 7200 * time.Second},
+	}
+	for _, c := range checks {
+		if c.got != c.want {
+			t.Errorf("%s = %s, want %s", c.name, c.got, c.want)
+		}
+	}
+}
+
+func TestLoadConfig_IntervalDurationStringForm(t *testing.T) {
+	cfg, err := loadFromYAML(t, `
+interval:
+  autoSettleBufferTime: "45s"
+  forceSettlementProcessor: "15m"
+revenueTransfer:
+  interval: "2h"
+`)
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	if cfg.Interval.AutoSettleBufferTime != 45*time.Second {
+		t.Errorf("AutoSettleBufferTime = %s", cfg.Interval.AutoSettleBufferTime)
+	}
+	if cfg.Interval.ForceSettlementProcessor != 15*time.Minute {
+		t.Errorf("ForceSettlementProcessor = %s", cfg.Interval.ForceSettlementProcessor)
+	}
+	if cfg.RevenueTransfer.Interval != 2*time.Hour {
+		t.Errorf("RevenueTransfer.Interval = %s", cfg.RevenueTransfer.Interval)
+	}
+}
+
+// --- Time field migration (Approach B: dual fields, suffix dropped) ---------
+
+func TestLoadConfig_Migrate_LegacyMinutesSecondsKeys(t *testing.T) {
+	cfg, err := loadFromYAML(t, `
+lora:
+  offloadAfterMinutes: 45
+  pollBlockIntervalSeconds: 7
+async:
+  resultTTLMinutes: 25
+  cleanupIntervalSeconds: 90
+  jobTimeoutMinutes: 20
+providerHttp:
+  totalTimeoutMinutes: 12
+  responseHeaderTimeoutMinutes: 9
+`)
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	cases := []struct {
+		name string
+		got  time.Duration
+		want time.Duration
+	}{
+		{"LoRA.OffloadAfter", cfg.LoRA.OffloadAfter, 45 * time.Minute},
+		{"LoRA.PollBlockInterval", cfg.LoRA.PollBlockInterval, 7 * time.Second},
+		{"Async.ResultTTL", cfg.Async.ResultTTL, 25 * time.Minute},
+		{"Async.CleanupInterval", cfg.Async.CleanupInterval, 90 * time.Second},
+		{"Async.JobTimeout", cfg.Async.JobTimeout, 20 * time.Minute},
+		{"ProviderHttp.TotalTimeout", cfg.ProviderHttp.TotalTimeout, 12 * time.Minute},
+		{"ProviderHttp.ResponseHeaderTimeout", cfg.ProviderHttp.ResponseHeaderTimeout, 9 * time.Minute},
+	}
+	for _, c := range cases {
+		if c.got != c.want {
+			t.Errorf("%s = %s, want %s", c.name, c.got, c.want)
+		}
+	}
+}
+
+func TestLoadConfig_NewKeysPreferredOverLegacyMinutes(t *testing.T) {
+	cfg, err := loadFromYAML(t, `
+lora:
+  offloadAfter: "10m"
+  offloadAfterMinutes: 99
+`)
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	if cfg.LoRA.OffloadAfter != 10*time.Minute {
+		t.Errorf("OffloadAfter = %s; expected new key to win", cfg.LoRA.OffloadAfter)
+	}
+}
+
+// --- Field rename migration -------------------------------------------------
+
+func TestLoadConfig_Migrate_DatabaseProviderToDSN(t *testing.T) {
+	cfg, err := loadFromYAML(t, `
+database:
+  provider: "root:pw@tcp(mysql:3306)/db?parseTime=true"
+`)
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	if cfg.Database.DSN != "root:pw@tcp(mysql:3306)/db?parseTime=true" {
+		t.Errorf("Database.DSN = %q", cfg.Database.DSN)
+	}
+}
+
+func TestLoadConfig_Migrate_EventProviderAddrToListenAddr(t *testing.T) {
+	cfg, err := loadFromYAML(t, `
+event:
+  providerAddr: ":9090"
+`)
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	if cfg.Event.ListenAddr != ":9090" {
+		t.Errorf("Event.ListenAddr = %q", cfg.Event.ListenAddr)
+	}
+}
+
+func TestLoadConfig_Migrate_ZKProviderToURL(t *testing.T) {
+	cfg, err := loadFromYAML(t, `
+zk:
+  provider: "zk-host:3001"
+`)
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	if cfg.ZK.URL != "zk-host:3001" {
+		t.Errorf("ZK.URL = %q", cfg.ZK.URL)
+	}
+}
+
+func TestLoadConfig_RenamedKeysPreferred(t *testing.T) {
+	cfg, err := loadFromYAML(t, `
+database:
+  dsn: "new-dsn"
+  provider: "old-dsn"
+event:
+  listenAddr: ":7777"
+  providerAddr: ":8888"
+zk:
+  url: "new-url"
+  provider: "old-url"
+`)
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	if cfg.Database.DSN != "new-dsn" {
+		t.Errorf("Database.DSN = %q", cfg.Database.DSN)
+	}
+	if cfg.Event.ListenAddr != ":7777" {
+		t.Errorf("Event.ListenAddr = %q", cfg.Event.ListenAddr)
+	}
+	if cfg.ZK.URL != "new-url" {
+		t.Errorf("ZK.URL = %q", cfg.ZK.URL)
+	}
+}

--- a/api/inference/contract/contract.go
+++ b/api/inference/contract/contract.go
@@ -41,14 +41,8 @@ type RetryOption struct {
 	MaxGasPrice      *big.Int
 }
 
-func NewServingContract(servingAddress common.Address, conf *config.Networks, network string, gasPrice, maxGasPrice string, logger log.Logger) (*ServingContract, error) {
-	var networkConfig client.BlockchainNetwork
-	var err error
-	if network == "hardhat" {
-		networkConfig, err = client.NewHardhatNetwork(conf)
-	} else {
-		networkConfig, err = client.New0gNetwork(conf)
-	}
+func NewServingContract(servingAddress common.Address, conf *config.NetworkConfig, gasPrice, maxGasPrice string, logger log.Logger) (*ServingContract, error) {
+	networkConfig, err := client.NewEthereumNetwork(conf)
 	if err != nil {
 		return nil, err
 	}

--- a/api/inference/integration/config/config.mainnet.yml
+++ b/api/inference/integration/config/config.mainnet.yml
@@ -9,13 +9,13 @@ contractAddress: "0x47340d900bdFec2BD393c626E12ea0656F938d84"
 
 # Database configuration
 database:
-  # Database connection string (format: user:password@tcp(host:port)/database?parseTime=true)
-  provider: "root:123456@tcp(mysql:3306)/provider?parseTime=true"
+  # MySQL DSN (format: user:password@tcp(host:port)/database?parseTime=true)
+  dsn: "root:123456@tcp(mysql:3306)/provider?parseTime=true"
 
 # Event service configuration
 event:
-  # Address where the event service listens
-  providerAddr: ":8088"
+  # Listen address for the event process's metrics HTTP server
+  listenAddr: ":8088"
 
 # Gas price configuration for blockchain transactions
 # Leave empty for automatic gas price detection
@@ -25,16 +25,16 @@ gasPrice: <gasPrice>
 # Leave empty for no limit
 maxGasPrice: <maxGasPrice>
 
-# Timing intervals for various processing tasks (in seconds)
+# Timing intervals for various processing tasks (Go duration strings)
 interval:
   # Buffer time before automatic settlement triggers
-  autoSettleBufferTime: 60
+  autoSettleBufferTime: "60s"
 
-  # Interval for forced settlement processor (in seconds)
-  forceSettlementProcessor: 600
+  # Interval for forced settlement processor
+  forceSettlementProcessor: "10m"
 
-  # Interval for regular settlement processor (in seconds)
-  settlementProcessor: 300
+  # Interval for regular settlement processor
+  settlementProcessor: "5m"
 
 # Settlement profitability configuration
 settlement:
@@ -96,25 +96,23 @@ service:
   #   teeType: "TDX"
   #   expirationDate: "2026-12-31T00:00:00Z"
 
-# Network configurations for blockchain connections
-networks:
-  # Example network configuration - 0G testnet
-  ethereum0g:
-    # RPC URL for the blockchain network
-    url: "https://evmrpc.0g.ai"
+# Network configuration for blockchain connection (0G mainnet)
+network:
+  # RPC URL for the blockchain network
+  url: "https://evmrpc.0g.ai"
 
-    # Chain ID of the network
-    chainID: 16661
+  # Chain ID of the network
+  chainID: 16661
 
-    # Private keys for transaction signing (keep secure!)
-    privateKeys:
-      - <privateKey>
+  # Private keys for transaction signing (keep secure!)
+  privateKeys:
+    - <privateKey>
 
-    # Maximum number of transactions to process in parallel
-    transactionLimit: 5000000
+  # Maximum number of transactions to process in parallel
+  transactionLimit: 5000000
 
-    # Buffer for gas estimation
-    gasEstimationBuffer: 100000
+  # Buffer for gas estimation
+  gasEstimationBuffer: 100000
 
 # Monitoring configuration
 monitor:
@@ -126,8 +124,8 @@ monitor:
 
 # Zero-knowledge configuration
 zk:
-  # Provider URL for ZK service
-  provider: "nginx:3001"
+  # URL for the ZK service
+  url: "nginx:3001"
 
   # Maximum request length for ZK operations
   requestLength: 40

--- a/api/inference/integration/config/config.testnet.yml
+++ b/api/inference/integration/config/config.testnet.yml
@@ -9,13 +9,13 @@ contractAddress: "0xa79F4c8311FF93C06b8CfB403690cc987c93F91E"
 
 # Database configuration
 database:
-  # Database connection string (format: user:password@tcp(host:port)/database?parseTime=true)
-  provider: "root:123456@tcp(mysql:3306)/provider?parseTime=true"
+  # MySQL DSN (format: user:password@tcp(host:port)/database?parseTime=true)
+  dsn: "root:123456@tcp(mysql:3306)/provider?parseTime=true"
 
 # Event service configuration
 event:
-  # Address where the event service listens
-  providerAddr: ":8088"
+  # Listen address for the event process's metrics HTTP server
+  listenAddr: ":8088"
 
 # Gas price configuration for blockchain transactions
 # Leave empty for automatic gas price detection
@@ -25,16 +25,16 @@ gasPrice: <gasPrice>
 # Leave empty for no limit
 maxGasPrice: <maxGasPrice>
 
-# Timing intervals for various processing tasks (in seconds)
+# Timing intervals for various processing tasks (Go duration strings)
 interval:
   # Buffer time before automatic settlement triggers
-  autoSettleBufferTime: 60
+  autoSettleBufferTime: "60s"
 
-  # Interval for forced settlement processor (in seconds)
-  forceSettlementProcessor: 600
+  # Interval for forced settlement processor
+  forceSettlementProcessor: "10m"
 
-  # Interval for regular settlement processor (in seconds)
-  settlementProcessor: 300
+  # Interval for regular settlement processor
+  settlementProcessor: "5m"
 
 # Settlement profitability configuration
 settlement:
@@ -96,25 +96,23 @@ service:
   #   teeType: "TDX"
   #   expirationDate: "2026-12-31T00:00:00Z"
 
-# Network configurations for blockchain connections
-networks:
-  # Example network configuration - 0G testnet
-  ethereum0g:
-    # RPC URL for the blockchain network
-    url: "https://evmrpc-testnet.0g.ai"
+# Network configuration for blockchain connection (0G testnet)
+network:
+  # RPC URL for the blockchain network
+  url: "https://evmrpc-testnet.0g.ai"
 
-    # Chain ID of the network
-    chainID: 16602
+  # Chain ID of the network
+  chainID: 16602
 
-    # Private keys for transaction signing (keep secure!)
-    privateKeys:
-      - <privateKey>
+  # Private keys for transaction signing (keep secure!)
+  privateKeys:
+    - <privateKey>
 
-    # Maximum number of transactions to process in parallel
-    transactionLimit: 5000000
+  # Maximum number of transactions to process in parallel
+  transactionLimit: 5000000
 
-    # Buffer for gas estimation
-    gasEstimationBuffer: 100000
+  # Buffer for gas estimation
+  gasEstimationBuffer: 100000
 
 # Monitoring configuration
 monitor:
@@ -126,8 +124,8 @@ monitor:
 
 # Zero-knowledge configuration
 zk:
-  # Provider URL for ZK service
-  provider: "nginx:3001"
+  # URL for the ZK service
+  url: "nginx:3001"
 
   # Maximum request length for ZK operations
   requestLength: 40

--- a/api/inference/integration/config/main.go
+++ b/api/inference/integration/config/main.go
@@ -135,7 +135,25 @@ type NetworkConfig struct {
 	GasEstimationBuffer uint64   `yaml:"gasEstimationBuffer,omitempty"`
 }
 
-type Networks map[string]*NetworkConfig
+type Networks map[string]*NetworkConfig // Deprecated: kept so legacy config files still merge during the #507 deprecation window.
+
+// networkConfigOrEmpty returns the user's NetworkConfig, preferring the new
+// `network` field. Falls back to the first entry under the legacy `networks`
+// map for users still on the pre-#507 schema.
+func networkConfigOrEmpty(c *Config) *NetworkConfig {
+	if c.Network != nil {
+		return c.Network
+	}
+	if nc, ok := c.Networks["ethereum0g"]; ok && nc != nil {
+		return nc
+	}
+	for _, nc := range c.Networks {
+		if nc != nil {
+			return nc
+		}
+	}
+	return nil
+}
 
 type ControllerConfig struct {
 	Enable         bool     `yaml:"enable,omitempty"`
@@ -166,6 +184,9 @@ type Config struct {
 		Interval      int    `yaml:"interval,omitempty"`
 	} `yaml:"revenueTransfer,omitempty"`
 	Service  Service  `yaml:"service,omitempty"`
+	Network  *NetworkConfig `yaml:"network,omitempty"`
+	// Networks is kept so legacy config files still parse during the #507
+	// deprecation window. Deprecated: use Network.
 	Networks Networks `yaml:"networks,omitempty"`
 	Monitor  struct {
 		Enable       bool   `yaml:"enable,omitempty"`
@@ -708,7 +729,7 @@ var requiredFields = []RequiredField{
 		Validator:   isNotEmpty,
 	},
 	{
-		Path:        "networks.ethereum0g.privateKeys[0]",
+		Path:        "network.privateKeys[0]",
 		Description: "Private key for blockchain transactions (64 hex characters)",
 		Validator:   nil,
 	},
@@ -2092,7 +2113,11 @@ func mergeConfigs(base, user *Config) {
 		base.Service.ProviderIdentity = user.Service.ProviderIdentity
 	}
 
-	// Merge networks
+	// Merge network (new field takes precedence; legacy `networks` map is
+	// still merged so users mid-migration don't lose values).
+	if user.Network != nil {
+		base.Network = user.Network
+	}
 	if user.Networks != nil {
 		if base.Networks == nil {
 			base.Networks = make(Networks)
@@ -2133,7 +2158,7 @@ func checkAndPromptRequiredFields(config *Config, deployLLM bool) error {
 		"service.inputPrice",
 		"service.outputPrice",
 		"service.model",
-		"networks.ethereum0g.privateKeys[0]",
+		"network.privateKeys[0]",
 	}
 
 	fieldMap := make(map[string]RequiredField)
@@ -2242,9 +2267,9 @@ func getFieldValue(config *Config, path string) string {
 		return ""
 	case "service.model":
 		return config.Service.ModelType
-	case "networks.ethereum0g.privateKeys[0]":
-		if config.Networks != nil && config.Networks["ethereum0g"] != nil && len(config.Networks["ethereum0g"].PrivateKeys) > 0 {
-			return config.Networks["ethereum0g"].PrivateKeys[0]
+	case "network.privateKeys[0]":
+		if nc := networkConfigOrEmpty(config); nc != nil && len(nc.PrivateKeys) > 0 {
+			return nc.PrivateKeys[0]
 		}
 		return ""
 	}
@@ -2271,17 +2296,14 @@ func setFieldValue(config *Config, path, value string) error {
 		}
 	case "service.model":
 		config.Service.ModelType = value
-	case "networks.ethereum0g.privateKeys[0]":
-		if config.Networks == nil {
-			config.Networks = make(Networks)
+	case "network.privateKeys[0]":
+		if config.Network == nil {
+			config.Network = &NetworkConfig{}
 		}
-		if config.Networks["ethereum0g"] == nil {
-			config.Networks["ethereum0g"] = &NetworkConfig{}
-		}
-		if len(config.Networks["ethereum0g"].PrivateKeys) == 0 {
-			config.Networks["ethereum0g"].PrivateKeys = []string{value}
+		if len(config.Network.PrivateKeys) == 0 {
+			config.Network.PrivateKeys = []string{value}
 		} else {
-			config.Networks["ethereum0g"].PrivateKeys[0] = value
+			config.Network.PrivateKeys[0] = value
 		}
 	default:
 		return fmt.Errorf("unknown field path: %s", path)
@@ -2330,29 +2352,40 @@ func cleanupPlaceholderFields(config *Config) {
 		config.ContractAddress = ""
 	}
 
-	// Clean up placeholder private keys in all networks
+	// Clean up placeholder private keys in the new single-network field.
+	if config.Network != nil {
+		cleanPlaceholderPrivateKeys(config.Network)
+		if config.Network.PrivateKeys == nil && config.Network.URL == "" {
+			config.Network = nil
+		}
+	}
+
+	// Same cleanup for the legacy networks map (still merged during the
+	// deprecation window).
 	if config.Networks != nil {
 		for networkName, network := range config.Networks {
-			if network.PrivateKeys != nil {
-				var cleanedKeys []string
-				for _, key := range network.PrivateKeys {
-					if !isPlaceholder(key) {
-						cleanedKeys = append(cleanedKeys, key)
-					}
-				}
-				// If no valid keys remain, set to nil to omit from YAML
-				if len(cleanedKeys) == 0 {
-					network.PrivateKeys = nil
-				} else {
-					network.PrivateKeys = cleanedKeys
-				}
-			}
-
-			// Remove entire network if it has no meaningful configuration
+			cleanPlaceholderPrivateKeys(network)
 			if network.PrivateKeys == nil && network.URL == "" {
 				delete(config.Networks, networkName)
 			}
 		}
+	}
+}
+
+func cleanPlaceholderPrivateKeys(n *NetworkConfig) {
+	if n == nil || n.PrivateKeys == nil {
+		return
+	}
+	var cleanedKeys []string
+	for _, key := range n.PrivateKeys {
+		if !isPlaceholder(key) {
+			cleanedKeys = append(cleanedKeys, key)
+		}
+	}
+	if len(cleanedKeys) == 0 {
+		n.PrivateKeys = nil
+	} else {
+		n.PrivateKeys = cleanedKeys
 	}
 }
 

--- a/api/inference/integration/config/main.go
+++ b/api/inference/integration/config/main.go
@@ -162,6 +162,30 @@ type ControllerConfig struct {
 	Image          string   `yaml:"image,omitempty"`
 }
 
+// durationYAML carries a Go duration value as a string. UnmarshalYAML accepts
+// both the new string form ("60s") and the pre-#507 bare-integer form (60,
+// interpreted as seconds). The marshal side always emits the string form so a
+// wizard run rewrites legacy yaml in the canonical schema.
+type durationYAML string
+
+func (d *durationYAML) UnmarshalYAML(node *yaml.Node) error {
+	if node.Kind != yaml.ScalarNode {
+		return fmt.Errorf("duration must be a scalar (line %d)", node.Line)
+	}
+	// !!int → legacy seconds; !!str → new duration string. yaml.v3 picks
+	// the tag from the literal form, so we can rely on it rather than
+	// parsing the value twice.
+	switch node.Tag {
+	case "!!int":
+		*d = durationYAML(node.Value + "s")
+	case "!!str", "":
+		*d = durationYAML(node.Value)
+	default:
+		return fmt.Errorf("duration must be an int (legacy seconds) or string (\"30s\" / \"1h\"), got tag %s at line %d", node.Tag, node.Line)
+	}
+	return nil
+}
+
 type Config struct {
 	AllowOrigins    []string `yaml:"allowOrigins,omitempty"`
 	ContractAddress string   `yaml:"contractAddress,omitempty"`
@@ -177,20 +201,20 @@ type Config struct {
 	} `yaml:"event,omitempty"`
 	GasPrice    interface{} `yaml:"gasPrice,omitempty"`
 	MaxGasPrice interface{} `yaml:"maxGasPrice,omitempty"`
-	// Interval fields hold Go duration strings ("60s", "10m") in the new
-	// schema. Pre-#507 yaml using integer seconds would fail strict
-	// unmarshal here — users on legacy yaml should bump up to the new
-	// format before re-running the wizard.
+	// Interval fields hold Go duration values in the new schema. The
+	// durationYAML type unmarshals both "60s" (new form) and a bare 60
+	// (pre-#507 legacy integer seconds), then always marshals as a
+	// string — so re-running the wizard normalizes legacy yaml.
 	Interval struct {
-		AutoSettleBufferTime     string `yaml:"autoSettleBufferTime,omitempty"`
-		ForceSettlementProcessor string `yaml:"forceSettlementProcessor,omitempty"`
-		SettlementProcessor      string `yaml:"settlementProcessor,omitempty"`
-		ReconciliationProcessor  string `yaml:"reconciliationProcessor,omitempty"`
+		AutoSettleBufferTime     durationYAML `yaml:"autoSettleBufferTime,omitempty"`
+		ForceSettlementProcessor durationYAML `yaml:"forceSettlementProcessor,omitempty"`
+		SettlementProcessor      durationYAML `yaml:"settlementProcessor,omitempty"`
+		ReconciliationProcessor  durationYAML `yaml:"reconciliationProcessor,omitempty"`
 	} `yaml:"interval,omitempty"`
 	RevenueTransfer struct {
-		TargetAddress string `yaml:"targetAddress,omitempty"`
-		ReserveAmount string `yaml:"reserveAmount,omitempty"`
-		Interval      string `yaml:"interval,omitempty"`
+		TargetAddress string       `yaml:"targetAddress,omitempty"`
+		ReserveAmount string       `yaml:"reserveAmount,omitempty"`
+		Interval      durationYAML `yaml:"interval,omitempty"`
 	} `yaml:"revenueTransfer,omitempty"`
 	Service  Service  `yaml:"service,omitempty"`
 	Network  *NetworkConfig `yaml:"network,omitempty"`
@@ -989,7 +1013,7 @@ func main() {
 		ReserveAmount string
 		// Duration string e.g. "1h" — see #507. Pre-#507 the value here
 		// was an integer count of seconds.
-		Interval string
+		Interval durationYAML
 	}
 	fmt.Print("\n💰 Do you want to configure automatic revenue transfer to another address? [y/N]: ")
 	revenueResponse, _ := reader.ReadString('\n')
@@ -1037,9 +1061,9 @@ func main() {
 			revenueTransferConfig.Interval = "1h"
 		default:
 			if n, err := strconv.Atoi(intervalInput); err == nil {
-				revenueTransferConfig.Interval = fmt.Sprintf("%ds", n)
+				revenueTransferConfig.Interval = durationYAML(fmt.Sprintf("%ds", n))
 			} else if _, err := time.ParseDuration(intervalInput); err == nil {
-				revenueTransferConfig.Interval = intervalInput
+				revenueTransferConfig.Interval = durationYAML(intervalInput)
 			} else {
 				revenueTransferConfig.Interval = "1h"
 				fmt.Println("   ⚠️  Invalid interval, using default: 1h")
@@ -1413,7 +1437,7 @@ func promptOutputDirectory() (string, error) {
 	return outputDir, nil
 }
 
-func generateYAMLConfig(originalDir string, deployLLM bool, targetTeeAddress string, targetSeparated bool, verifierUrl string, additionalHeaders map[string]string, useMonitoring bool, networkType string, revenueTargetAddress string, revenueReserveAmount string, revenueInterval string, controllerEnable bool, controllerAdminAddress string, modelInfo *ModelInfo, ownedBy string, providerType string, providerIdentity string) (string, string, *Config, error) {
+func generateYAMLConfig(originalDir string, deployLLM bool, targetTeeAddress string, targetSeparated bool, verifierUrl string, additionalHeaders map[string]string, useMonitoring bool, networkType string, revenueTargetAddress string, revenueReserveAmount string, revenueInterval durationYAML, controllerEnable bool, controllerAdminAddress string, modelInfo *ModelInfo, ownedBy string, providerType string, providerIdentity string) (string, string, *Config, error) {
 	reader := bufio.NewReader(os.Stdin)
 
 	// Find base config file in original directory
@@ -2427,6 +2451,8 @@ func isPlaceholderInterface(value interface{}) bool {
 }
 
 func saveConfig(config *Config, path string) error {
+	normalizeForSave(config)
+
 	file, err := os.Create(path)
 	if err != nil {
 		return err
@@ -2438,6 +2464,44 @@ func saveConfig(config *Config, path string) error {
 	defer encoder.Close()
 
 	return encoder.Encode(config)
+}
+
+// normalizeForSave guarantees the wizard's output yaml is in the post-#507
+// schema: a single `network:` block, never the legacy `networks:` map
+// alongside it.
+//
+// Without this step a wizard run against a legacy config produces a yaml with
+// both blocks set (the new write path touches only Network, while merge
+// preserves the user's existing Networks map). The broker's strict
+// "both keys set" check would then reject that yaml at startup.
+func normalizeForSave(c *Config) {
+	if c == nil {
+		return
+	}
+	if c.Network != nil && (c.Network.URL != "" || len(c.Network.PrivateKeys) > 0) {
+		c.Networks = nil
+		return
+	}
+	if c.Network == nil && len(c.Networks) > 0 {
+		// Wizard didn't touch the new field but the user still has a
+		// legacy block. Migrate the canonical entry (ethereum0g) if
+		// present, else the only entry.
+		var picked *NetworkConfig
+		if nc, ok := c.Networks["ethereum0g"]; ok && nc != nil {
+			picked = nc
+		} else if len(c.Networks) == 1 {
+			for _, nc := range c.Networks {
+				if nc != nil {
+					picked = nc
+					break
+				}
+			}
+		}
+		if picked != nil {
+			c.Network = picked
+			c.Networks = nil
+		}
+	}
 }
 
 func isValidURL(value string) bool {

--- a/api/inference/integration/config/main.go
+++ b/api/inference/integration/config/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"text/template"
@@ -175,14 +176,23 @@ func (d *durationYAML) UnmarshalYAML(node *yaml.Node) error {
 	// !!int → legacy seconds; !!str → new duration string. yaml.v3 picks
 	// the tag from the literal form, so we can rely on it rather than
 	// parsing the value twice.
+	var s string
 	switch node.Tag {
 	case "!!int":
-		*d = durationYAML(node.Value + "s")
+		s = node.Value + "s"
 	case "!!str", "":
-		*d = durationYAML(node.Value)
+		s = node.Value
 	default:
 		return fmt.Errorf("duration must be an int (legacy seconds) or string (\"30s\" / \"1h\"), got tag %s at line %d", node.Tag, node.Line)
 	}
+	// Validate that the resulting string is actually a Go duration. Without
+	// this check the wizard happily round-trips `autoSettleBufferTime: "banana"`
+	// into the generated yaml, and the misconfig only surfaces later at
+	// broker startup with a less specific error.
+	if _, err := time.ParseDuration(s); err != nil {
+		return fmt.Errorf("duration %q (line %d) is not a valid Go duration: %w", node.Value, node.Line, err)
+	}
+	*d = durationYAML(s)
 	return nil
 }
 
@@ -2451,7 +2461,9 @@ func isPlaceholderInterface(value interface{}) bool {
 }
 
 func saveConfig(config *Config, path string) error {
-	normalizeForSave(config)
+	if err := normalizeForSave(config); err != nil {
+		return err
+	}
 
 	file, err := os.Create(path)
 	if err != nil {
@@ -2474,34 +2486,50 @@ func saveConfig(config *Config, path string) error {
 // both blocks set (the new write path touches only Network, while merge
 // preserves the user's existing Networks map). The broker's strict
 // "both keys set" check would then reject that yaml at startup.
-func normalizeForSave(c *Config) {
+func normalizeForSave(c *Config) error {
 	if c == nil {
-		return
+		return nil
 	}
 	if c.Network != nil && (c.Network.URL != "" || len(c.Network.PrivateKeys) > 0) {
 		c.Networks = nil
-		return
+		return nil
 	}
 	if c.Network == nil && len(c.Networks) > 0 {
 		// Wizard didn't touch the new field but the user still has a
-		// legacy block. Migrate the canonical entry (ethereum0g) if
-		// present, else the only entry.
+		// legacy block. Match common/config.PickLegacyNetwork's selection:
+		// single entry wins; otherwise pick ethereum0g (or ethereumHardhat
+		// when NETWORK=hardhat). If neither canonical key matches, fail
+		// loudly rather than emit a yaml with both blocks set.
 		var picked *NetworkConfig
-		if nc, ok := c.Networks["ethereum0g"]; ok && nc != nil {
-			picked = nc
-		} else if len(c.Networks) == 1 {
+		if len(c.Networks) == 1 {
 			for _, nc := range c.Networks {
 				if nc != nil {
 					picked = nc
 					break
 				}
 			}
+		} else {
+			wanted := "ethereum0g"
+			if os.Getenv("NETWORK") == "hardhat" {
+				wanted = "ethereumHardhat"
+			}
+			if nc, ok := c.Networks[wanted]; ok && nc != nil {
+				picked = nc
+			}
 		}
 		if picked != nil {
 			c.Network = picked
 			c.Networks = nil
+			return nil
 		}
+		keys := make([]string, 0, len(c.Networks))
+		for k := range c.Networks {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		return fmt.Errorf("wizard cannot normalize multi-entry legacy 'networks' map %v: no canonical entry (ethereum0g/ethereumHardhat) found and NETWORK=%q does not select any. Flatten to a single entry or set NETWORK to an existing key before re-running the wizard", keys, os.Getenv("NETWORK"))
 	}
+	return nil
 }
 
 func isValidURL(value string) bool {

--- a/api/inference/integration/config/main.go
+++ b/api/inference/integration/config/main.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"text/template"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -176,16 +177,20 @@ type Config struct {
 	} `yaml:"event,omitempty"`
 	GasPrice    interface{} `yaml:"gasPrice,omitempty"`
 	MaxGasPrice interface{} `yaml:"maxGasPrice,omitempty"`
-	Interval    struct {
-		AutoSettleBufferTime     int `yaml:"autoSettleBufferTime,omitempty"`
-		ForceSettlementProcessor int `yaml:"forceSettlementProcessor,omitempty"`
-		SettlementProcessor      int `yaml:"settlementProcessor,omitempty"`
-		ReconciliationProcessor  int `yaml:"reconciliationProcessor,omitempty"`
+	// Interval fields hold Go duration strings ("60s", "10m") in the new
+	// schema. Pre-#507 yaml using integer seconds would fail strict
+	// unmarshal here — users on legacy yaml should bump up to the new
+	// format before re-running the wizard.
+	Interval struct {
+		AutoSettleBufferTime     string `yaml:"autoSettleBufferTime,omitempty"`
+		ForceSettlementProcessor string `yaml:"forceSettlementProcessor,omitempty"`
+		SettlementProcessor      string `yaml:"settlementProcessor,omitempty"`
+		ReconciliationProcessor  string `yaml:"reconciliationProcessor,omitempty"`
 	} `yaml:"interval,omitempty"`
 	RevenueTransfer struct {
 		TargetAddress string `yaml:"targetAddress,omitempty"`
 		ReserveAmount string `yaml:"reserveAmount,omitempty"`
-		Interval      int    `yaml:"interval,omitempty"`
+		Interval      string `yaml:"interval,omitempty"`
 	} `yaml:"revenueTransfer,omitempty"`
 	Service  Service  `yaml:"service,omitempty"`
 	Network  *NetworkConfig `yaml:"network,omitempty"`
@@ -982,7 +987,9 @@ func main() {
 	var revenueTransferConfig struct {
 		TargetAddress string
 		ReserveAmount string
-		Interval      int
+		// Duration string e.g. "1h" — see #507. Pre-#507 the value here
+		// was an integer count of seconds.
+		Interval string
 	}
 	fmt.Print("\n💰 Do you want to configure automatic revenue transfer to another address? [y/N]: ")
 	revenueResponse, _ := reader.ReadString('\n')
@@ -1018,21 +1025,27 @@ func main() {
 		}
 		fmt.Printf("   ✓ Reserve amount set to: %s neuron\n", revenueTransferConfig.ReserveAmount)
 
-		// Ask for transfer interval
-		fmt.Print("\n⏱️  Enter the transfer interval in seconds (default: 3600 = 1 hour): ")
+		// Ask for transfer interval. Accept either a Go duration string
+		// ("1h", "30m") or a bare integer (legacy seconds) for
+		// convenience; the wizard always writes the new duration-string
+		// form into the generated yaml.
+		fmt.Print("\n⏱️  Enter the transfer interval as a duration (default: 1h; e.g. \"30m\", \"2h\", or an integer count of seconds): ")
 		intervalInput, _ := reader.ReadString('\n')
 		intervalInput = strings.TrimSpace(intervalInput)
-		if intervalInput == "" {
-			revenueTransferConfig.Interval = 3600
-		} else {
-			if interval, err := strconv.Atoi(intervalInput); err == nil {
-				revenueTransferConfig.Interval = interval
+		switch {
+		case intervalInput == "":
+			revenueTransferConfig.Interval = "1h"
+		default:
+			if n, err := strconv.Atoi(intervalInput); err == nil {
+				revenueTransferConfig.Interval = fmt.Sprintf("%ds", n)
+			} else if _, err := time.ParseDuration(intervalInput); err == nil {
+				revenueTransferConfig.Interval = intervalInput
 			} else {
-				revenueTransferConfig.Interval = 3600
-				fmt.Println("   ⚠️  Invalid interval, using default: 3600 seconds")
+				revenueTransferConfig.Interval = "1h"
+				fmt.Println("   ⚠️  Invalid interval, using default: 1h")
 			}
 		}
-		fmt.Printf("   ✓ Transfer interval set to: %d seconds\n", revenueTransferConfig.Interval)
+		fmt.Printf("   ✓ Transfer interval set to: %s\n", revenueTransferConfig.Interval)
 	} else {
 		fmt.Println("   ✓ Revenue transfer disabled")
 	}
@@ -1400,7 +1413,7 @@ func promptOutputDirectory() (string, error) {
 	return outputDir, nil
 }
 
-func generateYAMLConfig(originalDir string, deployLLM bool, targetTeeAddress string, targetSeparated bool, verifierUrl string, additionalHeaders map[string]string, useMonitoring bool, networkType string, revenueTargetAddress string, revenueReserveAmount string, revenueInterval int, controllerEnable bool, controllerAdminAddress string, modelInfo *ModelInfo, ownedBy string, providerType string, providerIdentity string) (string, string, *Config, error) {
+func generateYAMLConfig(originalDir string, deployLLM bool, targetTeeAddress string, targetSeparated bool, verifierUrl string, additionalHeaders map[string]string, useMonitoring bool, networkType string, revenueTargetAddress string, revenueReserveAmount string, revenueInterval string, controllerEnable bool, controllerAdminAddress string, modelInfo *ModelInfo, ownedBy string, providerType string, providerIdentity string) (string, string, *Config, error) {
 	reader := bufio.NewReader(os.Stdin)
 
 	// Find base config file in original directory
@@ -2035,14 +2048,14 @@ func mergeConfigs(base, user *Config) {
 		base.MaxGasPrice = user.MaxGasPrice
 	}
 
-	// Merge intervals
-	if user.Interval.AutoSettleBufferTime != 0 {
+	// Merge intervals (duration strings).
+	if user.Interval.AutoSettleBufferTime != "" {
 		base.Interval.AutoSettleBufferTime = user.Interval.AutoSettleBufferTime
 	}
-	if user.Interval.ForceSettlementProcessor != 0 {
+	if user.Interval.ForceSettlementProcessor != "" {
 		base.Interval.ForceSettlementProcessor = user.Interval.ForceSettlementProcessor
 	}
-	if user.Interval.SettlementProcessor != 0 {
+	if user.Interval.SettlementProcessor != "" {
 		base.Interval.SettlementProcessor = user.Interval.SettlementProcessor
 	}
 
@@ -2053,7 +2066,7 @@ func mergeConfigs(base, user *Config) {
 	if user.RevenueTransfer.ReserveAmount != "" {
 		base.RevenueTransfer.ReserveAmount = user.RevenueTransfer.ReserveAmount
 	}
-	if user.RevenueTransfer.Interval != 0 {
+	if user.RevenueTransfer.Interval != "" {
 		base.RevenueTransfer.Interval = user.RevenueTransfer.Interval
 	}
 

--- a/api/inference/integration/config/main.go
+++ b/api/inference/integration/config/main.go
@@ -164,10 +164,14 @@ type ControllerConfig struct {
 type Config struct {
 	AllowOrigins    []string `yaml:"allowOrigins,omitempty"`
 	ContractAddress string   `yaml:"contractAddress,omitempty"`
-	Database        struct {
+	Database struct {
+		DSN string `yaml:"dsn,omitempty"`
+		// Deprecated: use DSN.
 		Provider string `yaml:"provider,omitempty"`
 	} `yaml:"database,omitempty"`
 	Event struct {
+		ListenAddr string `yaml:"listenAddr,omitempty"`
+		// Deprecated: use ListenAddr.
 		ProviderAddr string `yaml:"providerAddr,omitempty"`
 	} `yaml:"event,omitempty"`
 	GasPrice    interface{} `yaml:"gasPrice,omitempty"`
@@ -2010,8 +2014,16 @@ func mergeConfigs(base, user *Config) {
 	if user.ContractAddress != "" {
 		base.ContractAddress = user.ContractAddress
 	}
+	// New canonical fields take precedence; legacy fields still merged
+	// during the #507 deprecation window.
+	if user.Database.DSN != "" {
+		base.Database.DSN = user.Database.DSN
+	}
 	if user.Database.Provider != "" {
 		base.Database.Provider = user.Database.Provider
+	}
+	if user.Event.ListenAddr != "" {
+		base.Event.ListenAddr = user.Event.ListenAddr
 	}
 	if user.Event.ProviderAddr != "" {
 		base.Event.ProviderAddr = user.Event.ProviderAddr

--- a/api/inference/integration/config/wiz_check_test.go
+++ b/api/inference/integration/config/wiz_check_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"bytes"
 	"os"
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -36,5 +38,78 @@ func TestWizardParsesUpdatedTemplates(t *testing.T) {
 		if c.Interval.AutoSettleBufferTime == "" {
 			t.Errorf("%s: Interval.AutoSettleBufferTime empty", p)
 		}
+	}
+}
+
+// TestWizard_DurationYAMLAcceptsLegacyInt makes sure the wizard can still load
+// a config.yml written under the pre-#507 schema (bare integer seconds for
+// interval fields) — otherwise re-running the wizard against an old config
+// would fail with a yaml type error.
+func TestWizard_DurationYAMLAcceptsLegacyInt(t *testing.T) {
+	var c Config
+	if err := yaml.Unmarshal([]byte("interval:\n  autoSettleBufferTime: 60\n  forceSettlementProcessor: 600\n"), &c); err != nil {
+		t.Fatalf("legacy integer yaml failed to parse: %v", err)
+	}
+	if c.Interval.AutoSettleBufferTime != "60s" {
+		t.Errorf("AutoSettleBufferTime = %q, want \"60s\"", c.Interval.AutoSettleBufferTime)
+	}
+	if c.Interval.ForceSettlementProcessor != "600s" {
+		t.Errorf("ForceSettlementProcessor = %q, want \"600s\"", c.Interval.ForceSettlementProcessor)
+	}
+}
+
+// TestWizard_NormalizeStripsLegacyNetworksOnSave guards against the wizard
+// emitting a yaml that carries both a `network:` block and a legacy
+// `networks:` map — that combination is rejected at broker startup as
+// genuinely ambiguous.
+func TestWizard_NormalizeStripsLegacyNetworksOnSave(t *testing.T) {
+	c := &Config{}
+	c.Network = &NetworkConfig{URL: "https://evmrpc.0g.ai", ChainID: 16661}
+	c.Networks = Networks{
+		"ethereum0g": &NetworkConfig{URL: "https://old.0g.ai", ChainID: 1},
+	}
+	tmp, err := os.CreateTemp(t.TempDir(), "out-*.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmp.Close()
+	if err := saveConfig(c, tmp.Name()); err != nil {
+		t.Fatalf("saveConfig: %v", err)
+	}
+	data, err := os.ReadFile(tmp.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(data, []byte("networks:")) {
+		t.Errorf("saved yaml still contains 'networks:' block:\n%s", data)
+	}
+	if !bytes.Contains(data, []byte("network:")) {
+		t.Errorf("saved yaml missing 'network:' block:\n%s", data)
+	}
+}
+
+// TestWizard_NormalizeMigratesLegacyOnlyOnSave covers the inverse case: the
+// wizard merged user config still has only the legacy block — normalize must
+// migrate it forward so the broker doesn't re-see the legacy yaml on next run.
+func TestWizard_NormalizeMigratesLegacyOnlyOnSave(t *testing.T) {
+	c := &Config{}
+	c.Networks = Networks{
+		"ethereum0g": &NetworkConfig{URL: "https://evmrpc.0g.ai", ChainID: 16661},
+	}
+	tmp, err := os.CreateTemp(t.TempDir(), "out-*.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmp.Close()
+	if err := saveConfig(c, tmp.Name()); err != nil {
+		t.Fatalf("saveConfig: %v", err)
+	}
+	data, err := os.ReadFile(tmp.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(data)
+	if !strings.Contains(s, "network:") || strings.Contains(s, "networks:") {
+		t.Errorf("expected 'network:' only, got:\n%s", s)
 	}
 }

--- a/api/inference/integration/config/wiz_check_test.go
+++ b/api/inference/integration/config/wiz_check_test.go
@@ -88,6 +88,47 @@ func TestWizard_NormalizeStripsLegacyNetworksOnSave(t *testing.T) {
 	}
 }
 
+// TestWizard_DurationYAMLRejectsInvalidString guards against the wizard
+// silently round-tripping garbage like `autoSettleBufferTime: "banana"` into
+// the generated yaml. The validation should fire at wizard load time, not at
+// broker startup.
+func TestWizard_DurationYAMLRejectsInvalidString(t *testing.T) {
+	var c Config
+	err := yaml.Unmarshal([]byte("interval:\n  autoSettleBufferTime: \"banana\"\n"), &c)
+	if err == nil {
+		t.Fatal("expected error for non-duration string value")
+	}
+	if !strings.Contains(err.Error(), "banana") {
+		t.Errorf("error should quote the invalid value; got: %v", err)
+	}
+}
+
+// TestWizard_NormalizeMultiEntryNoCanonicalFails ensures normalizeForSave
+// surfaces an error rather than silently emitting both `network:` and
+// `networks:` blocks when the legacy map has multiple entries and none of
+// them match the canonical key (ethereum0g or NETWORK=hardhat's
+// ethereumHardhat).
+func TestWizard_NormalizeMultiEntryNoCanonicalFails(t *testing.T) {
+	t.Setenv("NETWORK", "")
+	c := &Config{}
+	c.Networks = Networks{
+		"alpha": &NetworkConfig{URL: "https://a.example", ChainID: 1},
+		"beta":  &NetworkConfig{URL: "https://b.example", ChainID: 2},
+	}
+	tmp, err := os.CreateTemp(t.TempDir(), "out-*.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmp.Close()
+	err = saveConfig(c, tmp.Name())
+	if err == nil {
+		t.Fatal("expected saveConfig to fail on ambiguous multi-entry networks")
+	}
+	if !strings.Contains(err.Error(), "alpha") || !strings.Contains(err.Error(), "beta") {
+		t.Errorf("error should list actual keys; got: %v", err)
+	}
+}
+
 // TestWizard_NormalizeMigratesLegacyOnlyOnSave covers the inverse case: the
 // wizard merged user config still has only the legacy block — normalize must
 // migrate it forward so the broker doesn't re-see the legacy yaml on next run.

--- a/api/inference/integration/config/wiz_check_test.go
+++ b/api/inference/integration/config/wiz_check_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestWizardParsesUpdatedTemplates(t *testing.T) {
+	for _, p := range []string{
+		"config.testnet.yml",
+		"config.mainnet.yml",
+	} {
+		data, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatalf("%s: %v", p, err)
+		}
+		var c Config
+		if err := yaml.Unmarshal(data, &c); err != nil {
+			t.Fatalf("%s: %v", p, err)
+		}
+		if c.Network == nil {
+			t.Errorf("%s: expected Network to be set", p)
+			continue
+		}
+		if c.Network.URL == "" {
+			t.Errorf("%s: Network.URL empty", p)
+		}
+		if c.Database.DSN == "" {
+			t.Errorf("%s: Database.DSN empty", p)
+		}
+		if c.Event.ListenAddr == "" {
+			t.Errorf("%s: Event.ListenAddr empty", p)
+		}
+		if c.Interval.AutoSettleBufferTime == "" {
+			t.Errorf("%s: Interval.AutoSettleBufferTime empty", p)
+		}
+	}
+}

--- a/api/inference/integration/provider/config.example.yaml
+++ b/api/inference/integration/provider/config.example.yaml
@@ -1,20 +1,19 @@
 interval:
-  autoSettleBufferTime: 60
-  forceSettlementProcessor: 600
-  settlementProcessor: 300
+  autoSettleBufferTime: "60s"
+  forceSettlementProcessor: "10m"
+  settlementProcessor: "5m"
 # Settlement profitability: defer users whose fees don't cover gas costs.
 # minSettlementFee is the minimum accumulated fee (in neuron) per user.
 # Default "4000000000000000" (0.004 A0GI). Set to "0" to disable.
 # settlement:
 #   minSettlementFee: "4000000000000000"
-networks:
-  ethereum0g:
-    url: "https://evmrpc-testnet.0g.ai"
-    chainID: 16602
-    privateKeys:
-      - <Private_Key>
-    transactionLimit: 5000000
-    gasEstimationBuffer: 100000
+network:
+  url: "https://evmrpc-testnet.0g.ai"
+  chainID: 16602
+  privateKeys:
+    - <Private_Key>
+  transactionLimit: 5000000
+  gasEstimationBuffer: 100000
 service:
   servingUrl: <Serving URL>
   targetUrl: <Target URL>
@@ -68,5 +67,5 @@ service:
 # Optional: HTTP client timeouts for broker→provider communication.
 # Tune based on GPU speed and model complexity (e.g., image generation may need longer timeouts).
 # providerHttp:
-#   totalTimeoutMinutes: 15          # Overall HTTP request timeout (default: 15)
-#   responseHeaderTimeoutMinutes: 15 # Max time to wait for provider to start responding (default: 15)
+#   totalTimeout: "15m"          # Overall HTTP request timeout (default: 15m)
+#   responseHeaderTimeout: "15m" # Max time to wait for provider to start responding (default: 15m)

--- a/api/inference/integration_test/async_job_test.go
+++ b/api/inference/integration_test/async_job_test.go
@@ -78,9 +78,9 @@ func TestAsyncTextToImageFlow(t *testing.T) {
 			Enabled:                true,
 			MaxConcurrentJobs:      2,
 			MaxQueueSize:           10,
-			ResultTTLMinutes:       30,
-			CleanupIntervalSeconds: 3600, // long interval to avoid interference
-			JobTimeoutMinutes:      1,
+			ResultTTL:       30 * time.Minute,
+			CleanupInterval: time.Hour, // long interval to avoid interference
+			JobTimeout:      time.Minute,
 		}
 	})
 
@@ -235,9 +235,9 @@ func TestAsyncImageEditingFlow(t *testing.T) {
 			Enabled:                true,
 			MaxConcurrentJobs:      2,
 			MaxQueueSize:           10,
-			ResultTTLMinutes:       30,
-			CleanupIntervalSeconds: 3600,
-			JobTimeoutMinutes:      1,
+			ResultTTL:       30 * time.Minute,
+			CleanupInterval: time.Hour,
+			JobTimeout:      time.Minute,
 		}
 	})
 
@@ -347,9 +347,9 @@ func TestAsyncTextToImageFlow_ResponseFormatURL(t *testing.T) {
 			Enabled:                true,
 			MaxConcurrentJobs:      2,
 			MaxQueueSize:           10,
-			ResultTTLMinutes:       30,
-			CleanupIntervalSeconds: 3600,
-			JobTimeoutMinutes:      1,
+			ResultTTL:       30 * time.Minute,
+			CleanupInterval: time.Hour,
+			JobTimeout:      time.Minute,
 		}
 	})
 
@@ -502,9 +502,9 @@ func TestAsyncEndpoints_RequireAuth(t *testing.T) {
 			Enabled:                true,
 			MaxConcurrentJobs:      2,
 			MaxQueueSize:           10,
-			ResultTTLMinutes:       30,
-			CleanupIntervalSeconds: 3600,
-			JobTimeoutMinutes:      1,
+			ResultTTL:       30 * time.Minute,
+			CleanupInterval: time.Hour,
+			JobTimeout:      time.Minute,
 		}
 	})
 
@@ -561,9 +561,9 @@ func TestAsyncJob_OwnershipCheck(t *testing.T) {
 			Enabled:                true,
 			MaxConcurrentJobs:      2,
 			MaxQueueSize:           10,
-			ResultTTLMinutes:       30,
-			CleanupIntervalSeconds: 3600,
-			JobTimeoutMinutes:      1,
+			ResultTTL:       30 * time.Minute,
+			CleanupInterval: time.Hour,
+			JobTimeout:      time.Minute,
 		}
 	})
 
@@ -630,9 +630,9 @@ func TestAsyncJob_WhitelistUser(t *testing.T) {
 			Enabled:                true,
 			MaxConcurrentJobs:      2,
 			MaxQueueSize:           10,
-			ResultTTLMinutes:       30,
-			CleanupIntervalSeconds: 3600,
-			JobTimeoutMinutes:      1,
+			ResultTTL:       30 * time.Minute,
+			CleanupInterval: time.Hour,
+			JobTimeout:      time.Minute,
 		}
 	})
 

--- a/api/inference/integration_test/helpers_test.go
+++ b/api/inference/integration_test/helpers_test.go
@@ -148,9 +148,11 @@ func setupTestEnv(t *testing.T, opts ...func(*config.Config)) *testEnv {
 	cfg := &config.Config{
 		AllowOrigins: []string{"*"},
 		Database: struct {
-			Provider string `yaml:"provider"`
+			DSN string `yaml:"dsn"`
+			// Deprecated: kept while the #507 fallback window is open.
+			Provider string `yaml:"provider,omitempty"`
 		}{
-			Provider: sharedDSN,
+			DSN: sharedDSN,
 		},
 		Service: config.Service{
 			Type:            "video-generation",
@@ -158,12 +160,12 @@ func setupTestEnv(t *testing.T, opts ...func(*config.Config)) *testEnv {
 			TargetSeparated: true,
 		},
 		Interval: struct {
-			AutoSettleBufferTime    int `yaml:"autoSettleBufferTime"`
-			ForceSettlementProcessor int `yaml:"forceSettlementProcessor"`
-			SettlementProcessor      int `yaml:"settlementProcessor"`
-			ReconciliationProcessor  int `yaml:"reconciliationProcessor"`
+			AutoSettleBufferTime     time.Duration `yaml:"autoSettleBufferTime"`
+			ForceSettlementProcessor time.Duration `yaml:"forceSettlementProcessor"`
+			SettlementProcessor      time.Duration `yaml:"settlementProcessor"`
+			ReconciliationProcessor  time.Duration `yaml:"reconciliationProcessor"`
 		}{
-			AutoSettleBufferTime: 60,
+			AutoSettleBufferTime: 60 * time.Second,
 		},
 		ChatCacheExpiration: 20 * time.Minute,
 	}

--- a/api/inference/internal/contract/provider_contract.go
+++ b/api/inference/internal/contract/provider_contract.go
@@ -35,7 +35,7 @@ type ProviderContract struct {
 }
 
 func NewProviderContract(conf *config.Config, teeSignerAddress common.Address, logger log.Logger) (*ProviderContract, error) {
-	contract, err := contract.NewServingContract(common.HexToAddress(conf.ContractAddress), &conf.Networks, os.Getenv("NETWORK"), conf.GasPrice, conf.MaxGasPrice, logger)
+	contract, err := contract.NewServingContract(common.HexToAddress(conf.ContractAddress), &conf.Network, conf.GasPrice, conf.MaxGasPrice, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/api/inference/internal/ctrl/ctrl.go
+++ b/api/inference/internal/ctrl/ctrl.go
@@ -149,7 +149,7 @@ func New(
 	// Otherwise a completed async job can return broker URLs whose backing files
 	// have already been evicted, producing a 404 before the job row itself expires.
 	imageTTL := cfg.ChatCacheExpiration
-	if asyncTTL := time.Duration(cfg.Async.ResultTTLMinutes) * time.Minute; asyncTTL > imageTTL {
+	if asyncTTL := cfg.Async.ResultTTL; asyncTTL > imageTTL {
 		imageTTL = asyncTTL
 	}
 	imgStore, err := newImageStore(imageCacheDir, imageTTL)
@@ -222,7 +222,7 @@ func New(
 		// Optimized for single backend container with many concurrent users
 		// Timeouts are configurable via providerHttp config for different GPU/model requirements
 		httpClient: &http.Client{
-			Timeout: time.Duration(cfg.ProviderHttp.TotalTimeoutMinutes) * time.Minute, // Overall request timeout
+			Timeout: cfg.ProviderHttp.TotalTimeout, // Overall request timeout
 			Transport: &http.Transport{
 				// Connection pool settings for high concurrency scenarios
 				MaxIdleConns:          200,                                                                        // Increased total idle connections to handle more concurrent users
@@ -230,7 +230,7 @@ func New(
 				MaxConnsPerHost:       500,                                                                        // Limit max active connections to prevent resource exhaustion
 				IdleConnTimeout:       90 * time.Second,                                                           // How long idle connections stay open
 				TLSHandshakeTimeout:   10 * time.Second,                                                           // TLS handshake timeout
-				ResponseHeaderTimeout: time.Duration(cfg.ProviderHttp.ResponseHeaderTimeoutMinutes) * time.Minute, // Time to wait for response headers
+				ResponseHeaderTimeout: cfg.ProviderHttp.ResponseHeaderTimeout, // Time to wait for response headers
 				ExpectContinueTimeout: 1 * time.Second,                                                            // Time to wait for 100-continue response
 				DisableKeepAlives:     false,                                                                      // Enable connection reuse (critical)
 				DisableCompression:    false,                                                                      // Allow gzip compression

--- a/api/inference/internal/ctrl/ctrl.go
+++ b/api/inference/internal/ctrl/ctrl.go
@@ -195,7 +195,7 @@ func New(
 	}
 
 	p := &Ctrl{
-		autoSettleBufferTime: time.Duration(cfg.Interval.AutoSettleBufferTime) * time.Second,
+		autoSettleBufferTime: cfg.Interval.AutoSettleBufferTime,
 		minSettlementFee:     minSettlementFee,
 		db:                   db,
 		asyncDB:              db,

--- a/api/inference/internal/db/db.go
+++ b/api/inference/internal/db/db.go
@@ -17,7 +17,7 @@ func NewTestDB(gdb *gorm.DB) *DB {
 }
 
 func NewDB(conf *config.Config) (*DB, error) {
-	db, err := gorm.Open(mysql.Open(conf.Database.Provider), &gorm.Config{
+	db, err := gorm.Open(mysql.Open(conf.Database.DSN), &gorm.Config{
 		NamingStrategy: schema.NamingStrategy{
 			SingularTable: true,
 		},

--- a/api/inference/internal/event/reconciliation_processor.go
+++ b/api/inference/internal/event/reconciliation_processor.go
@@ -39,7 +39,7 @@ type ReconciliationProcessor struct {
 	contract *providercontract.ProviderContract
 	logger   log.Logger
 
-	interval           int    // seconds between scans
+	interval           time.Duration
 	confirmationBlocks uint64 // blocks to wait for finality
 	expiryBlocks       uint64 // blocks after which a pending settlement is expired
 }
@@ -49,11 +49,11 @@ type ReconciliationProcessor struct {
 func NewReconciliationProcessor(
 	db *db.DB,
 	contract *providercontract.ProviderContract,
-	interval int,
+	interval time.Duration,
 	logger log.Logger,
 ) *ReconciliationProcessor {
 	if interval <= 0 {
-		interval = 60
+		interval = 60 * time.Second
 	}
 	return &ReconciliationProcessor{
 		db:                 db,
@@ -67,7 +67,7 @@ func NewReconciliationProcessor(
 
 // Start implements the controller-runtime Runnable interface
 func (r *ReconciliationProcessor) Start(ctx context.Context) error {
-	ticker := time.NewTicker(time.Duration(r.interval) * time.Second)
+	ticker := time.NewTicker(r.interval)
 	defer ticker.Stop()
 
 	for {

--- a/api/inference/internal/event/revenue_transfer_processor.go
+++ b/api/inference/internal/event/revenue_transfer_processor.go
@@ -13,18 +13,18 @@ import (
 )
 
 type RevenueTransferProcessor struct {
-	contract       *providercontract.ProviderContract
-	logger         log.Logger
-	targetAddress  common.Address
-	reserveAmount  *big.Int
-	transferInterval int
+	contract         *providercontract.ProviderContract
+	logger           log.Logger
+	targetAddress    common.Address
+	reserveAmount    *big.Int
+	transferInterval time.Duration
 }
 
 func NewRevenueTransferProcessor(
 	contract *providercontract.ProviderContract,
 	targetAddress string,
 	reserveAmount string,
-	transferInterval int,
+	transferInterval time.Duration,
 	logger log.Logger,
 ) (*RevenueTransferProcessor, error) {
 	if !common.IsHexAddress(targetAddress) {
@@ -48,7 +48,7 @@ func NewRevenueTransferProcessor(
 
 // Start implements controller-runtime/pkg/manager.Runnable interface
 func (r *RevenueTransferProcessor) Start(ctx context.Context) error {
-	ticker := time.NewTicker(time.Duration(r.transferInterval) * time.Second)
+	ticker := time.NewTicker(r.transferInterval)
 	defer ticker.Stop()
 
 	for {

--- a/api/inference/internal/event/settlement_processor.go
+++ b/api/inference/internal/event/settlement_processor.go
@@ -16,8 +16,8 @@ type SettlementProcessor struct {
 	ctrl   *ctrl.Ctrl
 	logger log.Logger
 
-	checkSettleInterval int
-	forceSettleInterval int
+	checkSettleInterval time.Duration
+	forceSettleInterval time.Duration
 
 	enableMonitor      bool
 	settleMu           sync.Mutex
@@ -25,7 +25,7 @@ type SettlementProcessor struct {
 	teeSignerReadyOnce sync.Once
 }
 
-func NewSettlementProcessor(ctrl *ctrl.Ctrl, checkSettleInterval, forceSettleInterval int, enableMonitor bool, logger log.Logger) *SettlementProcessor {
+func NewSettlementProcessor(ctrl *ctrl.Ctrl, checkSettleInterval, forceSettleInterval time.Duration, enableMonitor bool, logger log.Logger) *SettlementProcessor {
 	s := &SettlementProcessor{
 		ctrl:                ctrl,
 		logger:              logger,
@@ -45,8 +45,8 @@ func (s *SettlementProcessor) Start(ctx context.Context) error {
 		s.logger.Errorf("Failed to reset settlement state on startup: %s", err.Error())
 	}
 
-	checkSettleTicker := time.NewTicker(time.Duration(s.checkSettleInterval) * time.Second)
-	forceSettleTicker := time.NewTicker(time.Duration(s.forceSettleInterval) * time.Second)
+	checkSettleTicker := time.NewTicker(s.checkSettleInterval)
+	forceSettleTicker := time.NewTicker(s.forceSettleInterval)
 	defer checkSettleTicker.Stop()
 	defer forceSettleTicker.Stop()
 

--- a/api/inference/internal/lora/event_watcher.go
+++ b/api/inference/internal/lora/event_watcher.go
@@ -59,7 +59,7 @@ func (w *EventWatcher) Start(ctx context.Context) {
 		return
 	}
 
-	pollInterval := time.Duration(w.config.PollBlockIntervalSeconds) * time.Second
+	pollInterval := w.config.PollBlockInterval
 	if pollInterval <= 0 {
 		pollInterval = 5 * time.Second
 	}

--- a/api/inference/internal/lora/event_watcher_test.go
+++ b/api/inference/internal/lora/event_watcher_test.go
@@ -335,7 +335,7 @@ func TestEventWatcher_Start_PollsOnTick(t *testing.T) {
 		},
 		db:              nil,
 		client:          client,
-		config:          config.LoRAConfig{FineTuningContractAddr: "0xdeadbeef", PollBlockIntervalSeconds: 0},
+		config:          config.LoRAConfig{FineTuningContractAddr: "0xdeadbeef", PollBlockInterval: 0},
 		providerAddress: common.HexToAddress("0x1234"),
 		logger:          getTestLogger(),
 	}
@@ -399,9 +399,9 @@ func TestNewEventWatcher_SetsFields(t *testing.T) {
 	}
 
 	cfg := config.LoRAConfig{
-		ChainRpcUrl:              srv.URL,
-		FineTuningContractAddr:   "0xdeadbeef",
-		PollBlockIntervalSeconds: 10,
+		ChainRpcUrl:            srv.URL,
+		FineTuningContractAddr: "0xdeadbeef",
+		PollBlockInterval:      10 * time.Second,
 	}
 	providerAddr := common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678")
 

--- a/api/inference/internal/lora/lora_test.go
+++ b/api/inference/internal/lora/lora_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	commonConfig "github.com/0glabs/0g-serving-broker/common/config"
 	commonLog "github.com/0glabs/0g-serving-broker/common/log"
@@ -190,7 +191,7 @@ func cfgForTest(dir string) inferenceConfig.LoRAConfig {
 		Enable:              true,
 		BaseModel:           "base",
 		LoraModulesDir:      dir,
-		OffloadAfterMinutes: 60,
+		OffloadAfter:        60 * time.Minute,
 		EnableColdStorage:   false,
 	}
 }

--- a/api/inference/internal/lora/manager.go
+++ b/api/inference/internal/lora/manager.go
@@ -47,7 +47,7 @@ type Manager struct {
 
 // NewManager creates a LoRA adapter manager with the given config, 0G Storage downloader,
 // and ServerlessLLM client. Call Start() to begin background event processing.
-func NewManager(cfg config.LoRAConfig, networks commonconfig.Networks, database *db.DB, logger log.Logger) (*Manager, error) {
+func NewManager(cfg config.LoRAConfig, network *commonconfig.NetworkConfig, database *db.DB, logger log.Logger) (*Manager, error) {
 	if cfg.LoraModulesDir != "" {
 		if err := os.MkdirAll(cfg.LoraModulesDir, 0755); err != nil {
 			return nil, errors.Wrap(err, "create lora modules directory")
@@ -67,7 +67,7 @@ func NewManager(cfg config.LoRAConfig, networks commonconfig.Networks, database 
 		logger.Infof("using ECIES private key from LORA_ECIES_PRIVATE_KEY environment variable")
 	}
 	if eciesKey == "" {
-		k, err := commonconfig.GetProviderPrivateKey(networks)
+		k, err := commonconfig.GetProviderPrivateKey(network)
 		if err != nil {
 			logger.Warnf("provider private key not available for 0G Storage download: %v", err)
 		} else {

--- a/api/inference/internal/lora/manager.go
+++ b/api/inference/internal/lora/manager.go
@@ -544,7 +544,7 @@ func (m *Manager) offloadLoop(ctx context.Context) {
 		return
 	}
 
-	interval := time.Duration(m.config.OffloadAfterMinutes) * time.Minute
+	interval := m.config.OffloadAfter
 	if interval <= 0 {
 		interval = 60 * time.Minute
 	}
@@ -564,7 +564,7 @@ func (m *Manager) offloadLoop(ctx context.Context) {
 }
 
 func (m *Manager) offloadIdleAdapters(ctx context.Context) {
-	threshold := time.Duration(m.config.OffloadAfterMinutes) * time.Minute
+	threshold := m.config.OffloadAfter
 	idle, err := m.db.ListIdleAdapters(threshold)
 	if err != nil {
 		m.logger.Errorf("failed to list idle adapters: %v", err)

--- a/api/inference/internal/lora/manager_integration_test.go
+++ b/api/inference/internal/lora/manager_integration_test.go
@@ -401,7 +401,7 @@ func TestOffloadIdleAdapters_OffloadsViaClient(t *testing.T) {
 		},
 		config: func() config.LoRAConfig {
 			c := cfgForTest(t.TempDir())
-			c.OffloadAfterMinutes = 60
+			c.OffloadAfter = 60 * time.Minute
 			return c
 		}(),
 		db:         database,


### PR DESCRIPTION
## Summary

This PR implements a comprehensive configuration schema migration to improve type safety and usability:

1. **Time field modernization**: Convert integer-based time fields (seconds/minutes) to Go's `time.Duration` type, supporting both legacy integer form and new duration strings (e.g., "60s", "1h")
2. **Single-network schema**: Replace the legacy multi-network map (`networks:`) with a canonical single-network config (`network:`), maintaining backward compatibility during a deprecation window
3. **Field renaming**: Clarify misleading config key names (e.g., `providerAddr` → `listenAddr`, `provider` → `dsn`)

## Key Changes

### Configuration Schema Updates

**Time Fields (Approach A: Same YAML key, type change)**
- `interval.autoSettleBufferTime`, `forceSettlementProcessor`, `settlementProcessor`, `reconciliationProcessor`: `int` → `time.Duration`
- `revenueTransfer.interval`: `int` → `time.Duration`
- Supports both legacy integer-seconds form and new duration strings via `MigrateIntegerSecondsDuration()`

**Time Fields (Approach B: Dual fields, suffix dropped)**
- `lora.offloadAfterMinutes` → `lora.offloadAfter` (with legacy field kept for migration)
- `lora.pollBlockIntervalSeconds` → `lora.pollBlockInterval`
- `async.resultTTLMinutes` → `async.resultTTL`
- `async.cleanupIntervalSeconds` → `async.cleanupInterval`
- `async.jobTimeoutMinutes` → `async.jobTimeout`
- `providerHttp.totalTimeoutMinutes` → `providerHttp.totalTimeout`
- `providerHttp.responseHeaderTimeoutMinutes` → `providerHttp.responseHeaderTimeout`
- `service.fileRetentionHours` → `service.fileRetention`
- `settlementCheckIntervalSecs` → `settlementCheckInterval`
- `deliveredTaskAckTimeoutSecs` → `deliveredTaskAckTimeout`

**Network Schema Migration**
- New canonical field: `network: NetworkConfig` (single network)
- Legacy field kept: `networks: map[string]NetworkConfig` (multi-network, deprecated)
- Migration logic selects from legacy map based on `NETWORK` env var or defaults to `ethereum0g`
- Both fields present simultaneously is an error

**Field Renames**
- `database.provider` → `database.dsn` (clarifies it's a MySQL connection string, not a provider address)
- `event.providerAddr` → `event.listenAddr` (clarifies it's a local listen address)
- `zk.provider` → `zk.url` (clarifies it's a service endpoint)

### Migration Infrastructure

**New `api/common/config/deprecation.go`**
- `WarnDeprecated()`: Emit stderr warnings for deprecated keys
- `RawYAMLKeys()`: Parse YAML into generic map to detect user-written keys
- `RawHasKey()` / `RawGet()`: Walk nested key paths in raw YAML
- `MigrateIntegerSecondsDuration()`: Convert legacy integer-seconds to `time.Duration`
- `MigrateDurationFromInt()`: Handle dual-field migrations (old key with unit suffix → new key as duration)
- `DeprecationRemovalDate`: Deadline constant ("2026-07-23") for cleanup

**New `durationYAML` type in wizard** (`api/inference/integration/config/main.go`)
- Custom YAML unmarshaler that accepts both bare integers (legacy seconds) and duration strings
- Always marshals as string form so wizard rewrites legacy configs to canonical schema

### Test Coverage

**`api/inference/config/deprecation_test.go`** (356 lines)
- Networks migration: single entry, multi-entry with `NETWORK` env, defaults to `ethereum0g`
- Error cases: both `network` and `networks` set, missing URL, nil/empty entries
- Time field migrations: integer-to-duration

### Local Test

```
root@tdx:/dstack/vm99# docker compose logs 0g-serving-provider-broker-1
0g-serving-provider-broker-1-1  | 2026/05/29 07:05:05 [CONFIG-DEPRECATED] "interval.autoSettleBufferTime" is an integer count of seconds (legacy form); will be removed after 2026-07-23, use a duration string like "30s" / "1h" instead
0g-serving-provider-broker-1-1  | 2026/05/29 07:05:05 [CONFIG-DEPRECATED] "interval.forceSettlementProcessor" is an integer count of seconds (legacy form); will be removed after 2026-07-23, use a duration string like "30s" / "1h" instead
0g-serving-provider-broker-1-1  | 2026/05/29 07:05:05 [CONFIG-DEPRECATED] "interval.settlementProcessor" is an integer count of seconds (legacy form); will be removed after 2026-07-23, use a duration string like "30s" / "1h" instead
0g-serving-provider-broker-1-1  | 2026/05/29 07:05:05 [CONFIG-DEPRECATED] "revenueTransfer.interval" is an integer count of seconds (legacy form); will be removed after 2026-07-23, use a duration string like "30s" / "1h" instead
0g-serving-provider-broker-1-1  | 2026/05/29 07:05:05 [CONFIG-DEPRECATED] "database.provider" is deprecated, will be removed after 2026-07-23, use "database.dsn" instead
0g-serving-provider-broker-1-1  | 2026/05/29 07:05:05 [CONFIG-DEPRECATED] "event.providerAddr" is deprecated, will be removed after 2026-07-23, use "event.listenAddr" instead
0g-serving-provider-broker-1-1  | 2026/05/29 07:05:05 [CONFIG-DEPRECATED] "networks" is deprecated, will be removed after 2026-07-23, use "network" instead
0g-serving-provider-broker-1-1  | [GIN-debug] [WARNING] Running in "debug" mode. Switch to "release" mode in production.
```

https://claude.ai/code/session_01MbNT5Egvf45823CMp4cK2p