### PR TITLE
Add CanonicalID support for router-catalog model mapping

### DIFF
--- a/api/inference/config/config.go
+++ b/api/inference/config/config.go
@@ -18,6 +18,12 @@ import (
 // This prevents issues with the colon-delimited routing proof text format.
 var validProviderIdentity = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
 
+// validCanonicalID matches a bare lowercase canonical model identifier
+// (e.g. "glm-5.1", "deepseek-v3", "whisper-large-v3"). Disallows slashes
+// so namespaced names like "zai-org/GLM-5-FP8" cannot be set as canonical
+// — those belong in ModelType (the on-chain advertised name) instead.
+var validCanonicalID = regexp.MustCompile(`^[a-z0-9][a-z0-9.\-]*$`)
+
 // ModelArchitecture describes the model's input/output modalities.
 type ModelArchitecture struct {
 	Modality         string   `yaml:"modality" json:"modality"`                    // Required. e.g., "text->text", "text+image->text"
@@ -107,6 +113,14 @@ type Service struct {
 	// breaking clients that still send the old name. Out-of-set requests are
 	// still rejected.
 	ModelAliases     []string          `yaml:"modelAliases"`
+	// CanonicalID is the canonical model identifier this service maps to in the
+	// router's catalog (e.g. "glm-5.1", "deepseek-v3"). Bare lowercase, no
+	// namespace. Optional — when empty, the router falls back to its own
+	// registry-based mapping from ModelType. Also accepted as a valid model
+	// identifier on incoming requests (in addition to ModelType and ModelAliases).
+	// Not written on-chain, so changing it does not invalidate user
+	// acknowledgements.
+	CanonicalID      string            `yaml:"canonicalId"`
 	Verifiability    string            `yaml:"verifiability"`
 	AdditionalSecret map[string]string `yaml:"additionalSecret"`
 	VerifierURL      string            `yaml:"verifierUrl"`
@@ -717,6 +731,10 @@ func loadConfig(cfg *Config) error {
 		if err := cfg.Service.ModelInfo.Validate(cfg.Service.Type); err != nil {
 			return fmt.Errorf("invalid config: %w", err)
 		}
+	}
+
+	if cfg.Service.CanonicalID != "" && !validCanonicalID.MatchString(cfg.Service.CanonicalID) {
+		return fmt.Errorf("invalid config: service.canonicalId %q must be bare lowercase (letters, digits, '-', '.'); namespaced names like 'org/model' belong in service.model instead", cfg.Service.CanonicalID)
 	}
 
 	// Normalize and validate provider type

--- a/api/inference/config/config_test.go
+++ b/api/inference/config/config_test.go
@@ -147,6 +147,95 @@ service:
 	}
 }
 
+func TestLoadConfig_CanonicalID_Valid(t *testing.T) {
+	configPath := writeTestConfig(t, `
+service:
+  servingUrl: "http://example.com"
+  targetUrl: "http://backend:8000"
+  inputPrice: "1000"
+  outputPrice: "2000"
+  type: "chatbot"
+  model: "zai-org/GLM-5.1-FP8"
+  canonicalId: "glm-5.1"
+  verifiability: "TeeML"
+`)
+	t.Setenv("CONFIG_FILE", configPath)
+
+	cfg := &Config{}
+	if err := loadConfig(cfg); err != nil {
+		t.Fatalf("loadConfig failed: %v", err)
+	}
+	if cfg.Service.CanonicalID != "glm-5.1" {
+		t.Errorf("expected canonicalId 'glm-5.1', got %q", cfg.Service.CanonicalID)
+	}
+}
+
+func TestLoadConfig_CanonicalID_RejectsNamespaced(t *testing.T) {
+	configPath := writeTestConfig(t, `
+service:
+  servingUrl: "http://example.com"
+  targetUrl: "http://backend:8000"
+  inputPrice: "1000"
+  outputPrice: "2000"
+  type: "chatbot"
+  model: "zai-org/GLM-5.1-FP8"
+  canonicalId: "zai-org/glm-5.1"
+  verifiability: "TeeML"
+`)
+	t.Setenv("CONFIG_FILE", configPath)
+
+	cfg := &Config{}
+	err := loadConfig(cfg)
+	if err == nil {
+		t.Fatal("expected error for namespaced canonicalId, got nil")
+	}
+	if !strings.Contains(err.Error(), "canonicalId") {
+		t.Errorf("error should mention canonicalId, got: %v", err)
+	}
+}
+
+func TestLoadConfig_CanonicalID_RejectsUppercase(t *testing.T) {
+	configPath := writeTestConfig(t, `
+service:
+  servingUrl: "http://example.com"
+  targetUrl: "http://backend:8000"
+  inputPrice: "1000"
+  outputPrice: "2000"
+  type: "chatbot"
+  model: "zai-org/GLM-5.1-FP8"
+  canonicalId: "GLM-5.1"
+  verifiability: "TeeML"
+`)
+	t.Setenv("CONFIG_FILE", configPath)
+
+	cfg := &Config{}
+	if err := loadConfig(cfg); err == nil {
+		t.Fatal("expected error for uppercase canonicalId, got nil")
+	}
+}
+
+func TestLoadConfig_CanonicalID_EmptyOK(t *testing.T) {
+	configPath := writeTestConfig(t, `
+service:
+  servingUrl: "http://example.com"
+  targetUrl: "http://backend:8000"
+  inputPrice: "1000"
+  outputPrice: "2000"
+  type: "chatbot"
+  model: "zai-org/GLM-5.1-FP8"
+  verifiability: "TeeML"
+`)
+	t.Setenv("CONFIG_FILE", configPath)
+
+	cfg := &Config{}
+	if err := loadConfig(cfg); err != nil {
+		t.Fatalf("loadConfig failed: %v", err)
+	}
+	if cfg.Service.CanonicalID != "" {
+		t.Errorf("expected empty canonicalId, got %q", cfg.Service.CanonicalID)
+	}
+}
+
 func TestLoadConfig_ProviderTypeCentralized(t *testing.T) {
 	configPath := writeTestConfig(t, `
 service:

--- a/api/inference/integration/provider/config.example.yaml
+++ b/api/inference/integration/provider/config.example.yaml
@@ -21,6 +21,19 @@ service:
   outputPrice: <Output Price>
   type: "chatbot"
   model: <Model>
+  # Optional: canonical model id used by the router catalog (e.g. "glm-5.1",
+  # "deepseek-v3"). Bare lowercase, no namespace. When set, it is exposed in
+  # GET /v1/models as canonical_id and also accepted as a valid value of the
+  # request "model" field (alongside `model` above and any `modelAliases`).
+  # Not written on-chain, so changing it does NOT invalidate user
+  # acknowledgements. Leave unset to let the router fall back to its own
+  # registry-based mapping from `model`.
+  # canonicalId: "glm-5.1"
+  # Optional: legacy model identifiers accepted on incoming requests in
+  # addition to `model`. Lets you rename the advertised model without
+  # breaking clients that still send the old name.
+  # modelAliases:
+  #   - "zai-org/GLM-5.1"
   verifiability: "TeeML"
   # Optional: organization name shown in the owned_by field of GET /v1/models
   # ownedBy: "0G Foundation"

--- a/api/inference/internal/ctrl/proxy.go
+++ b/api/inference/internal/ctrl/proxy.go
@@ -50,9 +50,11 @@ func (c *Ctrl) PrepareHTTPRequest(ctx *gin.Context, targetURL string, reqBody []
 
 		// Enforce configured model when the service has asked for model
 		// validation/rewriting. TargetSeparated providers opt in for legacy
-		// reasons; UpstreamModel and ModelAliases each imply opt-in because
-		// they only make sense with this path running.
-		if c.Service.TargetSeparated || c.Service.UpstreamModel != "" || len(c.Service.ModelAliases) > 0 {
+		// reasons; UpstreamModel, ModelAliases and CanonicalID each imply
+		// opt-in because they only make sense with this path running (the
+		// canonical id must be rewritten to the chain/upstream name before
+		// being forwarded, or the upstream will reject it).
+		if c.Service.TargetSeparated || c.Service.UpstreamModel != "" || len(c.Service.ModelAliases) > 0 || c.Service.CanonicalID != "" {
 			userAddr, _ := ctx.Get("userAddress")
 			userAddrStr, _ := userAddr.(string)
 			modifiedBody, err = c.EnforceConfiguredModel(reqBody, userAddrStr)
@@ -549,7 +551,7 @@ func (c *Ctrl) EnforceConfiguredModel(body []byte, userAddr string) ([]byte, err
 		}
 
 		if requestModelStr != c.Service.ModelType &&
-			!(c.Service.CanonicalID != "" && requestModelStr == c.Service.CanonicalID) &&
+			(c.Service.CanonicalID == "" || requestModelStr != c.Service.CanonicalID) &&
 			!isModelAlias(requestModelStr, c.Service.ModelAliases) {
 			// Model mismatch detected - record in rate limiter and REJECT
 			c.logger.Warnf("Model mismatch detected and REJECTED: user=%s, requested=%s, configured=%s",

--- a/api/inference/internal/ctrl/proxy.go
+++ b/api/inference/internal/ctrl/proxy.go
@@ -499,7 +499,7 @@ func (c *Ctrl) EnsureStreamOptions(body []byte) ([]byte, error) {
 // configured model from c.Service.ModelType, or c.Service.UpstreamModel if set.
 //
 // Incoming requests are accepted if the "model" field matches any of:
-//   - c.Service.ModelType        (on-chain advertised name; required)
+//   - c.Service.ModelType        (on-chain advertised name; must be configured for enforcement to run)
 //   - c.Service.CanonicalID      (router-catalog canonical, when set)
 //   - any entry in c.Service.ModelAliases  (legacy ids)
 //
@@ -547,15 +547,16 @@ func (c *Ctrl) EnforceConfiguredModel(body []byte, userAddr string) ([]byte, err
 		requestModelStr, ok := requestModel.(string)
 		if !ok {
 			// Invalid model type, reject request
-			return nil, errors.New(fmt.Sprintf("invalid model type in request (expected string), configured model is: %s", c.Service.ModelType))
+			return nil, fmt.Errorf("invalid model type in request (expected string), configured model is: %s", c.Service.ModelType)
 		}
 
 		if requestModelStr != c.Service.ModelType &&
 			(c.Service.CanonicalID == "" || requestModelStr != c.Service.CanonicalID) &&
 			!isModelAlias(requestModelStr, c.Service.ModelAliases) {
 			// Model mismatch detected - record in rate limiter and REJECT
-			c.logger.Warnf("Model mismatch detected and REJECTED: user=%s, requested=%s, configured=%s",
-				userAddr, requestModelStr, c.Service.ModelType)
+			accepted := c.acceptedModelIDs()
+			c.logger.Warnf("Model mismatch detected and REJECTED: user=%s, requested=%s, accepted=%v",
+				userAddr, requestModelStr, accepted)
 
 			// Record this attempt in rate limiter if user address is available
 			if userAddr != "" {
@@ -567,8 +568,7 @@ func (c *Ctrl) EnforceConfiguredModel(body []byte, userAddr string) ([]byte, err
 				}
 			}
 
-			return nil, errors.New(fmt.Sprintf("model not supported: requested '%s', only '%s' is available for this service",
-				requestModelStr, c.Service.ModelType))
+			return nil, fmt.Errorf("model not supported: requested %q, accepted: %q", requestModelStr, accepted)
 		}
 
 		// Match — rewrite to the upstream id (no-op when UpstreamModel is empty).
@@ -593,6 +593,20 @@ func isModelAlias(name string, aliases []string) bool {
 		}
 	}
 	return false
+}
+
+// acceptedModelIDs returns the full set of model identifiers a client may
+// use in the request "model" field for this service: ModelType, plus
+// CanonicalID when set, plus any ModelAliases.  Used for log and error
+// messages so operators see what was actually accepted, not just ModelType.
+func (c *Ctrl) acceptedModelIDs() []string {
+	out := make([]string, 0, 2+len(c.Service.ModelAliases))
+	out = append(out, c.Service.ModelType)
+	if c.Service.CanonicalID != "" {
+		out = append(out, c.Service.CanonicalID)
+	}
+	out = append(out, c.Service.ModelAliases...)
+	return out
 }
 
 // rewriteMultipartResponseFormat ensures the forwarded multipart body carries

--- a/api/inference/internal/ctrl/proxy.go
+++ b/api/inference/internal/ctrl/proxy.go
@@ -496,7 +496,11 @@ func (c *Ctrl) EnsureStreamOptions(body []byte) ([]byte, error) {
 // This function forcibly overwrites any "model" field in the request body with the
 // configured model from c.Service.ModelType, or c.Service.UpstreamModel if set.
 //
-// Incoming requests are validated against ModelType (the advertised/on-chain name).
+// Incoming requests are accepted if the "model" field matches any of:
+//   - c.Service.ModelType        (on-chain advertised name; required)
+//   - c.Service.CanonicalID      (router-catalog canonical, when set)
+//   - any entry in c.Service.ModelAliases  (legacy ids)
+//
 // The outgoing body uses UpstreamModel when non-empty, otherwise ModelType. This
 // lets a provider advertise a stable public model id while forwarding to an
 // upstream that uses a different id.
@@ -544,7 +548,9 @@ func (c *Ctrl) EnforceConfiguredModel(body []byte, userAddr string) ([]byte, err
 			return nil, errors.New(fmt.Sprintf("invalid model type in request (expected string), configured model is: %s", c.Service.ModelType))
 		}
 
-		if requestModelStr != c.Service.ModelType && !isModelAlias(requestModelStr, c.Service.ModelAliases) {
+		if requestModelStr != c.Service.ModelType &&
+			!(c.Service.CanonicalID != "" && requestModelStr == c.Service.CanonicalID) &&
+			!isModelAlias(requestModelStr, c.Service.ModelAliases) {
 			// Model mismatch detected - record in rate limiter and REJECT
 			c.logger.Warnf("Model mismatch detected and REJECTED: user=%s, requested=%s, configured=%s",
 				userAddr, requestModelStr, c.Service.ModelType)

--- a/api/inference/internal/ctrl/proxy_test.go
+++ b/api/inference/internal/ctrl/proxy_test.go
@@ -82,6 +82,39 @@ func TestEnforceConfiguredModel_AcceptsAlias(t *testing.T) {
 	}
 }
 
+// The configured CanonicalID should be accepted as a valid incoming model id
+// (in addition to ModelType and ModelAliases), and rewritten to the upstream id
+// — same behavior as an alias match, but driven by the router-catalog canonical.
+func TestEnforceConfiguredModel_AcceptsCanonical(t *testing.T) {
+	c := newTestCtrlForEnforceModel(t, "zai-org/GLM-5.1-FP8", "z-ai/glm-5.1-fp8")
+	c.Service.CanonicalID = "glm-5.1"
+	body := []byte(`{"model":"glm-5.1","messages":[{"role":"user","content":"hi"}]}`)
+
+	got, err := c.EnforceConfiguredModel(body, "0xabc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var out map[string]interface{}
+	if err := json.Unmarshal(got, &out); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if out["model"] != "z-ai/glm-5.1-fp8" {
+		t.Errorf("model = %q, want %q", out["model"], "z-ai/glm-5.1-fp8")
+	}
+}
+
+// An empty CanonicalID must not silently match an empty incoming model field —
+// the empty-canonical guard prevents collision with the empty string.
+func TestEnforceConfiguredModel_EmptyCanonicalDoesNotMatchEmpty(t *testing.T) {
+	c := newTestCtrlForEnforceModel(t, "zai-org/GLM-5.1-FP8", "")
+	// CanonicalID intentionally left zero-value
+	body := []byte(`{"model":"","messages":[]}`)
+
+	if _, err := c.EnforceConfiguredModel(body, "0xabc"); err == nil {
+		t.Fatal("expected rejection for empty model with empty canonical, got nil")
+	}
+}
+
 // A model name that is neither ModelType nor an alias must still be rejected.
 func TestEnforceConfiguredModel_RejectsUnknownModel(t *testing.T) {
 	c := newTestCtrlForEnforceModel(t, "deepseek-v3.2", "", "deepseek/deepseek-chat-v3-0324")

--- a/api/inference/internal/ctrl/proxy_test.go
+++ b/api/inference/internal/ctrl/proxy_test.go
@@ -5,6 +5,7 @@ import (
 	"compress/flate"
 	"compress/gzip"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/andybalholm/brotli"
@@ -122,6 +123,27 @@ func TestEnforceConfiguredModel_RejectsUnknownModel(t *testing.T) {
 
 	if _, err := c.EnforceConfiguredModel(body, "0xabc"); err == nil {
 		t.Fatal("expected rejection for unknown model, got nil")
+	}
+}
+
+// Rejection errors must surface the full set of accepted identifiers
+// (ModelType + CanonicalID + ModelAliases), not just ModelType — otherwise
+// users hit "only X is available" while the broker actually accepts more,
+// which is misleading during debug.
+func TestEnforceConfiguredModel_RejectionShowsAllAccepted(t *testing.T) {
+	c := newTestCtrlForEnforceModel(t, "zai-org/GLM-5.1-FP8", "", "zai-org/GLM-5.1")
+	c.Service.CanonicalID = "glm-5.1"
+	body := []byte(`{"model":"gpt-4","messages":[]}`)
+
+	_, err := c.EnforceConfiguredModel(body, "0xabc")
+	if err == nil {
+		t.Fatal("expected rejection, got nil")
+	}
+	msg := err.Error()
+	for _, want := range []string{"zai-org/GLM-5.1-FP8", "glm-5.1", "zai-org/GLM-5.1"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message %q missing accepted id %q", msg, want)
+		}
 	}
 }
 

--- a/api/inference/internal/handler/models.go
+++ b/api/inference/internal/handler/models.go
@@ -15,6 +15,7 @@ import (
 // ModelObject represents a single model in the OpenAI-compatible /v1/models response.
 type ModelObject struct {
 	ID                  string                    `json:"id"`
+	CanonicalID         string                    `json:"canonical_id,omitempty"`
 	Object              string                    `json:"object"`
 	Created             int64                     `json:"created"`
 	OwnedBy             string                    `json:"owned_by"`
@@ -119,6 +120,7 @@ func (h *Handler) GetModels(ctx *gin.Context) {
 
 	obj := ModelObject{
 		ID:            svc.ModelType,
+		CanonicalID:   cfg.CanonicalID,
 		Object:        "model",
 		OwnedBy:       cfg.OwnedBy,
 		Type:          svc.Type,


### PR DESCRIPTION
## Summary
Adds support for a `canonicalId` field in service configuration, enabling providers to specify a canonical model identifier used by the router's catalog. This allows incoming requests to use the canonical ID (in addition to the on-chain `model` name and `modelAliases`) while transparently rewriting it to the upstream model name before forwarding.

## Key Changes

- **Config validation** (`config.go`):
  - Added `CanonicalID` field to `Service` struct with validation regex `validCanonicalID`
  - Enforces bare lowercase format (letters, digits, `-`, `.`) with no namespace/slashes
  - Rejects uppercase and namespaced names (e.g., `zai-org/glm-5.1`)
  - Optional field; empty value is valid and disables canonical matching

- **Request enforcement** (`proxy.go`):
  - Updated `EnforceConfiguredModel()` to accept requests with `model` field matching `CanonicalID`
  - Canonical ID is rewritten to upstream model name (same as alias behavior)
  - Added guard: empty `CanonicalID` does not match empty incoming model field
  - Updated opt-in condition to trigger enforcement when `CanonicalID` is set

- **API response** (`models.go`):
  - Added `CanonicalID` field to `ModelObject` JSON response (exposed as `canonical_id`)
  - Omitted when empty

- **Configuration documentation** (`config.example.yaml`):
  - Added commented example showing `canonicalId` usage and behavior
  - Clarified that canonical ID is not written on-chain and does not invalidate user acknowledgements

- **Test coverage** (`config_test.go`, `proxy_test.go`):
  - `TestLoadConfig_CanonicalID_Valid`: Validates correct canonical ID is loaded
  - `TestLoadConfig_CanonicalID_RejectsNamespaced`: Rejects namespaced format
  - `TestLoadConfig_CanonicalID_RejectsUppercase`: Rejects uppercase characters
  - `TestLoadConfig_CanonicalID_EmptyOK`: Confirms empty value is acceptable
  - `TestEnforceConfiguredModel_AcceptsCanonical`: Verifies canonical ID is accepted and rewritten
  - `TestEnforceConfiguredModel_EmptyCanonicalDoesNotMatchEmpty`: Prevents silent matching of empty values

## Implementation Details

The canonical ID feature integrates seamlessly with existing model validation:
- Incoming requests are validated against three sources: `ModelType`, `CanonicalID`, and `ModelAliases`
- The outgoing request uses `UpstreamModel` (if set) or `ModelType`, preserving existing upstream routing behavior
- Validation is only triggered when at least one of `TargetSeparated`, `UpstreamModel`, `ModelAliases`, or `CanonicalID` is configured
- The empty-canonical guard prevents accidental collision with requests that have an empty model field

https://claude.ai/code/session_01JDK2rvP1QxZanujB9euPdf