### PR TITLE
Support dual billing modes for speech-to-text (duration vs tokens)

### DIFF
--- a/api/inference/config/config.go
+++ b/api/inference/config/config.go
@@ -412,6 +412,15 @@ type Config struct {
 	Async               AsyncConfig             `yaml:"async"`
 	ProviderHttp        ProviderHttpConfig      `yaml:"providerHttp"`
 	ConcurrencyLimit    ConcurrencyLimitConfig  `yaml:"concurrencyLimit"`
+	// AllowTokenBilledSpeechToText opens the billing path for token-billed
+	// speech-to-text models (gpt-4o-transcribe, gpt-4o-mini-transcribe).
+	// Defaults to false: until issue #530 lands a per-row billing-unit
+	// discriminator on the requests table, allowing both whisper (seconds)
+	// and gpt-4o-transcribe (tokens) services to coexist would silently
+	// corrupt any aggregate query against requests.input_count. Set to
+	// true only after reading #530 and accepting the analytics risk for
+	// the deployment window.
+	AllowTokenBilledSpeechToText bool `yaml:"allowTokenBilledSpeechToText"`
 }
 
 // ConcurrencyLimitConfig defines concurrency limiting for backend protection.

--- a/api/inference/config/config.go
+++ b/api/inference/config/config.go
@@ -420,6 +420,11 @@ type Config struct {
 	// corrupt any aggregate query against requests.input_count. Set to
 	// true only after reading #530 and accepting the analytics risk for
 	// the deployment window.
+	//
+	// TODO(#530): a broker-wide flag is awkward — the unit conflation is
+	// per-service. Once the schema discriminator lands, derive this from
+	// the registered service's billing_unit instead of asking operators to
+	// flip a global flag.
 	AllowTokenBilledSpeechToText bool `yaml:"allowTokenBilledSpeechToText"`
 }
 

--- a/api/inference/config/config.go
+++ b/api/inference/config/config.go
@@ -24,6 +24,39 @@ var validProviderIdentity = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
 // — those belong in ModelType (the on-chain advertised name) instead.
 var validCanonicalID = regexp.MustCompile(`^[a-z0-9][a-z0-9.\-]*$`)
 
+// knownTokenBilledSTTModels enumerates the bare canonical names of STT
+// models whose usage upstream is shaped as input/output tokens (rather than
+// duration seconds). The list is intentionally exhaustive — pattern matching
+// against a substring like "gpt-4o" would catch unrelated multimodal models.
+// When OpenAI ships a new token-billed transcription model, add it here.
+var knownTokenBilledSTTModels = map[string]struct{}{
+	"gpt-4o-transcribe":      {},
+	"gpt-4o-mini-transcribe": {},
+}
+
+// tokenBilledSTTCanonicalName returns the recognized bare canonical name if
+// the given STT service is configured against a known token-billed model, or
+// "" otherwise. Checks every field that might carry a model identifier
+// (ModelType, UpstreamModel, CanonicalID, ModelAliases) and strips any
+// "org/" namespace prefix so e.g. "openai/gpt-4o-transcribe" matches.
+func tokenBilledSTTCanonicalName(svc *Service) string {
+	candidates := []string{svc.ModelType, svc.UpstreamModel, svc.CanonicalID}
+	candidates = append(candidates, svc.ModelAliases...)
+	for _, c := range candidates {
+		if c == "" {
+			continue
+		}
+		bare := c
+		if i := strings.LastIndex(c, "/"); i >= 0 {
+			bare = c[i+1:]
+		}
+		if _, ok := knownTokenBilledSTTModels[bare]; ok {
+			return bare
+		}
+	}
+	return ""
+}
+
 // ModelArchitecture describes the model's input/output modalities.
 type ModelArchitecture struct {
 	Modality         string   `yaml:"modality" json:"modality"`                    // Required. e.g., "text->text", "text+image->text"
@@ -414,12 +447,20 @@ type Config struct {
 	ConcurrencyLimit    ConcurrencyLimitConfig  `yaml:"concurrencyLimit"`
 	// AllowTokenBilledSpeechToText opens the billing path for token-billed
 	// speech-to-text models (gpt-4o-transcribe, gpt-4o-mini-transcribe).
-	// Defaults to false: until issue #530 lands a per-row billing-unit
-	// discriminator on the requests table, allowing both whisper (seconds)
-	// and gpt-4o-transcribe (tokens) services to coexist would silently
-	// corrupt any aggregate query against requests.input_count. Set to
-	// true only after reading #530 and accepting the analytics risk for
-	// the deployment window.
+	// Defaults to false.
+	//
+	// Enforced at startup: loadConfig refuses to boot the broker if
+	// service.type=="speech-to-text" is registered against a known token-
+	// billed model and this flag is false. Operators must consciously
+	// acknowledge the analytics trade-off (see #530) before deploying such
+	// a service — the failure mode is fail-stop at boot, not a per-request
+	// log line that gets lost in production.
+	//
+	// Also gates billSpeechToTextByTokens at runtime as defense-in-depth:
+	// if an unknown model proxies an unexpected token-shape response, the
+	// broker bills against real upstream usage anyway (refusing would mean
+	// free GPU since the response has already shipped) but logs a loud
+	// warning naming #530 so the operator can investigate.
 	//
 	// TODO(#530): a broker-wide flag is awkward — the unit conflation is
 	// per-service. Once the schema discriminator lands, derive this from
@@ -749,6 +790,23 @@ func loadConfig(cfg *Config) error {
 
 	if cfg.Service.CanonicalID != "" && !validCanonicalID.MatchString(cfg.Service.CanonicalID) {
 		return fmt.Errorf("invalid config: service.canonicalId %q must be bare lowercase (letters, digits, '-', '.'); namespaced names like 'org/model' belong in service.model instead", cfg.Service.CanonicalID)
+	}
+
+	// Token-billed STT startup gate. Until #530 lands a per-row billing-unit
+	// discriminator, deploying a known token-billed STT model without
+	// explicit operator opt-in would silently mix seconds (whisper) and
+	// tokens (gpt-4o-transcribe) under the same analytics aggregates. Refuse
+	// to boot rather than emit a per-request warning that operators are
+	// likely to overlook in production logs.
+	if cfg.Service.Type == constant.ServiceTypeSpeechToText && !cfg.AllowTokenBilledSpeechToText {
+		if model := tokenBilledSTTCanonicalName(&cfg.Service); model != "" {
+			return fmt.Errorf(
+				"invalid config: service.type=%q is registered against token-billed model %q but cfg.allowTokenBilledSpeechToText is false. "+
+					"Token-billed STT (gpt-4o-transcribe family) is gated until #530 lands a per-row billing-unit discriminator — "+
+					"set allowTokenBilledSpeechToText: true to acknowledge the analytics trade-off and proceed",
+				cfg.Service.Type, model,
+			)
+		}
 	}
 
 	// Normalize and validate provider type

--- a/api/inference/config/config_test.go
+++ b/api/inference/config/config_test.go
@@ -600,3 +600,141 @@ func TestService_IsCentralized(t *testing.T) {
 		})
 	}
 }
