### PR TITLE
Handle non-JSON speech-to-text responses with subtitle duration recovery

### DIFF
--- a/api/inference/internal/ctrl/speech_to_text.go
+++ b/api/inference/internal/ctrl/speech_to_text.go
@@ -67,18 +67,32 @@ type SpeechToTextUsage struct {
 	Seconds           float64                  `json:"seconds"`
 }
 
+// maxBillableSeconds caps a single transcription's billable duration at the
+// same 99 hours the subtitle-recovery lane enforces via its two-digit hours
+// cap (parseSubtitleTimestamp). No real transcription approaches 100 hours;
+// without a cap, one anomalous duration value — a provider-reported
+// usage.seconds, a verbose_json top-level duration, either malicious or
+// corrupted — could bill a fee large enough to drain the user's whole
+// locked balance. Centralized here so every duration source is covered.
+const maxBillableSeconds = 99 * 3600
+
 // billableSeconds returns the integer second count used for billing, metrics,
-// and rate limiting. Rounds to the nearest whole second, then applies a
-// 1-second floor for any positive input so a sub-half-second clip
-// (e.g. 0.4s) cannot pass hasBillableUsage and then collapse to a 0-fee row
-// — that would be the same zero-billing class of bug this PR exists to fix.
-// Non-positive inputs (zero or negative) return 0 so the caller can decline
-// to bill at all.
+// and rate limiting. Clamps to maxBillableSeconds, rounds to the nearest
+// whole second, then applies a 1-second floor for any positive input so a
+// sub-half-second clip (e.g. 0.4s) cannot pass hasBillableUsage and then
+// collapse to a 0-fee row — that would be the same zero-billing class of bug
+// this PR exists to fix. Non-positive inputs (zero or negative) return 0 so
+// the caller can decline to bill at all.
+//
+// The clamp also removes a float→int edge: converting a float64 beyond the
+// int64 range (e.g. Seconds=1e308) is platform-dependent in Go — on amd64
+// it produces a negative value, which the 1-second floor would then turn
+// into a near-free request.
 func billableSeconds(u *SpeechToTextUsage) int {
 	if u == nil || u.Seconds <= 0 {
 		return 0
 	}
-	rounded := int(math.Round(u.Seconds))
+	rounded := int(math.Round(math.Min(u.Seconds, maxBillableSeconds)))
 	if rounded < 1 {
 		return 1
 	}

--- a/api/inference/internal/ctrl/speech_to_text.go
+++ b/api/inference/internal/ctrl/speech_to_text.go
@@ -246,6 +246,12 @@ func (c *Ctrl) handleNonStreamingSpeechToText(ctx *gin.Context, resp *http.Respo
 			// Plain text carries no timing signal — fall back to estimated billing
 			return c.updateSpeechToTextFallback(ctx, reqModel, string(decompressedBody))
 		}
+		// Audit trail: the charge below is synthesized from a heuristic parse
+		// of a non-JSON body, not from a provider usage block. Logged at info
+		// so operators can answer billing disputes and spot providers that
+		// emit non-JSON shapes (the signal the parse-failure Warnf carried
+		// before recovery existed).
+		c.logger.Infof("recovered speech-to-text duration from subtitle timeline: %.3fs request=%s", seconds, reqModel.RequestHash)
 		transcriptionResp.Usage = &SpeechToTextUsage{Type: "duration", Seconds: seconds}
 	}
 
