### PR TITLE
fix(inference): log missing stream terminator at WARN, not ERROR

### DIFF
--- a/api/inference/internal/ctrl/chatbot.go
+++ b/api/inference/internal/ctrl/chatbot.go
@@ -856,9 +856,13 @@ func (c *Ctrl) processOpenAIStream(ctx context.Context, lines [][]byte, outputPr
 		*output += chunkOutput
 	}
 
-	// No [DONE] marker — the stream was truncated/dropped or the upstream omitted
-	// it. The client already received the accumulated output, so bill it rather
-	// than serving free, logging loudly so the missing terminator is diagnosable.
-	c.logger.Errorf("OpenAI stream ended without a [DONE] marker for request %s; finalizing on accumulated usage/output", requestHash)
+	// No [DONE] marker — the stream was truncated/dropped, or the upstream simply
+	// never emits one. Some OpenAI-"compatible" gateways (e.g. MiniMax) end the
+	// stream on EOF after the final usage chunk and never send `data: [DONE]`, so
+	// this fires on every otherwise-successful request from such an upstream. The
+	// client already received the accumulated output and we finalize billing on it
+	// below, so this is not an error — log at WARN to stay diagnosable without
+	// drowning genuine errors (e.g. upstream 5xx) in the error stream.
+	c.logger.Warnf("OpenAI stream ended without a [DONE] marker for request %s; finalizing on accumulated usage/output", requestHash)
 	return c.finalizeChatStream(ctx, *output, *usage, outputPrice, requestHash, isWhitelisted)
 }

--- a/api/inference/internal/ctrl/chatbot_litellm.go
+++ b/api/inference/internal/ctrl/chatbot_litellm.go
@@ -240,13 +240,15 @@ func (c *Ctrl) processLiteLLMStream(ctx context.Context, lines [][]byte, outputP
 		}
 	}
 
-	// No message_stop event — the stream was truncated/dropped or an
+	// No message_stop event — the stream was truncated/dropped, or an
 	// OpenAI-compatible shim omitted the terminal Anthropic event. The client
-	// already received the accumulated output, so bill it rather than serving
-	// free, logging loudly. haveUsage may be true from message_start/message_delta.
+	// already received the accumulated output and we finalize billing on it below,
+	// so this is not an error — log at WARN to stay diagnosable without drowning
+	// genuine errors in the error stream. haveUsage may be true from
+	// message_start/message_delta.
 	if haveUsage {
 		*usage = acc.toUsage()
 	}
-	c.logger.Errorf("LiteLLM stream ended without a message_stop event for request %s; finalizing on accumulated usage/output (haveUsage=%t)", requestHash, haveUsage)
+	c.logger.Warnf("LiteLLM stream ended without a message_stop event for request %s; finalizing on accumulated usage/output (haveUsage=%t)", requestHash, haveUsage)
 	return c.finalizeChatStream(ctx, *output, *usage, outputPrice, requestHash, isWhitelisted)
 }


### PR DESCRIPTION
## Problem

The streaming finalizers fall back to billing on accumulated usage/output when a stream ends **without** its terminal sentinel (OpenAI `data: [DONE]` / Anthropic `message_stop`). That fallback is correct — the client already received the full stream and we finalize billing on it — but it was logged at **ERROR**.

The trouble: some OpenAI-"compatible" upstreams **never** emit `[DONE]`. **MiniMax** (`MiniMax-M3`, newly onboarded as `26-minimax`) ends its SSE stream on EOF right after the final usage chunk and never sends `data: [DONE]`. I verified this directly against `api.minimax.io/v1` for both `finish_reason=stop` and `finish_reason=length` — no sentinel in either case (plain `\n\n` separators, no `[DONE]` line).

As a result this path fired on **every otherwise-successful streaming request** to MiniMax — ~100 ERROR lines per provider per run — drowning genuine errors (e.g. upstream 5xx) in the error stream. The fallback billing itself works fine (responses were signed with `ZG-Res-Key` and settled normally).

## Change

Downgrade the missing-terminator log from `Errorf` → `Warnf` in **both** stream paths:
- `processOpenAIStream` (missing `data: [DONE]`) — `chatbot.go`
- `processLiteLLMStream` (missing `message_stop`) — `chatbot_litellm.go`

Comments updated to explain that a clean EOF without the sentinel is an expected, already-handled condition for some upstreams.

**No behavioral change** to billing / signing / finalize — log level only.

## Test

- `go build ./...` passes.
- No tests assert on these log strings.