+
+// ==========================================================================
+// AllowTokenBilledSpeechToText startup gate
+//
+// Boot-time guard for the #530 schema-discriminator window: deploying a
+// known token-billed STT model without explicit operator opt-in is fail-stop
+// at loadConfig, not a per-request log line.
+// ==========================================================================
+
+func TestLoadConfig_TokenBilledSTT_BlockedByDefault(t *testing.T) {
+	for _, model := range []string{"gpt-4o-transcribe", "gpt-4o-mini-transcribe", "openai/gpt-4o-transcribe"} {
+		t.Run(model, func(t *testing.T) {
+			configPath := writeTestConfig(t, `
+service:
+  servingUrl: "http://example.com"
+  targetUrl: "http://backend:8000"
+  inputPrice: "1000"
+  outputPrice: "2000"
+  type: "speech-to-text"
+  model: "`+model+`"
+  verifiability: "TeeML"
+`)
+			t.Setenv("CONFIG_FILE", configPath)
+
+			cfg := &Config{}
+			err := loadConfig(cfg)
+			if err == nil {
+				t.Fatal("expected token-billed STT to be blocked by default, got nil")
+			}
+			// Error must name the issue so the operator can find the schema
+			// work without grepping the codebase.
+			if !strings.Contains(err.Error(), "#530") {
+				t.Errorf("error should reference #530, got: %v", err)
+			}
+			if !strings.Contains(err.Error(), "allowTokenBilledSpeechToText") {
+				t.Errorf("error should name the config flag operators have to flip, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestLoadConfig_TokenBilledSTT_AllowedWhenFlagSet(t *testing.T) {
+	configPath := writeTestConfig(t, `
+allowTokenBilledSpeechToText: true
+service:
+  servingUrl: "http://example.com"
+  targetUrl: "http://backend:8000"
+  inputPrice: "1000"
+  outputPrice: "2000"
+  type: "speech-to-text"
+  model: "gpt-4o-transcribe"
+  verifiability: "TeeML"
+`)
+	t.Setenv("CONFIG_FILE", configPath)
+
+	cfg := &Config{}
+	if err := loadConfig(cfg); err != nil {
+		t.Fatalf("loadConfig with allowTokenBilledSpeechToText=true should pass, got: %v", err)
+	}
+	if !cfg.AllowTokenBilledSpeechToText {
+		t.Error("AllowTokenBilledSpeechToText should be true after parse")
+	}
+}
+
+func TestLoadConfig_WhisperSTT_NeverGated(t *testing.T) {
+	// Whisper services should never trip the gate regardless of flag value,
+	// since they don't emit token-shape usage.
+	for _, model := range []string{"whisper-1", "whisper-large-v3", "openai/whisper-large-v3"} {
+		t.Run(model, func(t *testing.T) {
+			configPath := writeTestConfig(t, `
+service:
+  servingUrl: "http://example.com"
+  targetUrl: "http://backend:8000"
+  inputPrice: "1000"
+  outputPrice: "2000"
+  type: "speech-to-text"
+  model: "`+model+`"
+  verifiability: "TeeML"
+`)
+			t.Setenv("CONFIG_FILE", configPath)
+
+			cfg := &Config{}
+			if err := loadConfig(cfg); err != nil {
+				t.Fatalf("whisper STT should not be gated, got error: %v", err)
+			}
+		})
+	}
+}
+
+func TestLoadConfig_TokenBilledModel_OutsideSTTService_NotGated(t *testing.T) {
+	// The gate is scoped to service.type=="speech-to-text". A non-STT service
+	// (e.g. chatbot) running a model with a name that happens to look like an
+	// STT model should not trip the gate — the conflation we're protecting
+	// against is specifically requests.input_count in the speech_to_text lane.
+	configPath := writeTestConfig(t, `
+service:
+  servingUrl: "http://example.com"
+  targetUrl: "http://backend:8000"
+  inputPrice: "1000"
+  outputPrice: "2000"
+  type: "chatbot"
+  model: "gpt-4o-transcribe"
+  verifiability: "TeeML"
+`)
+	t.Setenv("CONFIG_FILE", configPath)
+
+	cfg := &Config{}
+	if err := loadConfig(cfg); err != nil {
+		t.Fatalf("non-STT service should not trip the STT gate, got: %v", err)
+	}
+}
+
+func TestTokenBilledSTTCanonicalName(t *testing.T) {
+	tests := []struct {
+		name string
+		svc  *Service
+		want string
+	}{
+		{"empty", &Service{}, ""},
+		{"whisper model", &Service{ModelType: "whisper-large-v3"}, ""},
+		{"bare gpt-4o-transcribe", &Service{ModelType: "gpt-4o-transcribe"}, "gpt-4o-transcribe"},
+		{"namespaced gpt-4o-transcribe", &Service{ModelType: "openai/gpt-4o-transcribe"}, "gpt-4o-transcribe"},
+		{"gpt-4o-mini-transcribe", &Service{ModelType: "gpt-4o-mini-transcribe"}, "gpt-4o-mini-transcribe"},
+		// Token model name appearing only in canonicalId is still caught.
+		{"canonical-id only", &Service{ModelType: "openai/some-renamed-model", CanonicalID: "gpt-4o-transcribe"}, "gpt-4o-transcribe"},
+		// Token model name appearing only in alias is still caught.
+		{"alias only", &Service{ModelType: "rebranded-stt", ModelAliases: []string{"gpt-4o-mini-transcribe"}}, "gpt-4o-mini-transcribe"},
+		// Substring of a known name shouldn't match — exact list, not pattern.
+		{"unrelated gpt-4o", &Service{ModelType: "gpt-4o"}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tokenBilledSTTCanonicalName(tt.svc); got != tt.want {
+				t.Errorf("tokenBilledSTTCanonicalName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/api/inference/internal/ctrl/ctrl.go
+++ b/api/inference/internal/ctrl/ctrl.go
@@ -52,6 +52,12 @@ type Ctrl struct {
 	priceFeed         config.PriceFeedConfig
 	concurrencyLimit  config.ConcurrencyLimitConfig
 
+	// allowTokenBilledSTT gates billSpeechToTextByTokens. Defaults to false
+	// because the requests.input_count column conflates seconds (whisper)
+	// and tokens (gpt-4o-transcribe) until issue #530 lands. See
+	// updateSpeechToTextWithUsage docstring and #530 for the trade-off.
+	allowTokenBilledSTT bool
+
 	// priceCache holds the latest wei prices derived from the live 0G/USD
 	// rate.  Non-nil only when Service.PriceDenomination == "USD".  Written
 	// by the PriceUpdateProcessor, read by GetCachedService to overlay
@@ -205,6 +211,7 @@ func New(
 		tieredPricing:        cfg.TieredPricing,
 		priceFeed:            cfg.PriceFeed,
 		concurrencyLimit:     cfg.ConcurrencyLimit,
+		allowTokenBilledSTT:  cfg.AllowTokenBilledSpeechToText,
 		priceCache:           priceCache,
 		svcCache:             svcCache,
 		teeService:           teeService,

--- a/api/inference/internal/ctrl/image_store_test.go
+++ b/api/inference/internal/ctrl/image_store_test.go
@@ -84,8 +84,13 @@ func TestImageStore_GetExpired(t *testing.T) {
 // eviction deterministically by sleeping past TTL and then calling
 // DeleteExpired ourselves — relying on the go-cache janitor's ttl/2 tick would
 // leave the test racing against scheduler noise.
+//
+// TTL is set generously (100ms) so the sleep-then-DeleteExpired sequence
+// remains robust under loaded CI runners. A previous 10ms value flaked under
+// the integration-test job's concurrency, where scheduler quantum delayed
+// time.Now() advancement past the cache entry's expiration timestamp.
 func TestImageStore_DiskFilesRemovedAfterEviction(t *testing.T) {
-	const ttl = 10 * time.Millisecond
+	const ttl = 100 * time.Millisecond
 	dir := t.TempDir()
 	store, err := newImageStore(dir, ttl)
 	if err != nil {

--- a/api/inference/internal/ctrl/settlement_tee.go
+++ b/api/inference/internal/ctrl/settlement_tee.go
@@ -779,8 +779,11 @@ func (c *Ctrl) deleteRequests(requests []*model.Request) error {
 	}
 
 	// Atomically accumulate stats and delete requests in a single transaction
-	// to prevent double-counting if deletion fails after accumulation
-	if err := c.db.AccumulateAndDeleteRequests(requests); err != nil {
+	// to prevent double-counting if deletion fails after accumulation.
+	// Pass the broker's configured service type so STT rows (where input_count
+	// is seconds, not tokens) skip the token-named columns in daily_stat.
+	// See AccumulateAndDeleteRequests doc + #530.
+	if err := c.db.AccumulateAndDeleteRequests(requests, c.Service.Type); err != nil {
 		c.logger.Errorf("CRITICAL: failed to accumulate stats and delete settled requests: %v", err)
 		return err
 	}

--- a/api/inference/internal/ctrl/settlement_tee.go
+++ b/api/inference/internal/ctrl/settlement_tee.go
@@ -783,6 +783,12 @@ func (c *Ctrl) deleteRequests(requests []*model.Request) error {
 	// Pass the broker's configured service type so STT rows (where input_count
 	// is seconds, not tokens) skip the token-named columns in daily_stat.
 	// See AccumulateAndDeleteRequests doc + #530.
+	//
+	// Assumption: a single broker process proxies exactly one service type
+	// (cfg.Service is a singular struct, not a list). Every row in `requests`
+	// at settlement time therefore shares c.Service.Type, so a function-wide
+	// skip is safe. If we ever multiplex services in one broker, this needs
+	// to partition `requests` by per-row service type instead — track in #530.
 	if err := c.db.AccumulateAndDeleteRequests(requests, c.Service.Type); err != nil {
 		c.logger.Errorf("CRITICAL: failed to accumulate stats and delete settled requests: %v", err)
 		return err

--- a/api/inference/internal/ctrl/speech_to_text.go
+++ b/api/inference/internal/ctrl/speech_to_text.go
@@ -58,6 +58,15 @@ func isDurationUsage(u *SpeechToTextUsage) bool {
 // actually settle against. A non-nil Usage with all zero counters (e.g. a
 // whisper response decoded into a token-only struct, or an empty {} block)
 // would otherwise silently bill zero.
+//
+// Strict-by-type rationale: when "type" is explicitly "duration" or "tokens"
+// we only honour the matching field. A mismatched response (e.g.
+// {type:"duration", input_tokens:100, seconds:0}) is treated as un-billable
+// and falls through to the word-count fallback. Routing it to the matching-
+// type bill function instead would silently charge 0 (the populated field
+// belongs to the other lane). Real OpenAI providers never emit mismatched
+// shapes; a non-conforming provider that does is best caught by the
+// fallback's estimator, which has a chance of producing a non-zero charge.
 func hasBillableUsage(u *SpeechToTextUsage) bool {
 	if u == nil {
 		return false
@@ -170,11 +179,7 @@ func (c *Ctrl) handleNonStreamingSpeechToText(ctx *gin.Context, resp *http.Respo
 
 	// Skip billing for whitelisted users, but record whitelist traffic metrics
 	if reqModel.IsWhitelisted {
-		if hasBillableUsage(transcriptionResp.Usage) {
-			in, out := usageMetricCounts(transcriptionResp.Usage)
-			monitor.RecordTokens("speech_to_text", in, out)
-			monitor.RecordWhitelistTokens("speech_to_text", in, out)
-		}
+		recordUsageMetrics(transcriptionResp.Usage, true)
 		return nil
 	}
 
@@ -272,11 +277,7 @@ func (c *Ctrl) handleStreamingSpeechToText(ctx *gin.Context, resp *http.Response
 
 	// Skip billing for whitelisted users, but record whitelist traffic metrics
 	if reqModel.IsWhitelisted {
-		if hasBillableUsage(usage) {
-			in, out := usageMetricCounts(usage)
-			monitor.RecordTokens("speech_to_text", in, out)
-			monitor.RecordWhitelistTokens("speech_to_text", in, out)
-		}
+		recordUsageMetrics(usage, true)
 		return nil
 	}
 
@@ -324,9 +325,7 @@ func (c *Ctrl) updateSpeechToTextWithUsage(ctx context.Context, usage *SpeechToT
 // count (with or without an explicit "type":"duration" discriminator).
 // InputPrice is treated as price-per-second; OutputPrice is ignored.
 func (c *Ctrl) billSpeechToTextByDuration(ctx context.Context, usage *SpeechToTextUsage, inputPrice, requestHash string) error {
-	seconds := usage.Seconds
-
-	inputFee, err := util.Multiply(inputPrice, int64(seconds))
+	feeStr, err := calcDurationFee(inputPrice, usage.Seconds)
 	if err != nil {
 		return errors.Wrap(err, "calculate duration fee")
 	}
@@ -334,39 +333,28 @@ func (c *Ctrl) billSpeechToTextByDuration(ctx context.Context, usage *SpeechToTe
 	// Persist seconds in input_count and 0 in output_count. There is no
 	// per-row unit discriminator; operators identify duration-billed rows
 	// by the service the row belongs to (whisper services bill seconds).
-	feeStr := inputFee.String()
 	if err := c.db.UpdateRequestWithAccurateTokens(requestHash, feeStr, "0", feeStr,
-		int64(seconds), 0); err != nil {
+		int64(usage.Seconds), 0); err != nil {
 		return errors.Wrap(err, "update request with duration usage")
 	}
 
-	monitor.RecordTokens("speech_to_text", int64(seconds), 0)
+	monitor.RecordAudioSeconds("speech_to_text", int64(usage.Seconds))
 	// No RecordTPSFromContext for duration mode: whisper has no
 	// tokens-per-second concept (the whole transcript is delivered as one
 	// shot, not as a generation stream). A seconds/second metric would be
 	// nonsensical and would pollute the chatbot TPS dashboard.
-	consumeSpeechToTextLimiter(ctx, seconds)
+	consumeSpeechToTextLimiter(ctx, usage.Seconds)
 	return nil
 }
 
 // billSpeechToTextByTokens handles gpt-4o-transcribe-style token usage.
 func (c *Ctrl) billSpeechToTextByTokens(ctx context.Context, usage *SpeechToTextUsage, inputPrice, outputPrice, requestHash string) error {
-	inputFee, err := util.Multiply(inputPrice, int64(usage.InputTokens))
+	inputFeeStr, outputFeeStr, totalFeeStr, err := calcTokenFees(inputPrice, outputPrice, usage.InputTokens, usage.OutputTokens)
 	if err != nil {
-		return errors.Wrap(err, "calculate input fee from actual tokens")
+		return err
 	}
 
-	outputFee, err := util.Multiply(outputPrice, int64(usage.OutputTokens))
-	if err != nil {
-		return errors.Wrap(err, "calculate output fee from actual tokens")
-	}
-
-	totalFee, err := util.Add(inputFee, outputFee)
-	if err != nil {
-		return errors.Wrap(err, "calculate total fee")
-	}
-
-	if err := c.db.UpdateRequestWithAccurateTokens(requestHash, inputFee.String(), outputFee.String(), totalFee.String(),
+	if err := c.db.UpdateRequestWithAccurateTokens(requestHash, inputFeeStr, outputFeeStr, totalFeeStr,
 		int64(usage.InputTokens), int64(usage.OutputTokens)); err != nil {
 		return errors.Wrap(err, "update request with accurate tokens")
 	}
@@ -375,6 +363,34 @@ func (c *Ctrl) billSpeechToTextByTokens(ctx context.Context, usage *SpeechToText
 	monitor.RecordTPSFromContext(ctx, "speech_to_text", int64(usage.OutputTokens))
 	consumeSpeechToTextLimiter(ctx, usage.InputTokens+usage.OutputTokens)
 	return nil
+}
+
+// calcDurationFee is the pure fee arithmetic for duration-mode billing.
+// Extracted so unit tests can cover the math without mocking DB/monitor/limiter.
+func calcDurationFee(inputPrice string, seconds int) (string, error) {
+	fee, err := util.Multiply(inputPrice, int64(seconds))
+	if err != nil {
+		return "", err
+	}
+	return fee.String(), nil
+}
+
+// calcTokenFees is the pure fee arithmetic for token-mode billing. Returns
+// (inputFee, outputFee, totalFee) as decimal strings ready for DB persistence.
+func calcTokenFees(inputPrice, outputPrice string, inputTokens, outputTokens int) (string, string, string, error) {
+	inputFee, err := util.Multiply(inputPrice, int64(inputTokens))
+	if err != nil {
+		return "", "", "", errors.Wrap(err, "calculate input fee from actual tokens")
+	}
+	outputFee, err := util.Multiply(outputPrice, int64(outputTokens))
+	if err != nil {
+		return "", "", "", errors.Wrap(err, "calculate output fee from actual tokens")
+	}
+	totalFee, err := util.Add(inputFee, outputFee)
+	if err != nil {
+		return "", "", "", errors.Wrap(err, "calculate total fee")
+	}
+	return inputFee.String(), outputFee.String(), totalFee.String(), nil
 }
 
 // consumeSpeechToTextLimiter feeds the post-consume TPM bucket with the actual
@@ -405,19 +421,49 @@ func consumeSpeechToTextLimiter(ctx context.Context, units int) {
 	limiter.ConsumeTokens(userStr, units)
 }
 
-// usageMetricCounts returns the (input, output) values to feed into
-// monitor.RecordTokens for a given usage object. For duration mode the seconds
-// count is reported in the input position to stay aligned with what InputPrice
-// settled against. Must use the same classifier as the billing dispatch so
-// the whitelist metrics lane never diverges from the settlement lane.
-func usageMetricCounts(u *SpeechToTextUsage) (int64, int64) {
-	if u == nil {
-		return 0, 0
+// classifyUsageForMetrics splits a usage object into the values destined for
+// each Prometheus counter family. Pure function — exposed so unit tests can
+// pin the routing rule without spinning up a real Prometheus registry.
+//
+// Returned tuple semantics:
+//   - seconds > 0: duration mode, route to AudioSecondsTotal
+//   - inputTokens or outputTokens > 0: tokens mode, route to InputTokensTotal /
+//     OutputTokensTotal
+//   - all zero: caller should not record anything (the usage carried no
+//     billable signal)
+//
+// Routes through isDurationUsage so the metrics lane and the billing dispatch
+// classify identically — divergence between these two paths is exactly the
+// bug PR #523's review caught.
+func classifyUsageForMetrics(u *SpeechToTextUsage) (seconds, inputTokens, outputTokens int64) {
+	if !hasBillableUsage(u) {
+		return 0, 0, 0
 	}
 	if isDurationUsage(u) {
-		return int64(u.Seconds), 0
+		return int64(u.Seconds), 0, 0
 	}
-	return int64(u.InputTokens), int64(u.OutputTokens)
+	return 0, int64(u.InputTokens), int64(u.OutputTokens)
+}
+
+// recordUsageMetrics writes a usage object to the appropriate Prometheus
+// counters. whitelisted=true additionally mirrors the values into the
+// whitelist-only counter family so operators can split traffic by
+// exempt-vs-paid users.
+func recordUsageMetrics(u *SpeechToTextUsage, whitelisted bool) {
+	seconds, in, out := classifyUsageForMetrics(u)
+	const svc = "speech_to_text"
+	if seconds > 0 {
+		monitor.RecordAudioSeconds(svc, seconds)
+		if whitelisted {
+			monitor.RecordWhitelistAudioSeconds(svc, seconds)
+		}
+	}
+	if in > 0 || out > 0 {
+		monitor.RecordTokens(svc, in, out)
+		if whitelisted {
+			monitor.RecordWhitelistTokens(svc, in, out)
+		}
+	}
 }
 
 /*

--- a/api/inference/internal/ctrl/speech_to_text.go
+++ b/api/inference/internal/ctrl/speech_to_text.go
@@ -288,13 +288,18 @@ func (c *Ctrl) updateSpeechToTextWithUsage(ctx context.Context, usage *SpeechToT
 		return errors.Wrap(err, "get cached service for speech-to-text billing")
 	}
 
-	if usage.Type == "duration" {
+	// Route to duration billing when the provider says so, or when Seconds is
+	// populated and the type field is missing/unknown. A response that
+	// explicitly says type="tokens" stays on the tokens path even if it also
+	// carries a Seconds field — trust the explicit discriminator.
+	if usage.Type == "duration" || (usage.Type != "tokens" && usage.Seconds > 0) {
 		return c.billSpeechToTextByDuration(ctx, usage, service.InputPrice, requestHash)
 	}
 	return c.billSpeechToTextByTokens(ctx, usage, service.InputPrice, service.OutputPrice, requestHash)
 }
 
-// billSpeechToTextByDuration handles whisper-style {"type":"duration","seconds":N}.
+// billSpeechToTextByDuration handles whisper-style usage carrying a seconds
+// count (with or without an explicit "type":"duration" discriminator).
 // InputPrice is treated as price-per-second; OutputPrice is ignored.
 func (c *Ctrl) billSpeechToTextByDuration(ctx context.Context, usage *SpeechToTextUsage, inputPrice, requestHash string) error {
 	seconds := int64(usage.Seconds)
@@ -304,8 +309,9 @@ func (c *Ctrl) billSpeechToTextByDuration(ctx context.Context, usage *SpeechToTe
 		return errors.Wrap(err, "calculate duration fee")
 	}
 
-	// Persist as input_count=seconds, output_count=0 so duration-billed rows
-	// can be distinguished from token-billed rows by output==0+input>0+type.
+	// Persist seconds in input_count and 0 in output_count. There is no
+	// per-row unit discriminator; operators identify duration-billed rows
+	// by the service the row belongs to (whisper services bill seconds).
 	if err := c.db.UpdateRequestWithAccurateTokens(requestHash, inputFee.String(), "0", inputFee.String(),
 		seconds, 0); err != nil {
 		return errors.Wrap(err, "update request with duration usage")

--- a/api/inference/internal/ctrl/speech_to_text.go
+++ b/api/inference/internal/ctrl/speech_to_text.go
@@ -420,13 +420,18 @@ func (c *Ctrl) billSpeechToTextByDuration(ctx context.Context, usage *SpeechToTe
 
 // billSpeechToTextByTokens handles gpt-4o-transcribe-style token usage.
 //
-// Fail-closed: gated behind cfg.AllowTokenBilledSpeechToText (default false).
-// Until issue #530 adds a per-row billing-unit discriminator to the requests
-// table, mixing whisper (seconds) and gpt-4o-transcribe (tokens) rows under
-// the same service_type silently corrupts any aggregate query against
-// requests.input_count. An operator who needs to deploy token-billed STT
-// before #530 lands must flip the flag explicitly and accept the analytics
-// risk for that window. See #530 for the schema work + acceptance criteria.
+// The primary gate against accidental token-billed-STT deployment lives in
+// config.loadConfig: if a known token-billed model (gpt-4o-transcribe family)
+// is registered with cfg.AllowTokenBilledSpeechToText=false, the broker
+// refuses to boot. By the time a request lands in this function the operator
+// has already passed that check.
+//
+// This runtime gate is defense-in-depth for the edge case where an unknown
+// model (not in the startup gate's whitelist) ends up emitting a token-shape
+// usage response. Rather than silently writing tokens to requests.input_count
+// against an unprepared operator, we return ErrTokenBilledSpeechToTextGated;
+// the caller routes to billGatedTokenSTT which bills against the real
+// upstream usage and logs loudly. See #530.
 func (c *Ctrl) billSpeechToTextByTokens(ctx context.Context, usage *SpeechToTextUsage, inputPrice, outputPrice, requestHash string) error {
 	if !c.allowTokenBilledSTT {
 		// Sentinel error so callers can detect the gate-fired case and route

--- a/api/inference/internal/ctrl/speech_to_text.go
+++ b/api/inference/internal/ctrl/speech_to_text.go
@@ -50,14 +50,21 @@ type SpeechToTextUsage struct {
 }
 
 // billableSeconds returns the integer second count used for billing, metrics,
-// and rate limiting. Rounds to the nearest whole second to match OpenAI's
-// documented "billed to the nearest second" semantic, and clamps negatives
-// to 0 so a non-conforming provider can never produce a credit-billing row.
+// and rate limiting. Rounds to the nearest whole second, then applies a
+// 1-second floor for any positive input so a sub-half-second clip
+// (e.g. 0.4s) cannot pass hasBillableUsage and then collapse to a 0-fee row
+// — that would be the same zero-billing class of bug this PR exists to fix.
+// Non-positive inputs (zero or negative) return 0 so the caller can decline
+// to bill at all.
 func billableSeconds(u *SpeechToTextUsage) int {
 	if u == nil || u.Seconds <= 0 {
 		return 0
 	}
-	return int(math.Round(u.Seconds))
+	rounded := int(math.Round(u.Seconds))
+	if rounded < 1 {
+		return 1
+	}
+	return rounded
 }
 
 // isDurationUsage classifies a usage object as duration-billed (whisper-style)

--- a/api/inference/internal/ctrl/speech_to_text.go
+++ b/api/inference/internal/ctrl/speech_to_text.go
@@ -39,6 +39,21 @@ type SpeechToTextUsage struct {
 	Seconds           int                      `json:"seconds"`
 }
 
+// isDurationUsage classifies a usage object as duration-billed (whisper-style)
+// vs token-billed (gpt-4o-transcribe-style). This is the single source of
+// truth — billing dispatch, whitelist metrics, and any future consumer must
+// route through this so the same input never lands in two different lanes.
+//
+// Rules: trust an explicit type discriminator when present; otherwise infer
+// from which counter the provider populated. A response that explicitly says
+// type="tokens" stays on the tokens path even if it also carries Seconds.
+func isDurationUsage(u *SpeechToTextUsage) bool {
+	if u == nil {
+		return false
+	}
+	return u.Type == "duration" || (u.Type != "tokens" && u.Seconds > 0)
+}
+
 // hasBillableUsage reports whether a parsed usage object carries data we can
 // actually settle against. A non-nil Usage with all zero counters (e.g. a
 // whisper response decoded into a token-only struct, or an empty {} block)
@@ -275,24 +290,31 @@ func (c *Ctrl) handleStreamingSpeechToText(ctx *gin.Context, resp *http.Response
 }
 
 // updateSpeechToTextWithUsage updates the request with accurate usage from the
-// API response. Dispatches on usage.Type:
-//   - "duration": bill Seconds × InputPrice (whisper family). InputPrice is
+// API response. Dispatches via isDurationUsage:
+//   - duration mode: bill Seconds × InputPrice (whisper family). InputPrice is
 //     interpreted as price-per-second by convention; OutputPrice is unused
 //     because whisper has no generation-side cost.
-//   - "tokens" (or unknown but with token counts): bill input_tokens × InputPrice
-//     + output_tokens × OutputPrice. For gpt-4o-transcribe, output_tokens is
-//     always 0 upstream, so this collapses to input-only billing.
+//   - tokens mode: bill input_tokens × InputPrice + output_tokens × OutputPrice.
+//     For gpt-4o-transcribe, output_tokens is always 0 upstream, so this
+//     collapses to input-only billing.
+//
+// WARNING — InputPrice is semantically overloaded across speech-to-text
+// services: whisper-* services reuse it as price-per-second, gpt-4o-transcribe-*
+// services use it as price-per-token. There is no schema-level discriminator;
+// the unit is implied by which model the service is registered to proxy.
+// Pointing a whisper service at a per-token price (or vice versa) silently
+// over- or under-charges by orders of magnitude. Operators must keep the
+// service's registered InputPrice consistent with the upstream model's usage
+// shape (whisper → per-second, gpt-4o-transcribe → per-token). A future on-chain
+// `BillingUnit` field would let this dispatch reject mismatches; tracked as a
+// follow-up to PR #523.
 func (c *Ctrl) updateSpeechToTextWithUsage(ctx context.Context, usage *SpeechToTextUsage, requestHash string) error {
 	service, err := c.GetCachedService(ctx)
 	if err != nil {
 		return errors.Wrap(err, "get cached service for speech-to-text billing")
 	}
 
-	// Route to duration billing when the provider says so, or when Seconds is
-	// populated and the type field is missing/unknown. A response that
-	// explicitly says type="tokens" stays on the tokens path even if it also
-	// carries a Seconds field — trust the explicit discriminator.
-	if usage.Type == "duration" || (usage.Type != "tokens" && usage.Seconds > 0) {
+	if isDurationUsage(usage) {
 		return c.billSpeechToTextByDuration(ctx, usage, service.InputPrice, requestHash)
 	}
 	return c.billSpeechToTextByTokens(ctx, usage, service.InputPrice, service.OutputPrice, requestHash)
@@ -302,9 +324,9 @@ func (c *Ctrl) updateSpeechToTextWithUsage(ctx context.Context, usage *SpeechToT
 // count (with or without an explicit "type":"duration" discriminator).
 // InputPrice is treated as price-per-second; OutputPrice is ignored.
 func (c *Ctrl) billSpeechToTextByDuration(ctx context.Context, usage *SpeechToTextUsage, inputPrice, requestHash string) error {
-	seconds := int64(usage.Seconds)
+	seconds := usage.Seconds
 
-	inputFee, err := util.Multiply(inputPrice, seconds)
+	inputFee, err := util.Multiply(inputPrice, int64(seconds))
 	if err != nil {
 		return errors.Wrap(err, "calculate duration fee")
 	}
@@ -312,13 +334,18 @@ func (c *Ctrl) billSpeechToTextByDuration(ctx context.Context, usage *SpeechToTe
 	// Persist seconds in input_count and 0 in output_count. There is no
 	// per-row unit discriminator; operators identify duration-billed rows
 	// by the service the row belongs to (whisper services bill seconds).
-	if err := c.db.UpdateRequestWithAccurateTokens(requestHash, inputFee.String(), "0", inputFee.String(),
-		seconds, 0); err != nil {
+	feeStr := inputFee.String()
+	if err := c.db.UpdateRequestWithAccurateTokens(requestHash, feeStr, "0", feeStr,
+		int64(seconds), 0); err != nil {
 		return errors.Wrap(err, "update request with duration usage")
 	}
 
-	monitor.RecordTokens("speech_to_text", seconds, 0)
-	consumeSpeechToTextLimiter(ctx, int(seconds))
+	monitor.RecordTokens("speech_to_text", int64(seconds), 0)
+	// No RecordTPSFromContext for duration mode: whisper has no
+	// tokens-per-second concept (the whole transcript is delivered as one
+	// shot, not as a generation stream). A seconds/second metric would be
+	// nonsensical and would pollute the chatbot TPS dashboard.
+	consumeSpeechToTextLimiter(ctx, seconds)
 	return nil
 }
 
@@ -381,12 +408,13 @@ func consumeSpeechToTextLimiter(ctx context.Context, units int) {
 // usageMetricCounts returns the (input, output) values to feed into
 // monitor.RecordTokens for a given usage object. For duration mode the seconds
 // count is reported in the input position to stay aligned with what InputPrice
-// settled against.
+// settled against. Must use the same classifier as the billing dispatch so
+// the whitelist metrics lane never diverges from the settlement lane.
 func usageMetricCounts(u *SpeechToTextUsage) (int64, int64) {
 	if u == nil {
 		return 0, 0
 	}
-	if u.Type == "duration" {
+	if isDurationUsage(u) {
 		return int64(u.Seconds), 0
 	}
 	return int64(u.InputTokens), int64(u.OutputTokens)

--- a/api/inference/internal/ctrl/speech_to_text.go
+++ b/api/inference/internal/ctrl/speech_to_text.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"math"
 	"net/http"
 
 	"github.com/andybalholm/brotli"
@@ -30,13 +31,33 @@ import (
 //
 // For the token shape, output_tokens is always 0 upstream — transcription is
 // treated as input-side processing, not generation.
+//
+// Seconds is float64 rather than int because Go's encoding/json refuses to
+// decode JSON numbers with a decimal point into integer fields — even
+// "207.0". A non-conforming provider (or a JSON encoder that always emits
+// floats, e.g. Python's json.dumps on a float) would otherwise fail the
+// whole struct unmarshal, fall through to the word-count estimator, and
+// silently bill 0 for whisper services where OutputPrice is 0. Use
+// billableSeconds() to get the rounded integer used for fee math /
+// persistence / metrics.
 type SpeechToTextUsage struct {
 	Type              string                   `json:"type"`
 	TotalTokens       int                      `json:"total_tokens"`
 	InputTokens       int                      `json:"input_tokens"`
 	InputTokenDetails SpeechToTextTokenDetails `json:"input_token_details"`
 	OutputTokens      int                      `json:"output_tokens"`
-	Seconds           int                      `json:"seconds"`
+	Seconds           float64                  `json:"seconds"`
+}
+
+// billableSeconds returns the integer second count used for billing, metrics,
+// and rate limiting. Rounds to the nearest whole second to match OpenAI's
+// documented "billed to the nearest second" semantic, and clamps negatives
+// to 0 so a non-conforming provider can never produce a credit-billing row.
+func billableSeconds(u *SpeechToTextUsage) int {
+	if u == nil || u.Seconds <= 0 {
+		return 0
+	}
+	return int(math.Round(u.Seconds))
 }
 
 // isDurationUsage classifies a usage object as duration-billed (whisper-style)
@@ -325,7 +346,9 @@ func (c *Ctrl) updateSpeechToTextWithUsage(ctx context.Context, usage *SpeechToT
 // count (with or without an explicit "type":"duration" discriminator).
 // InputPrice is treated as price-per-second; OutputPrice is ignored.
 func (c *Ctrl) billSpeechToTextByDuration(ctx context.Context, usage *SpeechToTextUsage, inputPrice, requestHash string) error {
-	feeStr, err := calcDurationFee(inputPrice, usage.Seconds)
+	seconds := billableSeconds(usage)
+
+	feeStr, err := calcDurationFee(inputPrice, seconds)
 	if err != nil {
 		return errors.Wrap(err, "calculate duration fee")
 	}
@@ -334,16 +357,16 @@ func (c *Ctrl) billSpeechToTextByDuration(ctx context.Context, usage *SpeechToTe
 	// per-row unit discriminator; operators identify duration-billed rows
 	// by the service the row belongs to (whisper services bill seconds).
 	if err := c.db.UpdateRequestWithAccurateTokens(requestHash, feeStr, "0", feeStr,
-		int64(usage.Seconds), 0); err != nil {
+		int64(seconds), 0); err != nil {
 		return errors.Wrap(err, "update request with duration usage")
 	}
 
-	monitor.RecordAudioSeconds("speech_to_text", int64(usage.Seconds))
+	monitor.RecordAudioSeconds("speech_to_text", int64(seconds))
 	// No RecordTPSFromContext for duration mode: whisper has no
 	// tokens-per-second concept (the whole transcript is delivered as one
 	// shot, not as a generation stream). A seconds/second metric would be
 	// nonsensical and would pollute the chatbot TPS dashboard.
-	consumeSpeechToTextLimiter(ctx, usage.Seconds)
+	consumeSpeechToTextLimiter(ctx, seconds)
 	return nil
 }
 
@@ -440,7 +463,7 @@ func classifyUsageForMetrics(u *SpeechToTextUsage) (seconds, inputTokens, output
 		return 0, 0, 0
 	}
 	if isDurationUsage(u) {
-		return int64(u.Seconds), 0, 0
+		return int64(billableSeconds(u)), 0, 0
 	}
 	return 0, int64(u.InputTokens), int64(u.OutputTokens)
 }

--- a/api/inference/internal/ctrl/speech_to_text.go
+++ b/api/inference/internal/ctrl/speech_to_text.go
@@ -334,9 +334,13 @@ func (c *Ctrl) handleStreamingSpeechToText(ctx *gin.Context, resp *http.Response
 // Pointing a whisper service at a per-token price (or vice versa) silently
 // over- or under-charges by orders of magnitude. Operators must keep the
 // service's registered InputPrice consistent with the upstream model's usage
-// shape (whisper → per-second, gpt-4o-transcribe → per-token). A future on-chain
-// `BillingUnit` field would let this dispatch reject mismatches; tracked as a
-// follow-up to PR #523.
+// shape (whisper → per-second, gpt-4o-transcribe → per-token).
+//
+// Token-billed speech-to-text (gpt-4o-transcribe family) is gated behind
+// cfg.AllowTokenBilledSpeechToText and fails closed by default until the
+// per-row billing-unit discriminator from #530 lands. Without that
+// discriminator, mixing whisper and gpt-4o-transcribe traffic on the same
+// service_type silently corrupts requests.input_count aggregates.
 func (c *Ctrl) updateSpeechToTextWithUsage(ctx context.Context, usage *SpeechToTextUsage, requestHash string) error {
 	service, err := c.GetCachedService(ctx)
 	if err != nil {
@@ -378,7 +382,18 @@ func (c *Ctrl) billSpeechToTextByDuration(ctx context.Context, usage *SpeechToTe
 }
 
 // billSpeechToTextByTokens handles gpt-4o-transcribe-style token usage.
+//
+// Fail-closed: gated behind cfg.AllowTokenBilledSpeechToText (default false).
+// Until issue #530 adds a per-row billing-unit discriminator to the requests
+// table, mixing whisper (seconds) and gpt-4o-transcribe (tokens) rows under
+// the same service_type silently corrupts any aggregate query against
+// requests.input_count. An operator who needs to deploy token-billed STT
+// before #530 lands must flip the flag explicitly and accept the analytics
+// risk for that window. See #530 for the schema work + acceptance criteria.
 func (c *Ctrl) billSpeechToTextByTokens(ctx context.Context, usage *SpeechToTextUsage, inputPrice, outputPrice, requestHash string) error {
+	if !c.allowTokenBilledSTT {
+		return errors.New("token-billed speech-to-text is gated behind cfg.allowTokenBilledSpeechToText pending the per-row billing-unit discriminator in issue #530; set the flag to enable after reviewing the analytics trade-off")
+	}
 	inputFeeStr, outputFeeStr, totalFeeStr, err := calcTokenFees(inputPrice, outputPrice, usage.InputTokens, usage.OutputTokens)
 	if err != nil {
 		return err

--- a/api/inference/internal/ctrl/speech_to_text.go
+++ b/api/inference/internal/ctrl/speech_to_text.go
@@ -21,13 +21,40 @@ import (
 	"github.com/0glabs/0g-serving-broker/inference/monitor"
 )
 
-// SpeechToTextUsage represents the usage information from speech-to-text API
+// SpeechToTextUsage represents the usage information from speech-to-text API.
+//
+// Two shapes exist in the wild:
+//   - Whisper family (whisper-1, whisper-large-v3): {"type":"duration","seconds":N}
+//   - gpt-4o-transcribe family: {"type":"tokens","input_tokens":N,
+//     "input_token_details":{...},"output_tokens":0,"total_tokens":N}
+//
+// For the token shape, output_tokens is always 0 upstream — transcription is
+// treated as input-side processing, not generation.
 type SpeechToTextUsage struct {
-	Type               string                    `json:"type"`
-	TotalTokens        int                       `json:"total_tokens"`
-	InputTokens        int                       `json:"input_tokens"`
-	InputTokenDetails  SpeechToTextTokenDetails  `json:"input_token_details"`
-	OutputTokens       int                       `json:"output_tokens"`
+	Type              string                   `json:"type"`
+	TotalTokens       int                      `json:"total_tokens"`
+	InputTokens       int                      `json:"input_tokens"`
+	InputTokenDetails SpeechToTextTokenDetails `json:"input_token_details"`
+	OutputTokens      int                      `json:"output_tokens"`
+	Seconds           int                      `json:"seconds"`
+}
+
+// hasBillableUsage reports whether a parsed usage object carries data we can
+// actually settle against. A non-nil Usage with all zero counters (e.g. a
+// whisper response decoded into a token-only struct, or an empty {} block)
+// would otherwise silently bill zero.
+func hasBillableUsage(u *SpeechToTextUsage) bool {
+	if u == nil {
+		return false
+	}
+	switch u.Type {
+	case "duration":
+		return u.Seconds > 0
+	case "tokens":
+		return u.InputTokens > 0 || u.OutputTokens > 0
+	default:
+		return u.Seconds > 0 || u.InputTokens > 0 || u.OutputTokens > 0
+	}
 }
 
 // SpeechToTextTokenDetails contains detailed token information
@@ -128,15 +155,16 @@ func (c *Ctrl) handleNonStreamingSpeechToText(ctx *gin.Context, resp *http.Respo
 
 	// Skip billing for whitelisted users, but record whitelist traffic metrics
 	if reqModel.IsWhitelisted {
-		if transcriptionResp.Usage != nil {
-			monitor.RecordTokens("speech_to_text", int64(transcriptionResp.Usage.InputTokens), int64(transcriptionResp.Usage.OutputTokens))
-			monitor.RecordWhitelistTokens("speech_to_text", int64(transcriptionResp.Usage.InputTokens), int64(transcriptionResp.Usage.OutputTokens))
+		if hasBillableUsage(transcriptionResp.Usage) {
+			in, out := usageMetricCounts(transcriptionResp.Usage)
+			monitor.RecordTokens("speech_to_text", in, out)
+			monitor.RecordWhitelistTokens("speech_to_text", in, out)
 		}
 		return nil
 	}
 
 	// Update billing with actual usage data
-	if transcriptionResp.Usage != nil {
+	if hasBillableUsage(transcriptionResp.Usage) {
 		return c.updateSpeechToTextWithUsage(ctx, transcriptionResp.Usage, reqModel.RequestHash)
 	}
 
@@ -229,15 +257,16 @@ func (c *Ctrl) handleStreamingSpeechToText(ctx *gin.Context, resp *http.Response
 
 	// Skip billing for whitelisted users, but record whitelist traffic metrics
 	if reqModel.IsWhitelisted {
-		if usage != nil {
-			monitor.RecordTokens("speech_to_text", int64(usage.InputTokens), int64(usage.OutputTokens))
-			monitor.RecordWhitelistTokens("speech_to_text", int64(usage.InputTokens), int64(usage.OutputTokens))
+		if hasBillableUsage(usage) {
+			in, out := usageMetricCounts(usage)
+			monitor.RecordTokens("speech_to_text", in, out)
+			monitor.RecordWhitelistTokens("speech_to_text", in, out)
 		}
 		return nil
 	}
 
 	// Update billing
-	if usage != nil {
+	if hasBillableUsage(usage) {
 		return c.updateSpeechToTextWithUsage(ctx, usage, reqModel.RequestHash)
 	}
 
@@ -245,21 +274,56 @@ func (c *Ctrl) handleStreamingSpeechToText(ctx *gin.Context, resp *http.Response
 	return c.updateSpeechToTextFallback(ctx, reqModel, rawBody.String())
 }
 
-// updateSpeechToTextWithUsage updates the request with accurate token counts from the API response
+// updateSpeechToTextWithUsage updates the request with accurate usage from the
+// API response. Dispatches on usage.Type:
+//   - "duration": bill Seconds × InputPrice (whisper family). InputPrice is
+//     interpreted as price-per-second by convention; OutputPrice is unused
+//     because whisper has no generation-side cost.
+//   - "tokens" (or unknown but with token counts): bill input_tokens × InputPrice
+//     + output_tokens × OutputPrice. For gpt-4o-transcribe, output_tokens is
+//     always 0 upstream, so this collapses to input-only billing.
 func (c *Ctrl) updateSpeechToTextWithUsage(ctx context.Context, usage *SpeechToTextUsage, requestHash string) error {
-	// Get service price from cache/contract instead of config
 	service, err := c.GetCachedService(ctx)
 	if err != nil {
 		return errors.Wrap(err, "get cached service for speech-to-text billing")
 	}
 
-	// Calculate actual fees based on API-provided token counts
-	inputFee, err := util.Multiply(service.InputPrice, int64(usage.InputTokens))
+	if usage.Type == "duration" {
+		return c.billSpeechToTextByDuration(ctx, usage, service.InputPrice, requestHash)
+	}
+	return c.billSpeechToTextByTokens(ctx, usage, service.InputPrice, service.OutputPrice, requestHash)
+}
+
+// billSpeechToTextByDuration handles whisper-style {"type":"duration","seconds":N}.
+// InputPrice is treated as price-per-second; OutputPrice is ignored.
+func (c *Ctrl) billSpeechToTextByDuration(ctx context.Context, usage *SpeechToTextUsage, inputPrice, requestHash string) error {
+	seconds := int64(usage.Seconds)
+
+	inputFee, err := util.Multiply(inputPrice, seconds)
+	if err != nil {
+		return errors.Wrap(err, "calculate duration fee")
+	}
+
+	// Persist as input_count=seconds, output_count=0 so duration-billed rows
+	// can be distinguished from token-billed rows by output==0+input>0+type.
+	if err := c.db.UpdateRequestWithAccurateTokens(requestHash, inputFee.String(), "0", inputFee.String(),
+		seconds, 0); err != nil {
+		return errors.Wrap(err, "update request with duration usage")
+	}
+
+	monitor.RecordTokens("speech_to_text", seconds, 0)
+	consumeSpeechToTextLimiter(ctx, int(seconds))
+	return nil
+}
+
+// billSpeechToTextByTokens handles gpt-4o-transcribe-style token usage.
+func (c *Ctrl) billSpeechToTextByTokens(ctx context.Context, usage *SpeechToTextUsage, inputPrice, outputPrice, requestHash string) error {
+	inputFee, err := util.Multiply(inputPrice, int64(usage.InputTokens))
 	if err != nil {
 		return errors.Wrap(err, "calculate input fee from actual tokens")
 	}
 
-	outputFee, err := util.Multiply(service.OutputPrice, int64(usage.OutputTokens))
+	outputFee, err := util.Multiply(outputPrice, int64(usage.OutputTokens))
 	if err != nil {
 		return errors.Wrap(err, "calculate output fee from actual tokens")
 	}
@@ -269,29 +333,57 @@ func (c *Ctrl) updateSpeechToTextWithUsage(ctx context.Context, usage *SpeechToT
 		return errors.Wrap(err, "calculate total fee")
 	}
 
-	// Update the request with accurate token counts and fees
 	if err := c.db.UpdateRequestWithAccurateTokens(requestHash, inputFee.String(), outputFee.String(), totalFee.String(),
 		int64(usage.InputTokens), int64(usage.OutputTokens)); err != nil {
 		return errors.Wrap(err, "update request with accurate tokens")
 	}
 
-	// Record token metrics
 	monitor.RecordTokens("speech_to_text", int64(usage.InputTokens), int64(usage.OutputTokens))
 	monitor.RecordTPSFromContext(ctx, "speech_to_text", int64(usage.OutputTokens))
-
-	// Update TPM limiter with actual token consumption
-	if ginCtx, ok := ctx.(*gin.Context); ok {
-		totalTokens := usage.InputTokens + usage.OutputTokens
-		userAddr, _ := ginCtx.Get("userAddress")
-		userStr, userOk := userAddr.(string)
-		if tpmLimiter, exists := ginCtx.Get("tpmLimiter"); exists && userOk {
-			if limiter, ok := tpmLimiter.(*middleware.PerUserTPMLimiter); ok {
-				limiter.ConsumeTokens(userStr, totalTokens)
-			}
-		}
-	}
-
+	consumeSpeechToTextLimiter(ctx, usage.InputTokens+usage.OutputTokens)
 	return nil
+}
+
+// consumeSpeechToTextLimiter feeds the post-consume TPM bucket with the actual
+// unit count (tokens or seconds, depending on the billing mode the caller
+// chose). The bucket is configured per-service so the unit conflation is
+// already implicit in the operator's RPM/TPM choice for whisper vs gpt-4o.
+func consumeSpeechToTextLimiter(ctx context.Context, units int) {
+	if units <= 0 {
+		return
+	}
+	ginCtx, ok := ctx.(*gin.Context)
+	if !ok {
+		return
+	}
+	userAddr, _ := ginCtx.Get("userAddress")
+	userStr, userOk := userAddr.(string)
+	if !userOk {
+		return
+	}
+	tpmLimiter, exists := ginCtx.Get("tpmLimiter")
+	if !exists {
+		return
+	}
+	limiter, ok := tpmLimiter.(*middleware.PerUserTPMLimiter)
+	if !ok {
+		return
+	}
+	limiter.ConsumeTokens(userStr, units)
+}
+
+// usageMetricCounts returns the (input, output) values to feed into
+// monitor.RecordTokens for a given usage object. For duration mode the seconds
+// count is reported in the input position to stay aligned with what InputPrice
+// settled against.
+func usageMetricCounts(u *SpeechToTextUsage) (int64, int64) {
+	if u == nil {
+		return 0, 0
+	}
+	if u.Type == "duration" {
+		return int64(u.Seconds), 0
+	}
+	return int64(u.InputTokens), int64(u.OutputTokens)
 }
 
 /*

--- a/api/inference/internal/ctrl/speech_to_text.go
+++ b/api/inference/internal/ctrl/speech_to_text.go
@@ -25,8 +25,8 @@ import (
 
 // ErrTokenBilledSpeechToTextGated is returned by billSpeechToTextByTokens when
 // cfg.AllowTokenBilledSpeechToText is false. Callers detect it with errors.Is
-// and degrade to the word-count fallback so the operator still captures
-// something for a request the user already received a response for. Tied to
+// and degrade to billGatedTokenSTT, which bills against the real upstream
+// usage (not an estimate) so the operator doesn't ship free GPU. Tied to
 // issue #530 — when the schema discriminator lands, the gate (and this
 // sentinel) get removed.
 var ErrTokenBilledSpeechToTextGated = stderrors.New("token-billed speech-to-text disabled pending #530")
@@ -231,8 +231,10 @@ func (c *Ctrl) handleNonStreamingSpeechToText(ctx *gin.Context, resp *http.Respo
 	if hasBillableUsage(transcriptionResp.Usage) {
 		err := c.updateSpeechToTextWithUsage(ctx, transcriptionResp.Usage, reqModel.RequestHash)
 		if stderrors.Is(err, ErrTokenBilledSpeechToTextGated) {
-			c.logger.Warnf("token-billed STT gated (#530), falling back to word-count estimation for request %s", reqModel.RequestHash)
-			return c.updateSpeechToTextFallback(ctx, reqModel, string(decompressedBody))
+			if billErr := c.billGatedTokenSTT(ctx, transcriptionResp.Usage, reqModel.RequestHash); billErr != nil {
+				return billErr
+			}
+			return nil
 		}
 		return err
 	}
@@ -324,6 +326,13 @@ func (c *Ctrl) handleStreamingSpeechToText(ctx *gin.Context, resp *http.Response
 		_ = c.signChatWithKey(reqBody, rawBody.Bytes(), chatKey)
 	}
 
+	// streamErr (set inside ctx.Stream above) is intentionally NOT returned
+	// here. If the upstream read or client write failed mid-stream, the user
+	// has whatever bytes we managed to ship — bill for whatever usage we
+	// extracted before the failure rather than handing them free output.
+	// handleBrokerError was already called inside the loop for visibility.
+	_ = streamErr
+
 	// Skip billing for whitelisted users, but record whitelist traffic metrics
 	if reqModel.IsWhitelisted {
 		recordWhitelistUsageMetrics(usage)
@@ -334,8 +343,10 @@ func (c *Ctrl) handleStreamingSpeechToText(ctx *gin.Context, resp *http.Response
 	if hasBillableUsage(usage) {
 		err := c.updateSpeechToTextWithUsage(ctx, usage, reqModel.RequestHash)
 		if stderrors.Is(err, ErrTokenBilledSpeechToTextGated) {
-			c.logger.Warnf("token-billed STT gated (#530), falling back to word-count estimation for request %s", reqModel.RequestHash)
-			return c.updateSpeechToTextFallback(ctx, reqModel, rawBody.String())
+			if billErr := c.billGatedTokenSTT(ctx, usage, reqModel.RequestHash); billErr != nil {
+				return billErr
+			}
+			return nil
 		}
 		return err
 	}
@@ -403,7 +414,7 @@ func (c *Ctrl) billSpeechToTextByDuration(ctx context.Context, usage *SpeechToTe
 	// tokens-per-second concept (the whole transcript is delivered as one
 	// shot, not as a generation stream). A seconds/second metric would be
 	// nonsensical and would pollute the chatbot TPS dashboard.
-	consumeSpeechToTextLimiter(ctx, seconds)
+	c.consumeSpeechToTextLimiter(ctx, seconds)
 	return nil
 }
 
@@ -419,13 +430,49 @@ func (c *Ctrl) billSpeechToTextByDuration(ctx context.Context, usage *SpeechToTe
 func (c *Ctrl) billSpeechToTextByTokens(ctx context.Context, usage *SpeechToTextUsage, inputPrice, outputPrice, requestHash string) error {
 	if !c.allowTokenBilledSTT {
 		// Sentinel error so callers can detect the gate-fired case and route
-		// to the word-count fallback. Billing here is post-response: the
-		// transcription has already streamed to the user, so refusing to bill
-		// at all means free GPU. Falling back to the estimator captures
-		// something against OutputPrice; the operator gets a warning log and
-		// can flip the flag once they've reviewed #530's trade-off.
+		// to billSpeechToTextByTokensCore directly. Billing here is
+		// post-response: the transcription has already streamed to the user,
+		// so refusing to bill would be free GPU. The handler logs a warning
+		// and bills against the real upstream usage anyway — daily_stat
+		// archive contamination is prevented by the separate STT skip in
+		// AccumulateAndDeleteRequests, so writing real values to
+		// requests.input_count is safe within the single-service-per-broker
+		// assumption. See #530.
 		return ErrTokenBilledSpeechToTextGated
 	}
+	return c.billSpeechToTextByTokensCore(ctx, usage, inputPrice, outputPrice, requestHash)
+}
+
+// billGatedTokenSTT bills a gate-tripped token-STT request against the real
+// upstream usage. Reviewer pointed out that routing the gate to the generic
+// word-count fallback bills `OutputPrice × estimate` — and gpt-4o-transcribe
+// operators typically set OutputPrice=0 (output_tokens is always 0 upstream),
+// so that path silently bills 0 again. The gate's structural protection
+// (preventing daily_stat archive contamination) is provided by the separate
+// STT skip in AccumulateAndDeleteRequests, so writing the real values to
+// requests.input_count is safe within the single-service-per-broker
+// assumption. Logs a warning loud enough that the operator can find it and
+// flip cfg.AllowTokenBilledSpeechToText after reading #530.
+func (c *Ctrl) billGatedTokenSTT(ctx context.Context, usage *SpeechToTextUsage, requestHash string) error {
+	c.logger.Warnf(
+		"token-billed STT gated (cfg.AllowTokenBilledSpeechToText=false, see #530) but transcription already shipped to user; "+
+			"billing against upstream usage (input_tokens=%d, output_tokens=%d) to avoid free GPU. "+
+			"Flip the config flag to silence this warning after reviewing the analytics trade-off. request=%s",
+		usage.InputTokens, usage.OutputTokens, requestHash,
+	)
+	service, err := c.GetCachedService(ctx)
+	if err != nil {
+		return errors.Wrap(err, "get cached service for gated token-stt billing")
+	}
+	return c.billSpeechToTextByTokensCore(ctx, usage, service.InputPrice, service.OutputPrice, requestHash)
+}
+
+// billSpeechToTextByTokensCore is the gate-less token-billing math. Called
+// directly by handler paths when the gate trips and we need to bill the
+// in-flight request against the real upstream usage rather than a fallback
+// estimate that may evaluate to 0 (gpt-4o-transcribe operators typically set
+// OutputPrice=0 since output_tokens is always 0).
+func (c *Ctrl) billSpeechToTextByTokensCore(ctx context.Context, usage *SpeechToTextUsage, inputPrice, outputPrice, requestHash string) error {
 	inputFeeStr, outputFeeStr, totalFeeStr, err := calcTokenFees(inputPrice, outputPrice, usage.InputTokens, usage.OutputTokens)
 	if err != nil {
 		return err
@@ -437,8 +484,13 @@ func (c *Ctrl) billSpeechToTextByTokens(ctx context.Context, usage *SpeechToText
 	}
 
 	monitor.RecordTokens(speechToTextMetricLabel, int64(usage.InputTokens), int64(usage.OutputTokens))
+	// RecordTPSFromContext early-returns when outputTokens <= 0, so gpt-4o-transcribe
+	// (output_tokens always 0 upstream) emits no observation rather than recording a
+	// misleading 0 — verified in monitor.RecordTPSFromContext. Kept for forward
+	// compatibility with any future token-billed STT model that does emit
+	// non-zero output_tokens.
 	monitor.RecordTPSFromContext(ctx, speechToTextMetricLabel, int64(usage.OutputTokens))
-	consumeSpeechToTextLimiter(ctx, usage.InputTokens+usage.OutputTokens)
+	c.consumeSpeechToTextLimiter(ctx, usage.InputTokens+usage.OutputTokens)
 	return nil
 }
 
@@ -474,25 +526,35 @@ func calcTokenFees(inputPrice, outputPrice string, inputTokens, outputTokens int
 // unit count (tokens or seconds, depending on the billing mode the caller
 // chose). The bucket is configured per-service so the unit conflation is
 // already implicit in the operator's RPM/TPM choice for whisper vs gpt-4o.
-func consumeSpeechToTextLimiter(ctx context.Context, units int) {
+//
+// Each "limiter missing" branch logs at debug level. These paths are not
+// errors (some tests / internal calls drive Ctrl without a gin context), but
+// if a production code path ever stopped wiring tpmLimiter through, rate
+// limiting would silently disable for STT — the debug logs let operators
+// discover that by toggling log level without us having to add a metric.
+func (c *Ctrl) consumeSpeechToTextLimiter(ctx context.Context, units int) {
 	if units <= 0 {
 		return
 	}
 	ginCtx, ok := ctx.(*gin.Context)
 	if !ok {
+		c.logger.Debugf("consumeSpeechToTextLimiter: ctx is not *gin.Context (units=%d), limiter skipped", units)
 		return
 	}
 	userAddr, _ := ginCtx.Get("userAddress")
 	userStr, userOk := userAddr.(string)
 	if !userOk {
+		c.logger.Debugf("consumeSpeechToTextLimiter: userAddress missing from gin.Context (units=%d), limiter skipped", units)
 		return
 	}
 	tpmLimiter, exists := ginCtx.Get("tpmLimiter")
 	if !exists {
+		c.logger.Debugf("consumeSpeechToTextLimiter: tpmLimiter missing from gin.Context user=%s (units=%d), limiter skipped", userStr, units)
 		return
 	}
 	limiter, ok := tpmLimiter.(*middleware.PerUserTPMLimiter)
 	if !ok {
+		c.logger.Debugf("consumeSpeechToTextLimiter: tpmLimiter has unexpected type %T user=%s (units=%d), limiter skipped", tpmLimiter, userStr, units)
 		return
 	}
 	limiter.ConsumeTokens(userStr, units)
@@ -590,16 +652,8 @@ func (c *Ctrl) updateSpeechToTextFallback(ctx context.Context, reqModel model.Re
 	monitor.RecordTokens(speechToTextMetricLabel, 0, estimatedOutputTokens)
 	monitor.RecordTPSFromContext(ctx, speechToTextMetricLabel, estimatedOutputTokens)
 
-	// Update TPM limiter with estimated token consumption (fallback path)
-	if ginCtx, ok := ctx.(*gin.Context); ok {
-		userAddr, _ := ginCtx.Get("userAddress")
-		userStr, userOk := userAddr.(string)
-		if tpmLimiter, exists := ginCtx.Get("tpmLimiter"); exists && userOk {
-			if limiter, ok := tpmLimiter.(*middleware.PerUserTPMLimiter); ok {
-				limiter.ConsumeTokens(userStr, int(estimatedOutputTokens))
-			}
-		}
-	}
+	// Update TPM limiter with estimated token consumption (fallback path).
+	c.consumeSpeechToTextLimiter(ctx, int(estimatedOutputTokens))
 
 	return nil
 }

--- a/api/inference/internal/ctrl/speech_to_text.go
+++ b/api/inference/internal/ctrl/speech_to_text.go
@@ -7,6 +7,7 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"io"
 	"math"
 	"net/http"
@@ -21,6 +22,21 @@ import (
 	"github.com/0glabs/0g-serving-broker/inference/model"
 	"github.com/0glabs/0g-serving-broker/inference/monitor"
 )
+
+// ErrTokenBilledSpeechToTextGated is returned by billSpeechToTextByTokens when
+// cfg.AllowTokenBilledSpeechToText is false. Callers detect it with errors.Is
+// and degrade to the word-count fallback so the operator still captures
+// something for a request the user already received a response for. Tied to
+// issue #530 — when the schema discriminator lands, the gate (and this
+// sentinel) get removed.
+var ErrTokenBilledSpeechToTextGated = stderrors.New("token-billed speech-to-text disabled pending #530")
+
+// speechToTextMetricLabel is the Prometheus service_type label value for the
+// speech-to-text family. Note: different from constant.ServiceTypeSpeechToText
+// ("speech-to-text" with a hyphen) — Prometheus label values use underscores
+// by convention across the broker, while broker-internal service-type strings
+// use hyphens.
+const speechToTextMetricLabel = "speech_to_text"
 
 // SpeechToTextUsage represents the usage information from speech-to-text API.
 //
@@ -213,7 +229,12 @@ func (c *Ctrl) handleNonStreamingSpeechToText(ctx *gin.Context, resp *http.Respo
 
 	// Update billing with actual usage data
 	if hasBillableUsage(transcriptionResp.Usage) {
-		return c.updateSpeechToTextWithUsage(ctx, transcriptionResp.Usage, reqModel.RequestHash)
+		err := c.updateSpeechToTextWithUsage(ctx, transcriptionResp.Usage, reqModel.RequestHash)
+		if stderrors.Is(err, ErrTokenBilledSpeechToTextGated) {
+			c.logger.Warnf("token-billed STT gated (#530), falling back to word-count estimation for request %s", reqModel.RequestHash)
+			return c.updateSpeechToTextFallback(ctx, reqModel, string(decompressedBody))
+		}
+		return err
 	}
 
 	// Fallback if no usage data
@@ -311,7 +332,12 @@ func (c *Ctrl) handleStreamingSpeechToText(ctx *gin.Context, resp *http.Response
 
 	// Update billing
 	if hasBillableUsage(usage) {
-		return c.updateSpeechToTextWithUsage(ctx, usage, reqModel.RequestHash)
+		err := c.updateSpeechToTextWithUsage(ctx, usage, reqModel.RequestHash)
+		if stderrors.Is(err, ErrTokenBilledSpeechToTextGated) {
+			c.logger.Warnf("token-billed STT gated (#530), falling back to word-count estimation for request %s", reqModel.RequestHash)
+			return c.updateSpeechToTextFallback(ctx, reqModel, rawBody.String())
+		}
+		return err
 	}
 
 	// Fallback if no usage data
@@ -372,7 +398,7 @@ func (c *Ctrl) billSpeechToTextByDuration(ctx context.Context, usage *SpeechToTe
 		return errors.Wrap(err, "update request with duration usage")
 	}
 
-	monitor.RecordAudioSeconds("speech_to_text", int64(seconds))
+	monitor.RecordAudioSeconds(speechToTextMetricLabel, int64(seconds))
 	// No RecordTPSFromContext for duration mode: whisper has no
 	// tokens-per-second concept (the whole transcript is delivered as one
 	// shot, not as a generation stream). A seconds/second metric would be
@@ -392,7 +418,13 @@ func (c *Ctrl) billSpeechToTextByDuration(ctx context.Context, usage *SpeechToTe
 // risk for that window. See #530 for the schema work + acceptance criteria.
 func (c *Ctrl) billSpeechToTextByTokens(ctx context.Context, usage *SpeechToTextUsage, inputPrice, outputPrice, requestHash string) error {
 	if !c.allowTokenBilledSTT {
-		return errors.New("token-billed speech-to-text is gated behind cfg.allowTokenBilledSpeechToText pending the per-row billing-unit discriminator in issue #530; set the flag to enable after reviewing the analytics trade-off")
+		// Sentinel error so callers can detect the gate-fired case and route
+		// to the word-count fallback. Billing here is post-response: the
+		// transcription has already streamed to the user, so refusing to bill
+		// at all means free GPU. Falling back to the estimator captures
+		// something against OutputPrice; the operator gets a warning log and
+		// can flip the flag once they've reviewed #530's trade-off.
+		return ErrTokenBilledSpeechToTextGated
 	}
 	inputFeeStr, outputFeeStr, totalFeeStr, err := calcTokenFees(inputPrice, outputPrice, usage.InputTokens, usage.OutputTokens)
 	if err != nil {
@@ -404,8 +436,8 @@ func (c *Ctrl) billSpeechToTextByTokens(ctx context.Context, usage *SpeechToText
 		return errors.Wrap(err, "update request with accurate tokens")
 	}
 
-	monitor.RecordTokens("speech_to_text", int64(usage.InputTokens), int64(usage.OutputTokens))
-	monitor.RecordTPSFromContext(ctx, "speech_to_text", int64(usage.OutputTokens))
+	monitor.RecordTokens(speechToTextMetricLabel, int64(usage.InputTokens), int64(usage.OutputTokens))
+	monitor.RecordTPSFromContext(ctx, speechToTextMetricLabel, int64(usage.OutputTokens))
 	consumeSpeechToTextLimiter(ctx, usage.InputTokens+usage.OutputTokens)
 	return nil
 }
@@ -499,14 +531,13 @@ func classifyUsageForMetrics(u *SpeechToTextUsage) (seconds, inputTokens, output
 // with the billing dispatch.
 func recordWhitelistUsageMetrics(u *SpeechToTextUsage) {
 	seconds, in, out := classifyUsageForMetrics(u)
-	const svc = "speech_to_text"
 	if seconds > 0 {
-		monitor.RecordAudioSeconds(svc, seconds)
-		monitor.RecordWhitelistAudioSeconds(svc, seconds)
+		monitor.RecordAudioSeconds(speechToTextMetricLabel, seconds)
+		monitor.RecordWhitelistAudioSeconds(speechToTextMetricLabel, seconds)
 	}
 	if in > 0 || out > 0 {
-		monitor.RecordTokens(svc, in, out)
-		monitor.RecordWhitelistTokens(svc, in, out)
+		monitor.RecordTokens(speechToTextMetricLabel, in, out)
+		monitor.RecordWhitelistTokens(speechToTextMetricLabel, in, out)
 	}
 }
 
@@ -556,8 +587,8 @@ func (c *Ctrl) updateSpeechToTextFallback(ctx context.Context, reqModel model.Re
 	}
 
 	// Record token metrics (estimated output tokens only, no input token data in fallback path)
-	monitor.RecordTokens("speech_to_text", 0, estimatedOutputTokens)
-	monitor.RecordTPSFromContext(ctx, "speech_to_text", estimatedOutputTokens)
+	monitor.RecordTokens(speechToTextMetricLabel, 0, estimatedOutputTokens)
+	monitor.RecordTPSFromContext(ctx, speechToTextMetricLabel, estimatedOutputTokens)
 
 	// Update TPM limiter with estimated token consumption (fallback path)
 	if ginCtx, ok := ctx.(*gin.Context); ok {

--- a/api/inference/internal/ctrl/speech_to_text.go
+++ b/api/inference/internal/ctrl/speech_to_text.go
@@ -179,7 +179,7 @@ func (c *Ctrl) handleNonStreamingSpeechToText(ctx *gin.Context, resp *http.Respo
 
 	// Skip billing for whitelisted users, but record whitelist traffic metrics
 	if reqModel.IsWhitelisted {
-		recordUsageMetrics(transcriptionResp.Usage, true)
+		recordWhitelistUsageMetrics(transcriptionResp.Usage)
 		return nil
 	}
 
@@ -277,7 +277,7 @@ func (c *Ctrl) handleStreamingSpeechToText(ctx *gin.Context, resp *http.Response
 
 	// Skip billing for whitelisted users, but record whitelist traffic metrics
 	if reqModel.IsWhitelisted {
-		recordUsageMetrics(usage, true)
+		recordWhitelistUsageMetrics(usage)
 		return nil
 	}
 
@@ -445,24 +445,23 @@ func classifyUsageForMetrics(u *SpeechToTextUsage) (seconds, inputTokens, output
 	return 0, int64(u.InputTokens), int64(u.OutputTokens)
 }
 
-// recordUsageMetrics writes a usage object to the appropriate Prometheus
-// counters. whitelisted=true additionally mirrors the values into the
-// whitelist-only counter family so operators can split traffic by
-// exempt-vs-paid users.
-func recordUsageMetrics(u *SpeechToTextUsage, whitelisted bool) {
+// recordWhitelistUsageMetrics writes a usage object into both the general and
+// the whitelist Prometheus counter families. Used on the IsWhitelisted code
+// path where billing is skipped but operators still want to see traffic from
+// internal/exempt users (double-counted into the general counter so dashboards
+// stay accurate, plus broken out into the whitelist counter so the share is
+// inspectable). Routes via classifyUsageForMetrics so it stays in lockstep
+// with the billing dispatch.
+func recordWhitelistUsageMetrics(u *SpeechToTextUsage) {
 	seconds, in, out := classifyUsageForMetrics(u)
 	const svc = "speech_to_text"
 	if seconds > 0 {
 		monitor.RecordAudioSeconds(svc, seconds)
-		if whitelisted {
-			monitor.RecordWhitelistAudioSeconds(svc, seconds)
-		}
+		monitor.RecordWhitelistAudioSeconds(svc, seconds)
 	}
 	if in > 0 || out > 0 {
 		monitor.RecordTokens(svc, in, out)
-		if whitelisted {
-			monitor.RecordWhitelistTokens(svc, in, out)
-		}
+		monitor.RecordWhitelistTokens(svc, in, out)
 	}
 }
 

--- a/api/inference/internal/ctrl/speech_to_text_test.go
+++ b/api/inference/internal/ctrl/speech_to_text_test.go
@@ -194,63 +194,81 @@ func TestHasBillableUsage(t *testing.T) {
 }
 
 // ==========================================================================
-// usageMetricCounts
+// classifyUsageForMetrics
 //
 // The whitelist metrics lane. Must classify identically to the billing
-// dispatch — divergence is exactly the bug flagged in review. The
+// dispatch — divergence is exactly the bug PR #523's review caught. The
 // "agrees with isDurationUsage" test is the structural guarantee.
+// Duration-billed usage must surface in the seconds slot, token-billed
+// usage in the token slots. Never both.
 // ==========================================================================
 
-func TestUsageMetricCounts(t *testing.T) {
+func TestClassifyUsageForMetrics(t *testing.T) {
 	tests := []struct {
-		name      string
-		usage     *SpeechToTextUsage
-		wantIn    int64
-		wantOut   int64
+		name        string
+		usage       *SpeechToTextUsage
+		wantSeconds int64
+		wantIn      int64
+		wantOut     int64
 	}{
-		{"nil", nil, 0, 0},
+		{"nil", nil, 0, 0, 0},
+		{"empty", &SpeechToTextUsage{}, 0, 0, 0},
 		{
-			"duration mode reports seconds in input slot",
+			"duration mode routes to seconds slot",
 			&SpeechToTextUsage{Type: "duration", Seconds: 207},
-			207, 0,
+			207, 0, 0,
 		},
 		{
-			"tokens mode reports input/output tokens",
+			"tokens mode routes to token slots",
 			&SpeechToTextUsage{Type: "tokens", InputTokens: 149, OutputTokens: 0},
-			149, 0,
+			0, 149, 0,
 		},
 		{
-			// Regression for the review finding: missing-type +
-			// seconds-only must report seconds, matching the billing
-			// dispatch instead of falling to the tokens shape (0, 0).
-			"missing type with seconds reports as duration",
+			"tokens mode with output > 0",
+			&SpeechToTextUsage{Type: "tokens", InputTokens: 100, OutputTokens: 50},
+			0, 100, 50,
+		},
+		{
+			// Mid-review regression: a {seconds:N} response without an
+			// explicit type discriminator must land in the seconds slot,
+			// not silently zero out as (0,0,0).
+			"missing type with seconds routes to seconds",
 			&SpeechToTextUsage{Seconds: 30},
-			30, 0,
+			30, 0, 0,
 		},
 		{
-			"missing type with tokens reports as tokens",
+			"missing type with tokens routes to token slots",
 			&SpeechToTextUsage{InputTokens: 50, OutputTokens: 10},
-			50, 10,
+			0, 50, 10,
+		},
+		{
+			"mismatched shape blocked at gate",
+			// type=duration + seconds=0 + input_tokens populated.
+			// hasBillableUsage returns false (strict-by-type), so the
+			// classifier emits (0,0,0) and the recorder no-ops.
+			&SpeechToTextUsage{Type: "duration", InputTokens: 100},
+			0, 0, 0,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotIn, gotOut := usageMetricCounts(tt.usage)
-			if gotIn != tt.wantIn || gotOut != tt.wantOut {
-				t.Errorf("usageMetricCounts() = (%d, %d), want (%d, %d)",
-					gotIn, gotOut, tt.wantIn, tt.wantOut)
+			gotSeconds, gotIn, gotOut := classifyUsageForMetrics(tt.usage)
+			if gotSeconds != tt.wantSeconds || gotIn != tt.wantIn || gotOut != tt.wantOut {
+				t.Errorf("classifyUsageForMetrics() = (s=%d, in=%d, out=%d), want (s=%d, in=%d, out=%d)",
+					gotSeconds, gotIn, gotOut, tt.wantSeconds, tt.wantIn, tt.wantOut)
 			}
 		})
 	}
 }
 
-// TestUsageMetricCounts_AgreesWithIsDurationUsage is the structural guard
-// against the dispatch/metrics divergence that motivated PR #523's review
-// fix. For every input where isDurationUsage returns true, the metric
-// helper must populate the input slot with seconds (and zero the output
-// slot). For tokens-mode inputs it must populate the token counters.
-func TestUsageMetricCounts_AgreesWithIsDurationUsage(t *testing.T) {
+// TestClassifyUsageForMetrics_AgreesWithIsDurationUsage is the structural
+// guard against the dispatch/metrics divergence that motivated PR #523's
+// review fix. For every input where isDurationUsage returns true AND the
+// usage is billable, the seconds slot must carry the value and both token
+// slots must be zero. The inverse holds for tokens mode. No input may set
+// both seconds AND token slots — that would double-count.
+func TestClassifyUsageForMetrics_AgreesWithIsDurationUsage(t *testing.T) {
 	usages := []*SpeechToTextUsage{
 		{Type: "duration", Seconds: 100},
 		{Type: "tokens", InputTokens: 100, OutputTokens: 0},
@@ -262,18 +280,138 @@ func TestUsageMetricCounts_AgreesWithIsDurationUsage(t *testing.T) {
 	}
 
 	for _, u := range usages {
-		gotIn, gotOut := usageMetricCounts(u)
+		seconds, in, out := classifyUsageForMetrics(u)
+		if !hasBillableUsage(u) {
+			if seconds != 0 || in != 0 || out != 0 {
+				t.Errorf("non-billable %+v: classified = (s=%d, in=%d, out=%d), want all-zero", u, seconds, in, out)
+			}
+			continue
+		}
+		if seconds > 0 && (in > 0 || out > 0) {
+			t.Errorf("double-counted %+v: classified = (s=%d, in=%d, out=%d) populates both lanes", u, seconds, in, out)
+		}
 		if isDurationUsage(u) {
-			if gotIn != int64(u.Seconds) || gotOut != 0 {
-				t.Errorf("duration-classified %+v: metrics = (%d, %d), want (%d, 0)",
-					u, gotIn, gotOut, u.Seconds)
+			if seconds != int64(u.Seconds) || in != 0 || out != 0 {
+				t.Errorf("duration-classified %+v: got (s=%d, in=%d, out=%d), want (s=%d, 0, 0)",
+					u, seconds, in, out, u.Seconds)
 			}
 		} else {
-			if gotIn != int64(u.InputTokens) || gotOut != int64(u.OutputTokens) {
-				t.Errorf("tokens-classified %+v: metrics = (%d, %d), want (%d, %d)",
-					u, gotIn, gotOut, u.InputTokens, u.OutputTokens)
+			if in != int64(u.InputTokens) || out != int64(u.OutputTokens) || seconds != 0 {
+				t.Errorf("tokens-classified %+v: got (s=%d, in=%d, out=%d), want (0, %d, %d)",
+					u, seconds, in, out, u.InputTokens, u.OutputTokens)
 			}
 		}
+	}
+}
+
+// ==========================================================================
+// calcDurationFee / calcTokenFees
+//
+// Pure fee arithmetic, extracted from the bill helpers so we can pin the
+// math without spinning up a DB. The bill helpers are now thin glue:
+// classifier → math → c.db.Update + monitor + limiter, where every step
+// except the DB call is unit-tested here.
+// ==========================================================================
+
+func TestCalcDurationFee(t *testing.T) {
+	tests := []struct {
+		name       string
+		inputPrice string
+		seconds    int
+		want       string
+	}{
+		{"normal", "100", 207, "20700"},
+		{"zero seconds", "100", 0, "0"},
+		{"zero price", "0", 207, "0"},
+		// Real-world-shaped: per-second price from the chain has 18-decimal
+		// fixed-point representation. Verify big.Int multiplication handles
+		// the wide range without precision loss.
+		{"big price", "70000000000", 207, "14490000000000"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := calcDurationFee(tt.inputPrice, tt.seconds)
+			if err != nil {
+				t.Fatalf("calcDurationFee: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("calcDurationFee(%q, %d) = %q, want %q",
+					tt.inputPrice, tt.seconds, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCalcDurationFee_BadPrice(t *testing.T) {
+	if _, err := calcDurationFee("not-a-number", 100); err == nil {
+		t.Error("expected error for non-numeric price")
+	}
+}
+
+func TestCalcTokenFees(t *testing.T) {
+	tests := []struct {
+		name        string
+		inputPrice  string
+		outputPrice string
+		inputTok    int
+		outputTok   int
+		wantIn      string
+		wantOut     string
+		wantTotal   string
+	}{
+		{
+			name:        "input only (gpt-4o-transcribe shape)",
+			inputPrice:  "100",
+			outputPrice: "200",
+			inputTok:    149,
+			outputTok:   0,
+			wantIn:      "14900",
+			wantOut:     "0",
+			wantTotal:   "14900",
+		},
+		{
+			name:        "input and output",
+			inputPrice:  "100",
+			outputPrice: "200",
+			inputTok:    10,
+			outputTok:   20,
+			wantIn:      "1000",
+			wantOut:     "4000",
+			wantTotal:   "5000",
+		},
+		{
+			name:        "all zero counts",
+			inputPrice:  "100",
+			outputPrice: "200",
+			inputTok:    0,
+			outputTok:   0,
+			wantIn:      "0",
+			wantOut:     "0",
+			wantTotal:   "0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotIn, gotOut, gotTotal, err := calcTokenFees(tt.inputPrice, tt.outputPrice, tt.inputTok, tt.outputTok)
+			if err != nil {
+				t.Fatalf("calcTokenFees: %v", err)
+			}
+			if gotIn != tt.wantIn || gotOut != tt.wantOut || gotTotal != tt.wantTotal {
+				t.Errorf("calcTokenFees() = (%q, %q, %q), want (%q, %q, %q)",
+					gotIn, gotOut, gotTotal, tt.wantIn, tt.wantOut, tt.wantTotal)
+			}
+		})
+	}
+}
+
+func TestCalcTokenFees_BadPrice(t *testing.T) {
+	if _, _, _, err := calcTokenFees("bad", "200", 10, 20); err == nil {
+		t.Error("expected error for non-numeric input price")
+	}
+	if _, _, _, err := calcTokenFees("100", "bad", 10, 20); err == nil {
+		t.Error("expected error for non-numeric output price")
 	}
 }
 

--- a/api/inference/internal/ctrl/speech_to_text_test.go
+++ b/api/inference/internal/ctrl/speech_to_text_test.go
@@ -3,7 +3,7 @@ package ctrl
 import (
 	"context"
 	"encoding/json"
-	"strings"
+	stderrors "errors"
 	"testing"
 )
 
@@ -19,13 +19,12 @@ func TestBillSpeechToTextByTokens_GatedByDefault(t *testing.T) {
 	c := &Ctrl{allowTokenBilledSTT: false}
 	usage := &SpeechToTextUsage{Type: "tokens", InputTokens: 100}
 	err := c.billSpeechToTextByTokens(context.Background(), usage, "1", "1", "hash")
-	if err == nil {
-		t.Fatal("expected gated error when allowTokenBilledSTT is false, got nil")
-	}
-	// The error message must mention the issue so anyone hitting it in
-	// the wild can find the schema-discriminator work without digging.
-	if !strings.Contains(err.Error(), "#530") {
-		t.Errorf("error message must reference issue #530, got: %v", err)
+	// Sentinel so callers can branch via errors.Is rather than substring-match.
+	// Handler paths use this to route gated requests into the word-count fallback
+	// (we already streamed the transcription to the user — refusing to bill at
+	// all would be free GPU time for the operator).
+	if !stderrors.Is(err, ErrTokenBilledSpeechToTextGated) {
+		t.Errorf("expected ErrTokenBilledSpeechToTextGated, got: %v", err)
 	}
 }
 

--- a/api/inference/internal/ctrl/speech_to_text_test.go
+++ b/api/inference/internal/ctrl/speech_to_text_test.go
@@ -1,0 +1,324 @@
+package ctrl
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// ==========================================================================
+// SpeechToTextUsage JSON decoding
+//
+// Both upstream usage shapes must round-trip cleanly so the dispatch sees
+// real data — if the struct silently drops a field, the downstream
+// classifier degenerates into the zero-fee bug PR #523 fixed.
+// ==========================================================================
+
+func TestSpeechToTextUsage_DecodeWhisperShape(t *testing.T) {
+	// What whisper-1 / whisper-large-v3 returns. The fact this is the
+	// shape that triggered the original zero-fee bug is why this test
+	// exists — if the JSON tag on Seconds ever drifts, billing goes
+	// silent again.
+	raw := []byte(`{"type":"duration","seconds":207}`)
+	var u SpeechToTextUsage
+	if err := json.Unmarshal(raw, &u); err != nil {
+		t.Fatalf("unmarshal whisper usage: %v", err)
+	}
+	if u.Type != "duration" {
+		t.Errorf("Type = %q, want %q", u.Type, "duration")
+	}
+	if u.Seconds != 207 {
+		t.Errorf("Seconds = %d, want 207", u.Seconds)
+	}
+	if u.InputTokens != 0 || u.OutputTokens != 0 {
+		t.Errorf("token counts = (%d, %d), want (0, 0)", u.InputTokens, u.OutputTokens)
+	}
+}
+
+func TestSpeechToTextUsage_DecodeGPT4OTranscribeShape(t *testing.T) {
+	raw := []byte(`{
+		"type":"tokens",
+		"total_tokens":149,
+		"input_tokens":149,
+		"input_token_details":{"text_tokens":6,"audio_tokens":143},
+		"output_tokens":0
+	}`)
+	var u SpeechToTextUsage
+	if err := json.Unmarshal(raw, &u); err != nil {
+		t.Fatalf("unmarshal gpt-4o-transcribe usage: %v", err)
+	}
+	if u.Type != "tokens" {
+		t.Errorf("Type = %q, want %q", u.Type, "tokens")
+	}
+	if u.InputTokens != 149 {
+		t.Errorf("InputTokens = %d, want 149", u.InputTokens)
+	}
+	if u.OutputTokens != 0 {
+		t.Errorf("OutputTokens = %d, want 0", u.OutputTokens)
+	}
+	if u.InputTokenDetails.AudioTokens != 143 {
+		t.Errorf("AudioTokens = %d, want 143", u.InputTokenDetails.AudioTokens)
+	}
+	if u.InputTokenDetails.TextTokens != 6 {
+		t.Errorf("TextTokens = %d, want 6", u.InputTokenDetails.TextTokens)
+	}
+}
+
+// ==========================================================================
+// isDurationUsage
+//
+// Single source of truth for dispatch. Every row here represents a real
+// or plausible upstream response shape — losing any of them means a
+// regression in billing accuracy.
+// ==========================================================================
+
+func TestIsDurationUsage(t *testing.T) {
+	tests := []struct {
+		name  string
+		usage *SpeechToTextUsage
+		want  bool
+	}{
+		{"nil", nil, false},
+		{"empty", &SpeechToTextUsage{}, false},
+		{
+			"explicit duration",
+			&SpeechToTextUsage{Type: "duration", Seconds: 207},
+			true,
+		},
+		{
+			"explicit duration with zero seconds",
+			&SpeechToTextUsage{Type: "duration", Seconds: 0},
+			true, // type wins; hasBillableUsage filters the zero case
+		},
+		{
+			"explicit tokens",
+			&SpeechToTextUsage{Type: "tokens", InputTokens: 100},
+			false,
+		},
+		{
+			// The regression case fixed mid-review of PR #523: a
+			// non-conforming provider that omits the type field but
+			// populates seconds must still be classified as duration.
+			"missing type with seconds",
+			&SpeechToTextUsage{Seconds: 30},
+			true,
+		},
+		{
+			"missing type with only input tokens",
+			&SpeechToTextUsage{InputTokens: 50},
+			false,
+		},
+		{
+			// Hypothetical mixed response: explicit type="tokens" must
+			// override any seconds field. Trust the discriminator.
+			"explicit tokens overrides stray seconds",
+			&SpeechToTextUsage{Type: "tokens", Seconds: 50, InputTokens: 100},
+			false,
+		},
+		{
+			"unknown type with seconds falls to duration",
+			&SpeechToTextUsage{Type: "future-mode", Seconds: 10},
+			true,
+		},
+		{
+			"unknown type with tokens falls to tokens",
+			&SpeechToTextUsage{Type: "future-mode", InputTokens: 10},
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isDurationUsage(tt.usage); got != tt.want {
+				t.Errorf("isDurationUsage() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// ==========================================================================
+// hasBillableUsage
+//
+// Admission gate for the accurate-billing path. Anything that returns
+// false here falls through to the word-count fallback, so getting this
+// wrong either bills zero (false negative) or feeds zero counters into
+// the billing helpers (false positive).
+// ==========================================================================
+
+func TestHasBillableUsage(t *testing.T) {
+	tests := []struct {
+		name  string
+		usage *SpeechToTextUsage
+		want  bool
+	}{
+		{"nil", nil, false},
+		{"empty", &SpeechToTextUsage{}, false},
+		{"empty duration", &SpeechToTextUsage{Type: "duration"}, false},
+		{"valid duration", &SpeechToTextUsage{Type: "duration", Seconds: 1}, true},
+		{"empty tokens", &SpeechToTextUsage{Type: "tokens"}, false},
+		{
+			// gpt-4o-transcribe — output_tokens always 0; input_tokens
+			// alone is enough to bill.
+			"tokens with input only",
+			&SpeechToTextUsage{Type: "tokens", InputTokens: 100},
+			true,
+		},
+		{
+			"tokens with output only",
+			&SpeechToTextUsage{Type: "tokens", OutputTokens: 50},
+			true,
+		},
+		{
+			"missing type, seconds populated",
+			&SpeechToTextUsage{Seconds: 30},
+			true,
+		},
+		{
+			"missing type, tokens populated",
+			&SpeechToTextUsage{InputTokens: 30},
+			true,
+		},
+		{
+			"missing type, all zero",
+			&SpeechToTextUsage{},
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasBillableUsage(tt.usage); got != tt.want {
+				t.Errorf("hasBillableUsage() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// ==========================================================================
+// usageMetricCounts
+//
+// The whitelist metrics lane. Must classify identically to the billing
+// dispatch — divergence is exactly the bug flagged in review. The
+// "agrees with isDurationUsage" test is the structural guarantee.
+// ==========================================================================
+
+func TestUsageMetricCounts(t *testing.T) {
+	tests := []struct {
+		name      string
+		usage     *SpeechToTextUsage
+		wantIn    int64
+		wantOut   int64
+	}{
+		{"nil", nil, 0, 0},
+		{
+			"duration mode reports seconds in input slot",
+			&SpeechToTextUsage{Type: "duration", Seconds: 207},
+			207, 0,
+		},
+		{
+			"tokens mode reports input/output tokens",
+			&SpeechToTextUsage{Type: "tokens", InputTokens: 149, OutputTokens: 0},
+			149, 0,
+		},
+		{
+			// Regression for the review finding: missing-type +
+			// seconds-only must report seconds, matching the billing
+			// dispatch instead of falling to the tokens shape (0, 0).
+			"missing type with seconds reports as duration",
+			&SpeechToTextUsage{Seconds: 30},
+			30, 0,
+		},
+		{
+			"missing type with tokens reports as tokens",
+			&SpeechToTextUsage{InputTokens: 50, OutputTokens: 10},
+			50, 10,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotIn, gotOut := usageMetricCounts(tt.usage)
+			if gotIn != tt.wantIn || gotOut != tt.wantOut {
+				t.Errorf("usageMetricCounts() = (%d, %d), want (%d, %d)",
+					gotIn, gotOut, tt.wantIn, tt.wantOut)
+			}
+		})
+	}
+}
+
+// TestUsageMetricCounts_AgreesWithIsDurationUsage is the structural guard
+// against the dispatch/metrics divergence that motivated PR #523's review
+// fix. For every input where isDurationUsage returns true, the metric
+// helper must populate the input slot with seconds (and zero the output
+// slot). For tokens-mode inputs it must populate the token counters.
+func TestUsageMetricCounts_AgreesWithIsDurationUsage(t *testing.T) {
+	usages := []*SpeechToTextUsage{
+		{Type: "duration", Seconds: 100},
+		{Type: "tokens", InputTokens: 100, OutputTokens: 0},
+		{Type: "tokens", InputTokens: 100, OutputTokens: 50},
+		{Seconds: 30},
+		{InputTokens: 50},
+		{Type: "future-mode", Seconds: 5},
+		{Type: "future-mode", InputTokens: 5},
+	}
+
+	for _, u := range usages {
+		gotIn, gotOut := usageMetricCounts(u)
+		if isDurationUsage(u) {
+			if gotIn != int64(u.Seconds) || gotOut != 0 {
+				t.Errorf("duration-classified %+v: metrics = (%d, %d), want (%d, 0)",
+					u, gotIn, gotOut, u.Seconds)
+			}
+		} else {
+			if gotIn != int64(u.InputTokens) || gotOut != int64(u.OutputTokens) {
+				t.Errorf("tokens-classified %+v: metrics = (%d, %d), want (%d, %d)",
+					u, gotIn, gotOut, u.InputTokens, u.OutputTokens)
+			}
+		}
+	}
+}
+
+// ==========================================================================
+// isSpeechToTextStream
+//
+// Driven entirely off the raw multipart request body — must not confuse
+// a stream=true form field with stray bytes inside a file part.
+// ==========================================================================
+
+func TestIsSpeechToTextStream(t *testing.T) {
+	ctrl := &Ctrl{logger: testLogger()}
+
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{
+			"stream true",
+			"--boundary\r\nContent-Disposition: form-data; name=\"stream\"\r\n\r\ntrue\r\n--boundary--",
+			true,
+		},
+		{
+			"no stream field",
+			"--boundary\r\nContent-Disposition: form-data; name=\"file\"\r\n\r\nbytes\r\n--boundary--",
+			false,
+		},
+		{
+			"stream false",
+			"--boundary\r\nContent-Disposition: form-data; name=\"stream\"\r\n\r\nfalse\r\n--boundary--",
+			false,
+		},
+		{
+			"empty body",
+			"",
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ctrl.isSpeechToTextStream([]byte(tt.body)); got != tt.want {
+				t.Errorf("isSpeechToTextStream() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/api/inference/internal/ctrl/speech_to_text_test.go
+++ b/api/inference/internal/ctrl/speech_to_text_test.go
@@ -1,9 +1,33 @@
 package ctrl
 
 import (
+	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 )
+
+// ==========================================================================
+// billSpeechToTextByTokens gate
+//
+// Until issue #530 lands a per-row billing-unit discriminator, the tokens
+// path is fail-closed behind cfg.AllowTokenBilledSpeechToText. Operators
+// who flip this flag accept the analytics-corruption risk knowingly.
+// ==========================================================================
+
+func TestBillSpeechToTextByTokens_GatedByDefault(t *testing.T) {
+	c := &Ctrl{allowTokenBilledSTT: false}
+	usage := &SpeechToTextUsage{Type: "tokens", InputTokens: 100}
+	err := c.billSpeechToTextByTokens(context.Background(), usage, "1", "1", "hash")
+	if err == nil {
+		t.Fatal("expected gated error when allowTokenBilledSTT is false, got nil")
+	}
+	// The error message must mention the issue so anyone hitting it in
+	// the wild can find the schema-discriminator work without digging.
+	if !strings.Contains(err.Error(), "#530") {
+		t.Errorf("error message must reference issue #530, got: %v", err)
+	}
+}
 
 // ==========================================================================
 // SpeechToTextUsage JSON decoding

--- a/api/inference/internal/ctrl/speech_to_text_test.go
+++ b/api/inference/internal/ctrl/speech_to_text_test.go
@@ -27,10 +27,71 @@ func TestSpeechToTextUsage_DecodeWhisperShape(t *testing.T) {
 		t.Errorf("Type = %q, want %q", u.Type, "duration")
 	}
 	if u.Seconds != 207 {
-		t.Errorf("Seconds = %d, want 207", u.Seconds)
+		t.Errorf("Seconds = %v, want 207", u.Seconds)
 	}
 	if u.InputTokens != 0 || u.OutputTokens != 0 {
 		t.Errorf("token counts = (%d, %d), want (0, 0)", u.InputTokens, u.OutputTokens)
+	}
+}
+
+// TestSpeechToTextUsage_DecodeFractionalSeconds is a regression guard.
+// The original struct typed Seconds as int, so Go's encoding/json rejected
+// any JSON number with a decimal point ("207.5" or even "207.0") and the
+// whole response failed to decode, sending the request down the word-count
+// fallback path — which silently billed 0 for whisper services (OutputPrice
+// is typically 0). Switching to float64 lets us accept either shape and
+// round at the bill site.
+func TestSpeechToTextUsage_DecodeFractionalSeconds(t *testing.T) {
+	tests := []struct {
+		name        string
+		raw         string
+		wantSeconds float64
+	}{
+		{"integer seconds", `{"type":"duration","seconds":207}`, 207},
+		{"fractional seconds", `{"type":"duration","seconds":207.5}`, 207.5},
+		// Python's json.dumps(207.0) emits this — Go's int field rejected it.
+		{"whole-number float", `{"type":"duration","seconds":207.0}`, 207},
+		{"sub-second", `{"type":"duration","seconds":0.4}`, 0.4},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var u SpeechToTextUsage
+			if err := json.Unmarshal([]byte(tt.raw), &u); err != nil {
+				t.Fatalf("unmarshal %s: %v", tt.raw, err)
+			}
+			if u.Seconds != tt.wantSeconds {
+				t.Errorf("Seconds = %v, want %v", u.Seconds, tt.wantSeconds)
+			}
+		})
+	}
+}
+
+// TestBillableSeconds covers the round-to-nearest-second helper used by
+// every billing/metric/limiting call site. Matches OpenAI's documented
+// "billed to the nearest second" semantic.
+func TestBillableSeconds(t *testing.T) {
+	tests := []struct {
+		name  string
+		usage *SpeechToTextUsage
+		want  int
+	}{
+		{"nil", nil, 0},
+		{"zero", &SpeechToTextUsage{Seconds: 0}, 0},
+		{"negative clamped to zero", &SpeechToTextUsage{Seconds: -5}, 0},
+		{"whole second", &SpeechToTextUsage{Seconds: 207}, 207},
+		{"rounds down", &SpeechToTextUsage{Seconds: 207.4}, 207},
+		{"rounds up", &SpeechToTextUsage{Seconds: 207.5}, 208},
+		{"sub-second rounds to zero", &SpeechToTextUsage{Seconds: 0.4}, 0},
+		{"sub-second rounds to one", &SpeechToTextUsage{Seconds: 0.5}, 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := billableSeconds(tt.usage); got != tt.want {
+				t.Errorf("billableSeconds(%+v) = %d, want %d", tt.usage, got, tt.want)
+			}
+		})
 	}
 }
 
@@ -291,9 +352,10 @@ func TestClassifyUsageForMetrics_AgreesWithIsDurationUsage(t *testing.T) {
 			t.Errorf("double-counted %+v: classified = (s=%d, in=%d, out=%d) populates both lanes", u, seconds, in, out)
 		}
 		if isDurationUsage(u) {
-			if seconds != int64(u.Seconds) || in != 0 || out != 0 {
+			wantSeconds := int64(billableSeconds(u))
+			if seconds != wantSeconds || in != 0 || out != 0 {
 				t.Errorf("duration-classified %+v: got (s=%d, in=%d, out=%d), want (s=%d, 0, 0)",
-					u, seconds, in, out, u.Seconds)
+					u, seconds, in, out, wantSeconds)
 			}
 		} else {
 			if in != int64(u.InputTokens) || out != int64(u.OutputTokens) || seconds != 0 {

--- a/api/inference/internal/ctrl/speech_to_text_test.go
+++ b/api/inference/internal/ctrl/speech_to_text_test.go
@@ -68,8 +68,11 @@ func TestSpeechToTextUsage_DecodeFractionalSeconds(t *testing.T) {
 }
 
 // TestBillableSeconds covers the round-to-nearest-second helper used by
-// every billing/metric/limiting call site. Matches OpenAI's documented
-// "billed to the nearest second" semantic.
+// every billing/metric/limiting call site. Round-to-nearest matches OpenAI's
+// "billed to the nearest second" semantic, with a 1-second floor for any
+// positive input — without that floor, a 0.4s clip would pass
+// hasBillableUsage (Seconds > 0) and then bill 0, recreating the zero-fee
+// bug class this PR exists to fix.
 func TestBillableSeconds(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -82,8 +85,11 @@ func TestBillableSeconds(t *testing.T) {
 		{"whole second", &SpeechToTextUsage{Seconds: 207}, 207},
 		{"rounds down", &SpeechToTextUsage{Seconds: 207.4}, 207},
 		{"rounds up", &SpeechToTextUsage{Seconds: 207.5}, 208},
-		{"sub-second rounds to zero", &SpeechToTextUsage{Seconds: 0.4}, 0},
-		{"sub-second rounds to one", &SpeechToTextUsage{Seconds: 0.5}, 1},
+		// Floor-positive — anything > 0 bills at least 1 second so the
+		// admission gate and the math agree on billability.
+		{"sub-half-second floored to 1", &SpeechToTextUsage{Seconds: 0.4}, 1},
+		{"barely above zero floored to 1", &SpeechToTextUsage{Seconds: 0.001}, 1},
+		{"half-second rounds to 1", &SpeechToTextUsage{Seconds: 0.5}, 1},
 	}
 
 	for _, tt := range tests {
@@ -92,6 +98,32 @@ func TestBillableSeconds(t *testing.T) {
 				t.Errorf("billableSeconds(%+v) = %d, want %d", tt.usage, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestBillableSeconds_NeverZeroWhenGateAdmitsDuration is the structural
+// guard against the regression class this PR exists to fix. The admission
+// gate (hasBillableUsage) and the math (billableSeconds) must agree on
+// billability: if the gate says "yes, this is billable" for a duration
+// usage, the math must produce a non-zero second count, or else we silently
+// write a fee=0 row through the accurate-billing path.
+//
+// The reviewer flagged 0 < seconds < 0.5 as a hole: the gate passes (any
+// Seconds > 0), but math.Round produces 0 without the floor.
+func TestBillableSeconds_NeverZeroWhenGateAdmitsDuration(t *testing.T) {
+	// Span the gap the reviewer flagged and the boundary just above zero.
+	subSecondInputs := []float64{0.001, 0.1, 0.4, 0.49, 0.5, 0.51, 0.9, 1.0}
+	for _, sec := range subSecondInputs {
+		u := &SpeechToTextUsage{Type: "duration", Seconds: sec}
+		if !hasBillableUsage(u) {
+			t.Fatalf("hasBillableUsage(seconds=%v) = false, want true (regression in admission gate)", sec)
+		}
+		if !isDurationUsage(u) {
+			t.Fatalf("isDurationUsage(seconds=%v) = false, want true", sec)
+		}
+		if got := billableSeconds(u); got <= 0 {
+			t.Errorf("billableSeconds(seconds=%v) = %d, want > 0 (gate admitted but math zero-bills)", sec, got)
+		}
 	}
 }
 

--- a/api/inference/internal/db/daily_stat.go
+++ b/api/inference/internal/db/daily_stat.go
@@ -3,6 +3,7 @@ package db
 import (
 	"fmt"
 
+	constant "github.com/0glabs/0g-serving-broker/inference/const"
 	"github.com/0glabs/0g-serving-broker/inference/model"
 	"gorm.io/gorm"
 )
@@ -31,7 +32,7 @@ func (d *DB) AccumulateAndDeleteRequests(requests []*model.Request, serviceType 
 	// speech-to-text writes seconds into input_count for whisper rows. Token
 	// accumulation would silently corrupt daily_stat.input_tokens, so skip
 	// it until #530 lands a dedicated audio_seconds column.
-	skipTokenAccumulation := serviceType == "speech-to-text"
+	skipTokenAccumulation := serviceType == constant.ServiceTypeSpeechToText
 
 	for _, req := range requests {
 		totalRequests++

--- a/api/inference/internal/db/daily_stat.go
+++ b/api/inference/internal/db/daily_stat.go
@@ -10,7 +10,16 @@ import (
 // AccumulateAndDeleteRequests atomically accumulates request stats into daily_stat
 // and deletes the requests in a single transaction. This prevents double-counting
 // that would occur if accumulation succeeds but deletion fails.
-func (d *DB) AccumulateAndDeleteRequests(requests []*model.Request) error {
+//
+// serviceType is the broker's configured service type ("chatbot",
+// "speech-to-text", etc.). For "speech-to-text", input_count/output_count
+// carry seconds (whisper) rather than tokens, so we skip the token-named
+// columns in daily_stat to keep AllTimeInputTokens / AllTimeOutputTokens
+// unit-coherent. total_requests is still bumped because the requests really
+// did happen. The whisper traffic loses long-term per-second analytics
+// history until issue #530 lands a per-unit column on daily_stat — that's
+// the accepted trade-off for the deployment window.
+func (d *DB) AccumulateAndDeleteRequests(requests []*model.Request, serviceType string) error {
 	if len(requests) == 0 {
 		return nil
 	}
@@ -19,10 +28,17 @@ func (d *DB) AccumulateAndDeleteRequests(requests []*model.Request) error {
 	var inputTokens, outputTokens int64
 	hashes := make([]string, 0, len(requests))
 
+	// speech-to-text writes seconds into input_count for whisper rows. Token
+	// accumulation would silently corrupt daily_stat.input_tokens, so skip
+	// it until #530 lands a dedicated audio_seconds column.
+	skipTokenAccumulation := serviceType == "speech-to-text"
+
 	for _, req := range requests {
 		totalRequests++
-		inputTokens += req.InputCount
-		outputTokens += req.OutputCount
+		if !skipTokenAccumulation {
+			inputTokens += req.InputCount
+			outputTokens += req.OutputCount
+		}
 		hashes = append(hashes, req.RequestHash)
 	}
 

--- a/api/inference/monitor/server.go
+++ b/api/inference/monitor/server.go
@@ -22,6 +22,10 @@ var (
 	InputTokensTotal *prometheus.CounterVec
 	// OutputTokensTotal tracks cumulative output token count, labeled by service_type.
 	OutputTokensTotal *prometheus.CounterVec
+	// AudioSecondsTotal tracks cumulative audio duration (in seconds) for
+	// duration-billed services like whisper. Kept separate from token counters
+	// so dashboards/alerts don't mix orders of magnitude across units.
+	AudioSecondsTotal *prometheus.CounterVec
 	// TokensPerSecond records per-request output token generation rate as a histogram, labeled by service_type.
 	TokensPerSecond *prometheus.HistogramVec
 
@@ -37,6 +41,8 @@ var (
 	WhitelistRequestsTotal  *prometheus.CounterVec
 	WhitelistInputTokensTotal  *prometheus.CounterVec
 	WhitelistOutputTokensTotal *prometheus.CounterVec
+	// WhitelistAudioSecondsTotal mirrors AudioSecondsTotal for whitelisted users.
+	WhitelistAudioSecondsTotal *prometheus.CounterVec
 )
 
 func PrometheusInit(serverName string) {
@@ -93,6 +99,15 @@ func PrometheusInit(serverName string) {
 		prometheus.CounterOpts{
 			Name:        "broker_output_tokens_total",
 			Help:        "Cumulative output token count.",
+			ConstLabels: prometheus.Labels{"server": serverName},
+		},
+		[]string{"service_type"},
+	)
+
+	AudioSecondsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name:        "broker_audio_seconds_total",
+			Help:        "Cumulative input audio duration in seconds for duration-billed services (e.g. whisper).",
 			ConstLabels: prometheus.Labels{"server": serverName},
 		},
 		[]string{"service_type"},
@@ -159,12 +174,22 @@ func PrometheusInit(serverName string) {
 		[]string{"service_type"},
 	)
 
+	WhitelistAudioSecondsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name:        "broker_whitelist_audio_seconds_total",
+			Help:        "Cumulative input audio duration in seconds from whitelisted (internal) users.",
+			ConstLabels: prometheus.Labels{"server": serverName},
+		},
+		[]string{"service_type"},
+	)
+
 	prometheus.MustRegister(RequestCount)
 	prometheus.MustRegister(ErrorCount)
 	prometheus.MustRegister(RequestDuration)
 	prometheus.MustRegister(UniqueUsersTotal)
 	prometheus.MustRegister(InputTokensTotal)
 	prometheus.MustRegister(OutputTokensTotal)
+	prometheus.MustRegister(AudioSecondsTotal)
 	prometheus.MustRegister(TokensPerSecond)
 	prometheus.MustRegister(AllTimeRequests)
 	prometheus.MustRegister(AllTimeInputTokens)
@@ -173,6 +198,7 @@ func PrometheusInit(serverName string) {
 	prometheus.MustRegister(WhitelistRequestsTotal)
 	prometheus.MustRegister(WhitelistInputTokensTotal)
 	prometheus.MustRegister(WhitelistOutputTokensTotal)
+	prometheus.MustRegister(WhitelistAudioSecondsTotal)
 }
 
 // StartDAUUpdater starts a background goroutine that periodically queries the database
@@ -284,6 +310,25 @@ func RecordTokens(serviceType string, inputTokens, outputTokens int64) {
 	if outputTokens > 0 {
 		OutputTokensTotal.WithLabelValues(serviceType).Add(float64(outputTokens))
 	}
+}
+
+// RecordAudioSeconds increments the cumulative audio-seconds counter for
+// duration-billed services. This is intentionally separate from RecordTokens —
+// accumulating seconds into broker_input_tokens_total would skew the metric
+// by orders of magnitude versus token-billed services on the same dashboard.
+func RecordAudioSeconds(serviceType string, seconds int64) {
+	if AudioSecondsTotal == nil || seconds <= 0 {
+		return
+	}
+	AudioSecondsTotal.WithLabelValues(serviceType).Add(float64(seconds))
+}
+
+// RecordWhitelistAudioSeconds mirrors RecordAudioSeconds for whitelisted users.
+func RecordWhitelistAudioSeconds(serviceType string, seconds int64) {
+	if WhitelistAudioSecondsTotal == nil || seconds <= 0 {
+		return
+	}
+	WhitelistAudioSecondsTotal.WithLabelValues(serviceType).Add(float64(seconds))
 }
 
 // RecordWhitelistRequest increments the whitelist request counter for the given service type.

--- a/api/inference/monitor/server_test.go
+++ b/api/inference/monitor/server_test.go
@@ -135,9 +135,28 @@ func setupTestMetrics(t *testing.T) *prometheus.Registry {
 		[]string{"service_type"},
 	)
 
+	AudioSecondsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name:        "broker_audio_seconds_total",
+			Help:        "Audio seconds.",
+			ConstLabels: prometheus.Labels{"server": serverName},
+		},
+		[]string{"service_type"},
+	)
+
+	WhitelistAudioSecondsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name:        "broker_whitelist_audio_seconds_total",
+			Help:        "Whitelist audio seconds.",
+			ConstLabels: prometheus.Labels{"server": serverName},
+		},
+		[]string{"service_type"},
+	)
+
 	registry.MustRegister(InputTokensTotal, OutputTokensTotal, TokensPerSecond,
 		RequestCount, ErrorCount, RequestDuration,
-		WhitelistRequestsTotal, WhitelistInputTokensTotal, WhitelistOutputTokensTotal)
+		WhitelistRequestsTotal, WhitelistInputTokensTotal, WhitelistOutputTokensTotal,
+		AudioSecondsTotal, WhitelistAudioSecondsTotal)
 
 	return registry
 }
@@ -268,6 +287,76 @@ func TestRecordTokensNilMetrics(t *testing.T) {
 
 	// Should not panic
 	RecordTokens("chatbot", 100, 50)
+}
+
+// TestRecordAudioSeconds verifies the duration counter increments for positive
+// values and no-ops for non-positive values. The counter is intentionally
+// separate from RecordTokens so dashboards don't mix seconds and tokens on the
+// same axis — that's the bug PR #523 review caught.
+func TestRecordAudioSeconds(t *testing.T) {
+	setupTestMetrics(t)
+
+	tests := []struct {
+		name        string
+		serviceType string
+		seconds     int64
+		want        float64
+	}{
+		{"positive seconds", "speech_to_text", 207, 207},
+		{"zero seconds is no-op", "speech_to_text", 0, 0},
+		{"negative seconds is no-op", "speech_to_text", -5, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			before := getCounterValue(AudioSecondsTotal, tt.serviceType)
+			RecordAudioSeconds(tt.serviceType, tt.seconds)
+			delta := getCounterValue(AudioSecondsTotal, tt.serviceType) - before
+			if delta != tt.want {
+				t.Errorf("audio seconds delta = %v, want %v", delta, tt.want)
+			}
+		})
+	}
+}
+
+// TestRecordAudioSecondsNilMetrics verifies the helper is a safe no-op when
+// the counter hasn't been initialised (e.g. tests that don't call PrometheusInit).
+func TestRecordAudioSecondsNilMetrics(t *testing.T) {
+	saved := AudioSecondsTotal
+	AudioSecondsTotal = nil
+	defer func() { AudioSecondsTotal = saved }()
+
+	// Should not panic
+	RecordAudioSeconds("speech_to_text", 100)
+}
+
+// TestRecordWhitelistAudioSeconds mirrors TestRecordAudioSeconds for the
+// whitelist counter family.
+func TestRecordWhitelistAudioSeconds(t *testing.T) {
+	setupTestMetrics(t)
+
+	before := getCounterValue(WhitelistAudioSecondsTotal, "speech_to_text")
+	RecordWhitelistAudioSeconds("speech_to_text", 207)
+	if delta := getCounterValue(WhitelistAudioSecondsTotal, "speech_to_text") - before; delta != 207 {
+		t.Errorf("whitelist audio seconds delta = %v, want 207", delta)
+	}
+
+	// Zero/negative no-op
+	before = getCounterValue(WhitelistAudioSecondsTotal, "speech_to_text")
+	RecordWhitelistAudioSeconds("speech_to_text", 0)
+	RecordWhitelistAudioSeconds("speech_to_text", -10)
+	if delta := getCounterValue(WhitelistAudioSecondsTotal, "speech_to_text") - before; delta != 0 {
+		t.Errorf("whitelist audio seconds should not increment on non-positive, got delta=%v", delta)
+	}
+}
+
+func TestRecordWhitelistAudioSecondsNilMetrics(t *testing.T) {
+	saved := WhitelistAudioSecondsTotal
+	WhitelistAudioSecondsTotal = nil
+	defer func() { WhitelistAudioSecondsTotal = saved }()
+
+	// Should not panic
+	RecordWhitelistAudioSeconds("speech_to_text", 100)
 }
 
 // TestRecordTPS verifies TPS histogram recording for various inputs.


### PR DESCRIPTION
## Summary

Fixes a zero-fee bug on the speech-to-text path and refactors the billing pipeline to handle the two distinct `usage` shapes upstream providers emit:

- **Whisper family** (`whisper-1`, `whisper-large-v3`) — `{"usage":{"type":"duration","seconds":N}}`
- **gpt-4o-transcribe family** (`gpt-4o-transcribe`, `gpt-4o-mini-transcribe`) — `{"usage":{"type":"tokens","input_tokens":N,"output_tokens":0,...}}`

The original `SpeechToTextUsage` struct only had token fields, so whisper responses decoded to all-zero counters and silently billed `0` through the "accurate usage" code path. Anything routed at a whisper-style provider was effectively free.

## The bug, concretely

```json
// whisper response
{ "text": "...", "usage": { "type": "duration", "seconds": 207 } }
```

`SpeechToTextUsage` had no `Seconds` field, so:
- `usage != nil` admission gate passed
- `usage.InputTokens == 0`, `usage.OutputTokens == 0` (zero-value defaults)
- `fee = InputPrice × 0 + OutputPrice × 0 = 0`
- 207 seconds of transcription billed at **0**

## Fix

### Billing dispatch
- Add `Seconds float64` field to `SpeechToTextUsage`. `float64` (not `int`) because Go's `encoding/json` refuses any JSON number with a decimal point — including `207.0` — into an `int` field, which would re-introduce the zero-fee bug for any provider that emits floats.
- `billableSeconds()` helper rounds to nearest int with a **1-second floor for any positive input**, so a sub-half-second clip can't pass the admission gate and then collapse to zero in the math.
- Single classifier `isDurationUsage()` decides which lane an arrival belongs in (used by billing, whitelist metrics, and any future consumer — no divergence).
- `hasBillableUsage()` replaces the bare `usage != nil` admission gate so empty `{}` or zero-counter responses fall through to the word-count fallback instead of charging 0.
- `updateSpeechToTextWithUsage()` dispatches to one of:
  - **`billSpeechToTextByDuration`** — `fee = seconds × InputPrice`; `OutputPrice` ignored (whisper has no generation-side cost).
  - **`billSpeechToTextByTokens`** — gate-check + delegation to `billSpeechToTextByTokensCore`. Core runs `fee = input_tokens × InputPrice + output_tokens × OutputPrice`. For gpt-4o-transcribe, `output_tokens` is always `0` upstream so this collapses to input-only billing. **Gated** — see below.
- Pure fee arithmetic extracted to `calcDurationFee` / `calcTokenFees`, leaving the bill functions as thin glue (classifier → math → DB + monitor + limiter).

### Routing table

| Upstream `usage` | Route |
|---|---|
| `{type:"duration", seconds:>0}` | duration |
| `{type:"tokens", input/output tokens:>0}` | tokens (explicit type wins even if `seconds` also present) |
| `{seconds:>0}` (no type field) | duration |
| `{input_tokens:>0}` (no type field) | tokens |
| `{}` / all zeros / nil | word-count fallback |

### Token-billed STT is gated — issue #530

Two layers of defense protect the requests/daily_stat schema from unit conflation until #530 lands a per-row billing-unit discriminator.

**Layer 1 — startup gate (primary)**: `config.loadConfig` refuses to boot the broker when `service.type=="speech-to-text"` is registered against a known token-billed model (`gpt-4o-transcribe` / `gpt-4o-mini-transcribe`) with `cfg.AllowTokenBilledSpeechToText` false. The broker fails to start with an explicit error naming #530 and the config flag the operator must flip. This is the honest semantics of the "allow" flag: turning it off prevents the broker from running the configuration at all, not just emitting a runtime warning that's easy to miss in production logs.

`tokenBilledSTTCanonicalName` scans `ModelType`, `UpstreamModel`, `CanonicalID`, and `ModelAliases`, stripping any `org/` namespace prefix so `openai/gpt-4o-transcribe` matches the bare canonical name. The known-token-billed list is exhaustive (not a substring pattern) so unrelated `gpt-4o` models don't trip the gate accidentally.

**Layer 2 — runtime gate (defense in depth)**: `billSpeechToTextByTokens` still returns `ErrTokenBilledSpeechToTextGated` when the flag is false. With the startup gate in place this only fires for the edge case where an *unknown* model (not in the whitelist) emits a token-shape response. Rather than silently writing tokens to `requests.input_count` against an unprepared operator, the handler routes the sentinel to `billGatedTokenSTT`, which bills against the **real upstream usage** (the response already shipped — refusing to bill would be free GPU) and logs a loud warning naming #530. This is honest about the constraint: an operator deliberately running a non-whitelisted model that happens to emit tokens gets correct billing plus visibility.

### `daily_stat` STT skip — issue #530

Settlement (`AccumulateAndDeleteRequests`) rolls `requests.input_count` into `daily_stat.input_tokens`, which feeds the `AllTimeInputTokens` Prometheus gauge and analytics queries. Whisper traffic would silently pollute both with seconds values mixed into a token-named column, and `daily_stat` is a long-term archive (settled rows are deleted from `requests`, so the pollution would be irreversible).

The function now takes a `serviceType` parameter. For `constant.ServiceTypeSpeechToText` it still deletes the rows and bumps `daily_stat.total_requests`, but skips the `input_tokens` / `output_tokens` accumulation. The gauges stay unit-coherent (token-billed services only). Whisper traffic keeps its real-time visibility via the new `broker_audio_seconds_total` Prometheus counter.

Cost: whisper loses long-term per-second analytics history until #530 lands a dedicated `audio_seconds` column on `daily_stat`. Tracked as an acceptance criterion on that issue alongside the schema work.

### Prometheus metrics
Accumulating seconds and tokens into the same `broker_input_tokens_total` counter would skew dashboards by 1–2 orders of magnitude on the same `service_type` label depending on which upstream model a provider proxies. Two new counters keep the units cleanly separated:

- `broker_audio_seconds_total{service_type}` for duration-billed services
- `broker_whitelist_audio_seconds_total{service_type}` for the whitelist mirror

The metric lane is routed through the same `isDurationUsage` classifier as the billing dispatch so they can never diverge.

**TPS for the token-STT path**: `billSpeechToTextByTokensCore` calls `RecordTPSFromContext` with `output_tokens`. For gpt-4o-transcribe that's always 0 upstream, but `RecordTPSFromContext` already early-returns on `outputTokens <= 0` so no observation is recorded — the histogram stays empty for the current generation of STT models, and the call stays in place for forward-compat with any future token-billed STT model that emits non-zero outputs.

**Known residual pollution**: `updateSpeechToTextFallback` still records its estimated tokens into `broker_output_tokens_total{service_type="speech_to_text"}` for the JSON-parse-failure and mismatched-shape paths (the gate path no longer goes through this code). Tracked as a #530 acceptance criterion alongside the schema work.

### Operator-facing warning
`updateSpeechToTextWithUsage` docstring now explicitly flags that `InputPrice` is semantically overloaded across speech-to-text services — whisper interprets it as **price-per-second**, gpt-4o-transcribe as **price-per-token**. A future on-chain `BillingUnit` field would let the dispatch reject mismatched configurations; tracked in #530 alongside the schema discriminator work. The config flag carries a `TODO(#530)` noting it should derive from per-service config once that exists.

### Behavioural notes
- Duration mode intentionally skips `RecordTPSFromContext`: whisper has no tokens/sec concept (transcript is delivered as one shot, not a generation stream), and a seconds/sec metric would pollute the chatbot TPS dashboard.
- TPM limiter is fed whatever unit was actually billed (seconds for whisper, tokens for gpt-4o-transcribe). `consumeSpeechToTextLimiter` is now a method on `*Ctrl` and logs at debug level on each "limiter missing" early-return path so accidental rate-limit disablement is discoverable.
- Streaming handler explicitly retains its `streamErr` swallow behaviour (`_ = streamErr` + comment): if the upstream read or client write failed mid-stream, the user has whatever bytes shipped — bill for the partial usage rather than handing them free output.

## Tests

New `api/inference/internal/ctrl/speech_to_text_test.go` covers the pure functions that drive billing classification — the bug class that landed this PR deserves regression coverage:

- JSON decode round-trip for integer / fractional / whole-number-float / sub-second `seconds` JSON shapes (guards against struct-tag drift re-introducing the zero-fee bug)
- `TestBillableSeconds` (8 cases) including the 1-second floor for sub-half-second clips
- `TestBillableSeconds_NeverZeroWhenGateAdmitsDuration` — structural invariant: if `hasBillableUsage` admits, `billableSeconds` must be `> 0`. Spans `0.001 … 1.0`.
- `isDurationUsage` table covering every dispatch rule including the no-type+seconds regression case and the explicit-type-wins case
- `hasBillableUsage` admission gate
- `classifyUsageForMetrics` direct table **plus** a structural agreement test asserting the metrics lane never diverges from `isDurationUsage` — the exact divergence flagged in review
- `calcDurationFee` / `calcTokenFees` with realistic 18-decimal fixed-point price magnitudes and bad-price error paths
- `TestBillSpeechToTextByTokens_GatedByDefault` — runtime gate defaults closed; assertion uses `errors.Is(err, ErrTokenBilledSpeechToTextGated)` rather than substring matching
- `isSpeechToTextStream` multipart parsing

New `api/inference/config/config_test.go` startup gate tests:
- `TestLoadConfig_TokenBilledSTT_BlockedByDefault` — bare, namespaced, and `gpt-4o-mini-transcribe` variants all fail to boot; error references #530 and the flag name.
- `TestLoadConfig_TokenBilledSTT_AllowedWhenFlagSet` — happy path with the flag flipped.
- `TestLoadConfig_WhisperSTT_NeverGated` — whisper variants boot cleanly regardless of flag.
- `TestLoadConfig_TokenBilledModel_OutsideSTTService_NotGated` — gate scoped to `service.type=="speech-to-text"`, doesn't trip on a chatbot with a transcribe-shaped model name.
- `TestTokenBilledSTTCanonicalName` — helper covers ModelType, namespaced, CanonicalID-only, alias-only, and exact-name (no substring) matching.

`monitor/server_test.go` extended:
- `setupTestMetrics` now registers the two new audio-seconds counters
- New `RecordAudioSeconds` / `RecordWhitelistAudioSeconds` tests: positive increment, zero/negative no-op, nil-guard safety

The stateful helpers (`billSpeechToTextByDuration`, `billSpeechToTextByTokensCore`, `billGatedTokenSTT`, `AccumulateAndDeleteRequests`, the HTTP handlers) aren't unit-tested here — `Ctrl.db` is a concrete `*db.DB` rather than an interface, so mocking would need either a cross-cutting interface refactor or an in-memory MySQL. The arithmetic those helpers compose is fully covered by `calcDurationFee` / `calcTokenFees`; the DB calls themselves stay covered by integration tests.

## Test plan

- [ ] Unit tests: `cd api && go test ./inference/...` — all green
- [ ] Build: `cd api && go build ./...`
- [ ] Manual: send whisper-large-v3 transcription, confirm `broker_audio_seconds_total{service_type="speech_to_text"}` increments and the DB row records `input_count = seconds`, `total_fee = seconds × InputPrice`
- [ ] Manual: settle a batch of whisper requests, confirm `daily_stat.total_requests` increments but `daily_stat.input_tokens` / `output_tokens` are unchanged; `AllTimeInputTokens` Prometheus gauge stays unit-coherent (token-billed services only)
- [ ] Manual: register a broker with `service.model: "gpt-4o-transcribe"` and `cfg.AllowTokenBilledSpeechToText` unset → broker refuses to start with an error naming #530 and the flag name
- [ ] Manual: flip `cfg.AllowTokenBilledSpeechToText: true` and re-deploy → broker boots, gpt-4o-transcribe request succeeds, `broker_input_tokens_total` increments, `output_tokens == 0` doesn't break billing

## Follow-ups

- #530 — per-row billing-unit discriminator on `requests` and `daily_stat`. Blocking acceptance criteria for removing:
  - the `AllowTokenBilledSpeechToText` config gate (both startup + runtime layers)
  - the `ErrTokenBilledSpeechToTextGated` sentinel + `billGatedTokenSTT` helper + handler-path wiring
  - the STT skip in `AccumulateAndDeleteRequests`
  - the residual `broker_output_tokens_total` pollution from `updateSpeechToTextFallback`

https://claude.ai/code/session_01BvxpYBbzFCtivXhmLVrGGu

Closes #524