@@ -379,6 +385,10 @@ func (c *Ctrl) handleStreamingSpeechToText(ctx *gin.Context, resp *http.Response
 	// which bills OutputPrice × estimate — 0 for whisper services.
 	if !hasBillableUsage(usage) {
 		if seconds, ok := subtitleDurationSeconds(rawBody.String()); ok {
+			// Audit trail: charge synthesized from a heuristic parse of the
+			// captured stream body, not from a provider usage chunk — see
+			// the non-streaming recovery site for rationale.
+			c.logger.Infof("recovered streaming speech-to-text duration from subtitle timeline: %.3fs request=%s", seconds, reqModel.RequestHash)
 			usage = &SpeechToTextUsage{Type: "duration", Seconds: seconds}
 		}
 	}

--- a/api/inference/internal/ctrl/speech_to_text.go
+++ b/api/inference/internal/ctrl/speech_to_text.go
@@ -372,6 +372,17 @@ func (c *Ctrl) handleStreamingSpeechToText(ctx *gin.Context, resp *http.Response
 	// handleBrokerError was already called inside the loop for visibility.
 	_ = streamErr
 
+	// Symmetry with the non-streaming path: a non-conforming provider that
+	// accepts stream=true for response_format=srt/vtt delivers subtitle
+	// lines that never carry a usage chunk. Recover the duration from the
+	// captured stream body rather than falling to the word-count fallback,
+	// which bills OutputPrice × estimate — 0 for whisper services.
+	if !hasBillableUsage(usage) {
+		if seconds, ok := subtitleDurationSeconds(rawBody.String()); ok {
+			usage = &SpeechToTextUsage{Type: "duration", Seconds: seconds}
+		}
+	}
+
 	// Skip billing for whitelisted users, but record whitelist traffic metrics
 	if reqModel.IsWhitelisted {
 		recordWhitelistUsageMetrics(usage, c.metricModel(ctx))
@@ -739,9 +750,14 @@ func subtitleDurationSeconds(body string) (float64, bool) {
 }
 
 // parseSubtitleTimestamp parses an SRT ("HH:MM:SS,mmm") or WebVTT
-// ("HH:MM:SS.mmm", "MM:SS.mmm") timestamp into seconds. Rejects malformed
-// or non-finite components so a garbage line containing "-->" cannot
-// produce a bogus charge.
+// ("HH:MM:SS.mmm", "MM:SS.mmm") timestamp into seconds.
+//
+// Components must be plain decimal digits, with a fractional part permitted
+// only on the seconds (last) component, and every component except the hours
+// of an HH:MM:SS form must be < 60 — per the SRT/WebVTT grammars. This is
+// deliberately stricter than strconv.ParseFloat alone, which accepts signs
+// and scientific notation: a garbage line containing "-->" must not parse
+// "12:1e9" into a billion-second charge.
 func parseSubtitleTimestamp(ts string) (float64, bool) {
 	ts = strings.ReplaceAll(ts, ",", ".")
 	parts := strings.Split(ts, ":")
@@ -749,14 +765,53 @@ func parseSubtitleTimestamp(ts string) (float64, bool) {
 		return 0, false
 	}
 	total := 0.0
-	for _, p := range parts {
+	for i, p := range parts {
+		if !isSubtitleComponent(p, i == len(parts)-1) {
+			return 0, false
+		}
 		v, err := strconv.ParseFloat(p, 64)
-		if err != nil || v < 0 || math.IsInf(v, 0) || math.IsNaN(v) {
+		if err != nil {
+			return 0, false
+		}
+		// Only the hours of an HH:MM:SS form may reach 60; the leading
+		// component of the short MM:SS form is minutes and stays < 60.
+		// Hours are capped at two digits (the SRT grammar's "HH"): no real
+		// transcription approaches 100 hours, and an uncapped component
+		// would let one corrupted cue line ("999999999:00:00,000") bill a
+		// fee large enough to drain the user's whole locked balance.
+		isHours := i == 0 && len(parts) == 3
+		if isHours && v > 99 {
+			return 0, false
+		}
+		if !isHours && v >= 60 {
 			return 0, false
 		}
 		total = total*60 + v
 	}
 	return total, total > 0
+}
+
+// isSubtitleComponent reports whether p is a well-formed timestamp component:
+// decimal digits only, with one interior fractional dot permitted when
+// allowFraction is set (the seconds component).
+func isSubtitleComponent(p string, allowFraction bool) bool {
+	if p == "" {
+		return false
+	}
+	seenDot := false
+	for i, r := range p {
+		if r == '.' {
+			if !allowFraction || seenDot || i == 0 || i == len(p)-1 {
+				return false
+			}
+			seenDot = true
+			continue
+		}
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // isSpeechToTextStream checks if the request body contains stream parameter

--- a/api/inference/internal/ctrl/speech_to_text.go
+++ b/api/inference/internal/ctrl/speech_to_text.go
@@ -717,20 +717,28 @@ func (c *Ctrl) updateSpeechToTextFallback(ctx context.Context, reqModel model.Re
 }
 
 // subtitleDurationSeconds recovers the audio duration from an SRT or WebVTT
-// transcript (response_format=srt/vtt) by taking the end timestamp of the
-// last cue line ("HH:MM:SS,mmm --> HH:MM:SS,mmm"). The last cue's end time
-// is a tight lower bound on the audio length — whisper emits cues covering
-// the full transcribed span — so it is the per-second billing source when
-// the provider returns subtitles instead of JSON.
+// transcript (response_format=srt/vtt) by taking the largest cue end
+// timestamp. Only full cue lines count — "T1 --> T2 [settings]" with a
+// well-formed timestamp on BOTH sides of the arrow — so prose or JSON delta
+// text that merely mentions a "T1 --> T2" range inside surrounding words
+// cannot synthesize a charge. Taking the max (rather than the last
+// arrow-bearing line) means one trailing unparseable "-->" line cannot void
+// an earlier valid cue and re-open the 0-bill, and a truncated or reordered
+// tail stays harmless.
 //
-// Returns ok=false when the body contains no parseable cue line (e.g.
+// Returns ok=false when the body contains no billable cue (e.g.
 // response_format=text), in which case the caller falls back to the
 // word-count estimator.
 func subtitleDurationSeconds(body string) (float64, bool) {
-	var lastEnd string
+	var maxEnd float64
 	for _, line := range strings.Split(body, "\n") {
 		idx := strings.Index(line, "-->")
 		if idx < 0 {
+			continue
+		}
+		// The start side must itself be a timestamp (zero is fine — the
+		// first cue of a real transcript starts at 00:00:00,000).
+		if _, ok := parseSubtitleTimestamp(strings.TrimSpace(line[:idx])); !ok {
 			continue
 		}
 		end := strings.TrimSpace(line[idx+len("-->"):])
@@ -739,18 +747,18 @@ func subtitleDurationSeconds(body string) (float64, bool) {
 		if sp := strings.IndexAny(end, " \t"); sp >= 0 {
 			end = end[:sp]
 		}
-		if end != "" {
-			lastEnd = end
+		if secs, ok := parseSubtitleTimestamp(end); ok && secs > maxEnd {
+			maxEnd = secs
 		}
 	}
-	if lastEnd == "" {
-		return 0, false
-	}
-	return parseSubtitleTimestamp(lastEnd)
+	return maxEnd, maxEnd > 0
 }
 
 // parseSubtitleTimestamp parses an SRT ("HH:MM:SS,mmm") or WebVTT
-// ("HH:MM:SS.mmm", "MM:SS.mmm") timestamp into seconds.
+// ("HH:MM:SS.mmm", "MM:SS.mmm") timestamp into seconds. ok reports
+// well-formedness only — a zero timestamp is ok=true with seconds=0, since
+// cue START times legitimately begin at 00:00:00,000; billability (> 0) is
+// the caller's concern.
 //
 // Components must be plain decimal digits, with a fractional part permitted
 // only on the seconds (last) component, and every component except the hours
@@ -788,7 +796,7 @@ func parseSubtitleTimestamp(ts string) (float64, bool) {
 		}
 		total = total*60 + v
 	}
-	return total, total > 0
+	return total, true
 }
 
 // isSubtitleComponent reports whether p is a well-formed timestamp component:

--- a/api/inference/internal/ctrl/speech_to_text.go
+++ b/api/inference/internal/ctrl/speech_to_text.go
@@ -11,6 +11,8 @@ import (
 	"io"
 	"math"
 	"net/http"
+	"strconv"
+	"strings"
 
 	"github.com/andybalholm/brotli"
 	"github.com/gin-gonic/gin"
@@ -131,10 +133,32 @@ type SpeechToTextTokenDetails struct {
 	AudioTokens int `json:"audio_tokens"`
 }
 
-// SpeechToTextResponse represents the transcription response
+// SpeechToTextResponse represents the transcription response.
+//
+// Duration is the top-level audio length in seconds that verbose_json
+// responses (whisper family) carry alongside text/segments. Some providers
+// emit verbose_json without a usage block at all, so Duration is the only
+// billing signal in that shape — see effectiveUsage.
 type SpeechToTextResponse struct {
-	Text  string             `json:"text"`
-	Usage *SpeechToTextUsage `json:"usage,omitempty"`
+	Text     string             `json:"text"`
+	Duration float64            `json:"duration"`
+	Usage    *SpeechToTextUsage `json:"usage,omitempty"`
+}
+
+// effectiveUsage returns the usage block to bill against. When the response
+// carries no billable usage but verbose_json's top-level duration field is
+// populated, synthesizes a duration usage from it so the request doesn't
+// fall through to the word-count fallback — which bills
+// OutputPrice × estimate, i.e. 0 for whisper services where the per-second
+// price lives in InputPrice.
+func effectiveUsage(resp *SpeechToTextResponse) *SpeechToTextUsage {
+	if hasBillableUsage(resp.Usage) {
+		return resp.Usage
+	}
+	if resp.Duration > 0 {
+		return &SpeechToTextUsage{Type: "duration", Seconds: resp.Duration}
+	}
+	return resp.Usage
 }
 
 // SpeechToTextStreamChunk represents a streaming transcription chunk
@@ -209,11 +233,26 @@ func (c *Ctrl) handleNonStreamingSpeechToText(ctx *gin.Context, resp *http.Respo
 	// Parse response to extract usage
 	var transcriptionResp SpeechToTextResponse
 	if err := json.Unmarshal(decompressedBody, &transcriptionResp); err != nil {
-		c.logger.Warnf("Failed to parse speech-to-text response for usage extraction: %v", err)
-		c.logger.Debugf("Raw response causing parse error: %s", string(decompressedBody))
-		// Fallback to estimated billing if parsing fails
-		return c.updateSpeechToTextFallback(ctx, reqModel, string(decompressedBody))
+		// Non-JSON body: response_format=text/srt/vtt returns plain text.
+		// srt/vtt carry a timeline, so recover the audio duration from the
+		// last cue's end timestamp and bill it like a {type:"duration"}
+		// usage block. Falling through to the word-count fallback instead
+		// would bill OutputPrice × estimate — 0 for whisper services, whose
+		// per-second price lives in InputPrice.
+		seconds, ok := subtitleDurationSeconds(string(decompressedBody))
+		if !ok {
+			c.logger.Warnf("Failed to parse speech-to-text response for usage extraction: %v", err)
+			c.logger.Debugf("Raw response causing parse error: %s", string(decompressedBody))
+			// Plain text carries no timing signal — fall back to estimated billing
+			return c.updateSpeechToTextFallback(ctx, reqModel, string(decompressedBody))
+		}
+		transcriptionResp.Usage = &SpeechToTextUsage{Type: "duration", Seconds: seconds}
 	}
+
+	// verbose_json may carry the audio length only in the top-level duration
+	// field; synthesize a duration usage from it when the usage block is
+	// absent or unbillable.
+	transcriptionResp.Usage = effectiveUsage(&transcriptionResp)
 
 	// Sign response if needed
 	if !c.Service.TargetSeparated {
@@ -664,6 +703,60 @@ func (c *Ctrl) updateSpeechToTextFallback(ctx context.Context, reqModel model.Re
 	c.consumeSpeechToTextLimiter(ctx, int(estimatedOutputTokens))
 
 	return nil
+}
+
+// subtitleDurationSeconds recovers the audio duration from an SRT or WebVTT
+// transcript (response_format=srt/vtt) by taking the end timestamp of the
+// last cue line ("HH:MM:SS,mmm --> HH:MM:SS,mmm"). The last cue's end time
+// is a tight lower bound on the audio length — whisper emits cues covering
+// the full transcribed span — so it is the per-second billing source when
+// the provider returns subtitles instead of JSON.
+//
+// Returns ok=false when the body contains no parseable cue line (e.g.
+// response_format=text), in which case the caller falls back to the
+// word-count estimator.
+func subtitleDurationSeconds(body string) (float64, bool) {
+	var lastEnd string
+	for _, line := range strings.Split(body, "\n") {
+		idx := strings.Index(line, "-->")
+		if idx < 0 {
+			continue
+		}
+		end := strings.TrimSpace(line[idx+len("-->"):])
+		// WebVTT cue settings may trail the end timestamp,
+		// e.g. "00:00:04.000 align:start position:0%".
+		if sp := strings.IndexAny(end, " \t"); sp >= 0 {
+			end = end[:sp]
+		}
+		if end != "" {
+			lastEnd = end
+		}
+	}
+	if lastEnd == "" {
+		return 0, false
+	}
+	return parseSubtitleTimestamp(lastEnd)
+}
+
+// parseSubtitleTimestamp parses an SRT ("HH:MM:SS,mmm") or WebVTT
+// ("HH:MM:SS.mmm", "MM:SS.mmm") timestamp into seconds. Rejects malformed
+// or non-finite components so a garbage line containing "-->" cannot
+// produce a bogus charge.
+func parseSubtitleTimestamp(ts string) (float64, bool) {
+	ts = strings.ReplaceAll(ts, ",", ".")
+	parts := strings.Split(ts, ":")
+	if len(parts) < 2 || len(parts) > 3 {
+		return 0, false
+	}
+	total := 0.0
+	for _, p := range parts {
+		v, err := strconv.ParseFloat(p, 64)
+		if err != nil || v < 0 || math.IsInf(v, 0) || math.IsNaN(v) {
+			return 0, false
+		}
+		total = total*60 + v
+	}
+	return total, total > 0
 }
 
 // isSpeechToTextStream checks if the request body contains stream parameter

--- a/api/inference/internal/ctrl/speech_to_text_test.go
+++ b/api/inference/internal/ctrl/speech_to_text_test.go
@@ -113,6 +113,15 @@ func TestBillableSeconds(t *testing.T) {
 		{"sub-half-second floored to 1", &SpeechToTextUsage{Seconds: 0.4}, 1},
 		{"barely above zero floored to 1", &SpeechToTextUsage{Seconds: 0.001}, 1},
 		{"half-second rounds to 1", &SpeechToTextUsage{Seconds: 0.5}, 1},
+		// 99-hour cap, aligned with the subtitle lane's two-digit hours
+		// limit: an anomalous provider-reported duration (usage.seconds or
+		// verbose_json's duration field) must not bill an unbounded fee.
+		{"at the cap", &SpeechToTextUsage{Seconds: 99 * 3600}, 99 * 3600},
+		{"above the cap clamped", &SpeechToTextUsage{Seconds: 1e12}, 99 * 3600},
+		// Pre-clamp, float→int of a value beyond int64 range was
+		// platform-dependent (negative on amd64 → floored to 1 second, a
+		// near-free request instead of an overcharge).
+		{"extreme float clamped", &SpeechToTextUsage{Seconds: 1e308}, 99 * 3600},
 	}
 
 	for _, tt := range tests {

--- a/api/inference/internal/ctrl/speech_to_text_test.go
+++ b/api/inference/internal/ctrl/speech_to_text_test.go
@@ -610,10 +610,29 @@ func TestParseSubtitleTimestamp(t *testing.T) {
 		{"single component", "207", 0, false},
 		{"four components", "01:02:03:04", 0, false},
 		{"negative component", "00:-1:00", 0, false},
-		// strconv.ParseFloat accepts "Inf"/"NaN"; the parser must not let a
-		// non-finite component reach billableSeconds' int conversion.
+		// strconv.ParseFloat alone accepts all of these; the digit-only
+		// component check must reject them so a garbage line containing
+		// "-->" cannot produce a bogus (potentially huge) charge.
+		{"scientific notation", "12:1e9", 0, false},
+		{"explicit plus sign", "00:+1:00", 0, false},
 		{"infinite component", "00:00:Inf", 0, false},
 		{"nan component", "00:NaN:00", 0, false},
+		{"hex prefix", "0x1:00", 0, false},
+		// Grammar bounds: minutes/seconds < 60 (hours of HH:MM:SS exempt),
+		// fraction only on the seconds component, dot needs digits both sides.
+		{"seconds component over 59", "00:00:75,000", 0, false},
+		{"minutes component over 59", "00:75:00,000", 0, false},
+		{"short form minutes over 59", "75:00.000", 0, false},
+		{"hours over 59 allowed", "60:00:00,000", 216000, true},
+		{"two digit hours allowed", "99:00:00,000", 356400, true},
+		// Hours cap: one corrupted cue line must not be able to bill a fee
+		// that drains the user's whole locked balance.
+		{"three digit hours rejected", "100:00:00,000", 0, false},
+		{"absurd hours rejected", "999999999:00:00,000", 0, false},
+		{"fraction on minutes component", "00:1.5:00", 0, false},
+		{"bare leading dot", "00:00:.5", 0, false},
+		{"bare trailing dot", "00:00:5.", 0, false},
+		{"empty component", "00::05", 0, false},
 		{"empty", "", 0, false},
 	}
 

--- a/api/inference/internal/ctrl/speech_to_text_test.go
+++ b/api/inference/internal/ctrl/speech_to_text_test.go
@@ -577,9 +577,46 @@ func TestSubtitleDurationSeconds(t *testing.T) {
 			0, false,
 		},
 		{
+			// Reviewer probe: prose mentioning a full "T1 --> T2" range must
+			// not bill either — the start side is validated as a timestamp
+			// at the head of the line, and "skip from 01:02.000" is not one.
+			"timestamp range in prose",
+			"skip from 01:02.000 --> 03:27.250 in the video",
+			0, false,
+		},
+		{
+			// Reviewer probe: the streaming path runs recovery over bodies
+			// of JSON chunks whenever no usage arrived; a delta whose text
+			// mentions a cue range must not synthesize a charge (the JSON
+			// prefix before the arrow fails the start-timestamp check).
+			"timestamp range inside JSON delta",
+			`{"type":"transcript.text.delta","delta":"see 01:02.500 --> 03:27.250 in the clip"}`,
+			0, false,
+		},
+		{
 			// Malformed cue line: parser rejects rather than guessing.
 			"garbage timestamp",
 			"1\n00:00:00,000 --> not:a:time\nwords\n",
+			0, false,
+		},
+		{
+			// Reviewer regression: a trailing prose "-->" line must not void
+			// the valid cue before it — max parsed end wins, not last line.
+			"prose arrow after valid cue",
+			"1\n00:00:00,000 --> 00:03:27,250\nthe sign said exit --> turn left\n",
+			207.25, true,
+		},
+		{
+			// Reordered/corrupted tail: max end wins over a later, smaller cue.
+			"out-of-order cues take max",
+			"1\n00:00:00,000 --> 00:03:27,250\nlate\n\n2\n00:00:00,000 --> 00:01:00,000\nearly\n",
+			207.25, true,
+		},
+		{
+			// A single zero-length cue is well-formed but carries no
+			// billable duration.
+			"zero-length cue not billable",
+			"1\n00:00:00,000 --> 00:00:00,000\nblip\n",
 			0, false,
 		},
 	}
@@ -606,7 +643,10 @@ func TestParseSubtitleTimestamp(t *testing.T) {
 		{"vtt dot millis", "00:03:27.250", 207.25, true},
 		{"vtt short form", "03:27.500", 207.5, true},
 		{"hours", "01:00:05.000", 3605, true},
-		{"zero is not billable", "00:00:00,000", 0, false},
+		// ok reports well-formedness only: cue start times legitimately
+		// begin at zero, so the parser accepts it; subtitleDurationSeconds
+		// enforces billability (> 0) on the recovered end time.
+		{"zero is well-formed", "00:00:00,000", 0, true},
 		{"single component", "207", 0, false},
 		{"four components", "01:02:03:04", 0, false},
 		{"negative component", "00:-1:00", 0, false},

--- a/api/inference/internal/ctrl/speech_to_text_test.go
+++ b/api/inference/internal/ctrl/speech_to_text_test.go
@@ -533,6 +533,189 @@ func TestCalcTokenFees_BadPrice(t *testing.T) {
 }
 
 // ==========================================================================
+// Non-JSON / usage-less response_format recovery
+//
+// whisper supports response_format=json/verbose_json/text/srt/vtt, but only
+// json reliably carries a usage block. Before this recovery existed,
+// verbose_json (usage absent on some providers), srt, vtt and text all fell
+// through to the word-count fallback, which bills OutputPrice × estimate —
+// 0 for whisper services, whose per-second price lives in InputPrice. srt
+// and vtt carry a timeline, verbose_json carries a top-level duration field;
+// both are recovered into a duration usage. Plain text stays on the
+// fallback (no timing signal).
+// ==========================================================================
+
+func TestSubtitleDurationSeconds(t *testing.T) {
+	tests := []struct {
+		name        string
+		body        string
+		wantSeconds float64
+		wantOK      bool
+	}{
+		{
+			"srt two cues",
+			"1\r\n00:00:00,000 --> 00:00:04,000\r\nHello there.\r\n\r\n2\r\n00:00:04,500 --> 00:03:27,250\r\nGeneral Kenobi.\r\n",
+			207.25, true,
+		},
+		{
+			"vtt with header",
+			"WEBVTT\n\n00:00.000 --> 00:04.000\nHello there.\n\n00:04.500 --> 03:27.500\nGeneral Kenobi.\n",
+			207.5, true,
+		},
+		{
+			"vtt hour form with cue settings",
+			"WEBVTT\n\n01:00:00.000 --> 01:00:05.000 align:start position:0%\nstill going\n",
+			3605, true,
+		},
+		{"plain text", "Hello there. General Kenobi.", 0, false},
+		{"empty", "", 0, false},
+		{
+			// A transcript that merely mentions an arrow must not bill: the
+			// text after "-->" is not a parseable timestamp.
+			"arrow in prose",
+			"the sign said exit --> turn left here",
+			0, false,
+		},
+		{
+			// Malformed cue line: parser rejects rather than guessing.
+			"garbage timestamp",
+			"1\n00:00:00,000 --> not:a:time\nwords\n",
+			0, false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := subtitleDurationSeconds(tt.body)
+			if ok != tt.wantOK || got != tt.wantSeconds {
+				t.Errorf("subtitleDurationSeconds() = (%v, %v), want (%v, %v)",
+					got, ok, tt.wantSeconds, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestParseSubtitleTimestamp(t *testing.T) {
+	tests := []struct {
+		name        string
+		ts          string
+		wantSeconds float64
+		wantOK      bool
+	}{
+		{"srt comma millis", "00:03:27,250", 207.25, true},
+		{"vtt dot millis", "00:03:27.250", 207.25, true},
+		{"vtt short form", "03:27.500", 207.5, true},
+		{"hours", "01:00:05.000", 3605, true},
+		{"zero is not billable", "00:00:00,000", 0, false},
+		{"single component", "207", 0, false},
+		{"four components", "01:02:03:04", 0, false},
+		{"negative component", "00:-1:00", 0, false},
+		// strconv.ParseFloat accepts "Inf"/"NaN"; the parser must not let a
+		// non-finite component reach billableSeconds' int conversion.
+		{"infinite component", "00:00:Inf", 0, false},
+		{"nan component", "00:NaN:00", 0, false},
+		{"empty", "", 0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseSubtitleTimestamp(tt.ts)
+			if ok != tt.wantOK || got != tt.wantSeconds {
+				t.Errorf("parseSubtitleTimestamp(%q) = (%v, %v), want (%v, %v)",
+					tt.ts, got, ok, tt.wantSeconds, tt.wantOK)
+			}
+		})
+	}
+}
+
+// TestEffectiveUsage pins the verbose_json recovery rule: a billable usage
+// block always wins; otherwise the top-level duration field is promoted to
+// a synthetic duration usage; with neither, the original (possibly nil)
+// usage passes through so hasBillableUsage routes to the fallback.
+func TestEffectiveUsage(t *testing.T) {
+	tests := []struct {
+		name string
+		resp SpeechToTextResponse
+		want *SpeechToTextUsage
+	}{
+		{
+			"billable usage wins over duration field",
+			SpeechToTextResponse{
+				Duration: 99,
+				Usage:    &SpeechToTextUsage{Type: "duration", Seconds: 207},
+			},
+			&SpeechToTextUsage{Type: "duration", Seconds: 207},
+		},
+		{
+			"token usage wins over duration field",
+			SpeechToTextResponse{
+				Duration: 99,
+				Usage:    &SpeechToTextUsage{Type: "tokens", InputTokens: 149},
+			},
+			&SpeechToTextUsage{Type: "tokens", InputTokens: 149},
+		},
+		{
+			"verbose_json without usage promotes duration",
+			SpeechToTextResponse{Duration: 207.25},
+			&SpeechToTextUsage{Type: "duration", Seconds: 207.25},
+		},
+		{
+			"unbillable usage with duration field promotes duration",
+			SpeechToTextResponse{Duration: 30, Usage: &SpeechToTextUsage{Type: "duration"}},
+			&SpeechToTextUsage{Type: "duration", Seconds: 30},
+		},
+		{
+			"nothing billable passes through",
+			SpeechToTextResponse{Text: "hello"},
+			nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := effectiveUsage(&tt.resp)
+			if tt.want == nil {
+				if got != nil {
+					t.Fatalf("effectiveUsage() = %+v, want nil", got)
+				}
+				return
+			}
+			if got == nil || *got != *tt.want {
+				t.Errorf("effectiveUsage() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSpeechToTextResponse_DecodeVerboseJSON guards the Duration JSON tag.
+// verbose_json carries duration at the top level (a float, e.g. 8.47), not
+// inside usage — if the tag drifts, verbose_json responses without a usage
+// block quietly return to the 0-fee fallback.
+func TestSpeechToTextResponse_DecodeVerboseJSON(t *testing.T) {
+	raw := []byte(`{
+		"task": "transcribe",
+		"language": "english",
+		"duration": 8.47,
+		"text": "Hello there.",
+		"segments": [{"id": 0, "start": 0.0, "end": 8.47, "text": "Hello there."}]
+	}`)
+	var resp SpeechToTextResponse
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		t.Fatalf("unmarshal verbose_json response: %v", err)
+	}
+	if resp.Duration != 8.47 {
+		t.Errorf("Duration = %v, want 8.47", resp.Duration)
+	}
+	if resp.Usage != nil {
+		t.Errorf("Usage = %+v, want nil", resp.Usage)
+	}
+	got := effectiveUsage(&resp)
+	if got == nil || !isDurationUsage(got) || got.Seconds != 8.47 {
+		t.Errorf("effectiveUsage() = %+v, want duration usage with Seconds=8.47", got)
+	}
+}
+
+// ==========================================================================
 // isSpeechToTextStream
 //
 // Driven entirely off the raw multipart request body — must not confuse


### PR DESCRIPTION
## Summary
Adds support for billing speech-to-text requests when providers return non-JSON response formats (SRT, WebVTT, plain text) by recovering audio duration from subtitle timelines. This prevents requests from incorrectly falling back to word-count estimation, which would bill 0 for whisper services where per-second pricing lives in InputPrice.

## Key Changes

- **Added `Duration` field to `SpeechToTextResponse`**: Captures the top-level audio length that verbose_json responses carry alongside text/segments.

- **Implemented `effectiveUsage()` function**: Synthesizes a duration usage block when:
  - Response carries no billable usage but has a populated Duration field (verbose_json case)
  - Ensures requests don't fall through to word-count fallback (which bills OutputPrice × estimate = 0 for whisper)

- **Implemented subtitle duration recovery**:
  - `subtitleDurationSeconds()`: Extracts the end timestamp of the last cue line from SRT/WebVTT transcripts
  - `parseSubtitleTimestamp()`: Parses SRT ("HH:MM:SS,mmm") and WebVTT ("HH:MM:SS.mmm", "MM:SS.mmm") timestamps with strict validation
  - `isSubtitleComponent()`: Validates timestamp components (decimal digits only, fractional part only on seconds)

- **Updated non-streaming path** (`handleNonStreamingSpeechToText`):
  - When JSON parsing fails, attempts to recover duration from subtitle format
  - Falls back to word-count estimator only for plain text (no timing signal)
  - Applies `effectiveUsage()` to handle verbose_json without usage blocks

- **Updated streaming path** (`handleStreamingSpeechToText`):
  - Recovers duration from captured stream body when no billable usage is present
  - Prevents non-conforming providers from bypassing per-second billing

## Implementation Details

- Timestamp parsing is deliberately strict (rejects scientific notation, signs, special values) to prevent corrupted cue lines from generating excessive charges
- Hours component capped at 99 (two digits per SRT grammar) to prevent a single malformed cue from draining user's locked balance
- Minutes/seconds components must be < 60 per SRT/WebVTT grammars
- Fractional part permitted only on seconds component
- Last cue's end time used as tight lower bound on audio length (whisper emits cues covering full transcribed span)

## Testing
Comprehensive test coverage added:
- `TestSubtitleDurationSeconds`: SRT/WebVTT parsing with edge cases (malformed timestamps, prose containing "-->", empty input)
- `TestParseSubtitleTimestamp`: Timestamp validation (bounds checking, component format, scientific notation rejection, etc.)
- `TestEffectiveUsage`: Usage block promotion logic with various response shapes
- `TestSpeechToTextResponse_DecodeVerboseJSON`: Verifies Duration JSON tag and verbose_json recovery

https://claude.ai/code/session_011Wd6CiXnz8Ac84oLHsGX7c