### PR TITLE
Handle string-encoded floats in speech-to-text duration fields

### DIFF
--- a/api/inference/internal/ctrl/speech_to_text.go
+++ b/api/inference/internal/ctrl/speech_to_text.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	stderrors "errors"
+	"fmt"
 	"io"
 	"math"
 	"net/http"
@@ -50,8 +51,8 @@ const speechToTextMetricLabel = "speech_to_text"
 // For the token shape, output_tokens is always 0 upstream — transcription is
 // treated as input-side processing, not generation.
 //
-// Seconds is float64 rather than int because Go's encoding/json refuses to
-// decode JSON numbers with a decimal point into integer fields — even
+// Seconds is flexFloat64 rather than int because Go's encoding/json refuses
+// to decode JSON numbers with a decimal point into integer fields — even
 // "207.0". A non-conforming provider (or a JSON encoder that always emits
 // floats, e.g. Python's json.dumps on a float) would otherwise fail the
 // whole struct unmarshal, fall through to the word-count estimator, and
@@ -64,7 +65,58 @@ type SpeechToTextUsage struct {
 	InputTokens       int                      `json:"input_tokens"`
 	InputTokenDetails SpeechToTextTokenDetails `json:"input_token_details"`
 	OutputTokens      int                      `json:"output_tokens"`
-	Seconds           float64                  `json:"seconds"`
+	Seconds           flexFloat64              `json:"seconds"`
+}
+
+// flexFloat64 is a float64 that decodes from either a JSON number or a JSON
+// string holding a number ("206.34125" as well as 206.34125). Observed in
+// the wild: a whisper backend emitting verbose_json's top-level duration as
+// a quoted string — with a plain float64 field that single value fails the
+// whole struct unmarshal and the request falls through to the word-count
+// fallback, billing 0 for whisper services (the per-second price lives in
+// InputPrice). Same zero-billing bug class as the fractional-seconds issue
+// documented on SpeechToTextUsage.Seconds.
+//
+// JSON null and the empty string decode to 0 (un-billable, same as the field
+// being absent). A non-numeric or non-finite string ("abc", "Inf", "NaN")
+// returns an error so the response routes through the existing parse-failure
+// recovery (subtitle timeline, then the estimator fallback) — accepting
+// "+Inf" would instead clamp to maxBillableSeconds and bill 99 hours from a
+// garbage value.
+type flexFloat64 float64
+
+func (f *flexFloat64) UnmarshalJSON(data []byte) error {
+	trimmed := strings.TrimSpace(string(data))
+	if trimmed == "null" {
+		*f = 0
+		return nil
+	}
+	if strings.HasPrefix(trimmed, `"`) {
+		var s string
+		if err := json.Unmarshal(data, &s); err != nil {
+			return errors.Wrap(err, "decode string-encoded float")
+		}
+		s = strings.TrimSpace(s)
+		if s == "" {
+			*f = 0
+			return nil
+		}
+		v, err := strconv.ParseFloat(s, 64)
+		if err != nil {
+			return errors.Wrapf(err, "parse %q as float", s)
+		}
+		if math.IsNaN(v) || math.IsInf(v, 0) {
+			return fmt.Errorf("non-finite float value %q", s)
+		}
+		*f = flexFloat64(v)
+		return nil
+	}
+	var v float64
+	if err := json.Unmarshal(data, &v); err != nil {
+		return errors.Wrap(err, "decode float")
+	}
+	*f = flexFloat64(v)
+	return nil
 }
 
 // maxBillableSeconds caps a single transcription's billable duration at the
@@ -92,7 +144,7 @@ func billableSeconds(u *SpeechToTextUsage) int {
 	if u == nil || u.Seconds <= 0 {
 		return 0
 	}
-	rounded := int(math.Round(math.Min(u.Seconds, maxBillableSeconds)))
+	rounded := int(math.Round(math.Min(float64(u.Seconds), maxBillableSeconds)))
 	if rounded < 1 {
 		return 1
 	}
@@ -152,10 +204,11 @@ type SpeechToTextTokenDetails struct {
 // Duration is the top-level audio length in seconds that verbose_json
 // responses (whisper family) carry alongside text/segments. Some providers
 // emit verbose_json without a usage block at all, so Duration is the only
-// billing signal in that shape — see effectiveUsage.
+// billing signal in that shape — see effectiveUsage. flexFloat64 because
+// some providers quote the value ("206.34125") — see flexFloat64.
 type SpeechToTextResponse struct {
 	Text     string             `json:"text"`
-	Duration float64            `json:"duration"`
+	Duration flexFloat64        `json:"duration"`
 	Usage    *SpeechToTextUsage `json:"usage,omitempty"`
 }
 
@@ -266,7 +319,7 @@ func (c *Ctrl) handleNonStreamingSpeechToText(ctx *gin.Context, resp *http.Respo
 		// emit non-JSON shapes (the signal the parse-failure Warnf carried
 		// before recovery existed).
 		c.logger.Infof("recovered speech-to-text duration from subtitle timeline: %.3fs request=%s", seconds, reqModel.RequestHash)
-		transcriptionResp.Usage = &SpeechToTextUsage{Type: "duration", Seconds: seconds}
+		transcriptionResp.Usage = &SpeechToTextUsage{Type: "duration", Seconds: flexFloat64(seconds)}
 	}
 
 	// verbose_json may carry the audio length only in the top-level duration
@@ -403,7 +456,7 @@ func (c *Ctrl) handleStreamingSpeechToText(ctx *gin.Context, resp *http.Response
 			// captured stream body, not from a provider usage chunk — see
 			// the non-streaming recovery site for rationale.
 			c.logger.Infof("recovered streaming speech-to-text duration from subtitle timeline: %.3fs request=%s", seconds, reqModel.RequestHash)
-			usage = &SpeechToTextUsage{Type: "duration", Seconds: seconds}
+			usage = &SpeechToTextUsage{Type: "duration", Seconds: flexFloat64(seconds)}
 		}
 	}
 

--- a/api/inference/internal/ctrl/speech_to_text_test.go
+++ b/api/inference/internal/ctrl/speech_to_text_test.go
@@ -75,6 +75,13 @@ func TestSpeechToTextUsage_DecodeFractionalSeconds(t *testing.T) {
 		// Python's json.dumps(207.0) emits this — Go's int field rejected it.
 		{"whole-number float", `{"type":"duration","seconds":207.0}`, 207},
 		{"sub-second", `{"type":"duration","seconds":0.4}`, 0.4},
+		// String-encoded numbers — observed from a whisper backend that
+		// quotes verbose_json's duration; accept the same shape here so a
+		// provider quoting usage.seconds doesn't kill the struct unmarshal.
+		{"string seconds", `{"type":"duration","seconds":"207"}`, 207},
+		{"string fractional seconds", `{"type":"duration","seconds":"206.34125"}`, 206.34125},
+		{"empty string is zero", `{"type":"duration","seconds":""}`, 0},
+		{"null is zero", `{"type":"duration","seconds":null}`, 0},
 	}
 
 	for _, tt := range tests {
@@ -83,10 +90,30 @@ func TestSpeechToTextUsage_DecodeFractionalSeconds(t *testing.T) {
 			if err := json.Unmarshal([]byte(tt.raw), &u); err != nil {
 				t.Fatalf("unmarshal %s: %v", tt.raw, err)
 			}
-			if u.Seconds != tt.wantSeconds {
+			if float64(u.Seconds) != tt.wantSeconds {
 				t.Errorf("Seconds = %v, want %v", u.Seconds, tt.wantSeconds)
 			}
 		})
+	}
+}
+
+// TestFlexFloat64_RejectsGarbage pins the fail-closed side of flexFloat64:
+// a non-numeric or non-finite string must error so the response routes
+// through the parse-failure recovery (subtitle timeline → estimator) rather
+// than decoding to a bogus value. "+Inf" in particular would otherwise pass
+// hasBillableUsage and clamp to the 99-hour cap — a max-fee charge from a
+// garbage value.
+func TestFlexFloat64_RejectsGarbage(t *testing.T) {
+	for _, raw := range []string{
+		`{"seconds":"abc"}`,
+		`{"seconds":"+Inf"}`,
+		`{"seconds":"NaN"}`,
+		`{"seconds":true}`,
+	} {
+		var u SpeechToTextUsage
+		if err := json.Unmarshal([]byte(raw), &u); err == nil {
+			t.Errorf("unmarshal %s: expected error, got Seconds=%v", raw, u.Seconds)
+		}
 	}
 }
 
@@ -146,7 +173,7 @@ func TestBillableSeconds_NeverZeroWhenGateAdmitsDuration(t *testing.T) {
 	// Span the gap the reviewer flagged and the boundary just above zero.
 	subSecondInputs := []float64{0.001, 0.1, 0.4, 0.49, 0.5, 0.51, 0.9, 1.0}
 	for _, sec := range subSecondInputs {
-		u := &SpeechToTextUsage{Type: "duration", Seconds: sec}
+		u := &SpeechToTextUsage{Type: "duration", Seconds: flexFloat64(sec)}
 		if !hasBillableUsage(u) {
 			t.Fatalf("hasBillableUsage(seconds=%v) = false, want true (regression in admission gate)", sec)
 		}
@@ -780,6 +807,30 @@ func TestSpeechToTextResponse_DecodeVerboseJSON(t *testing.T) {
 	got := effectiveUsage(&resp)
 	if got == nil || !isDurationUsage(got) || got.Seconds != 8.47 {
 		t.Errorf("effectiveUsage() = %+v, want duration usage with Seconds=8.47", got)
+	}
+}
+
+// TestSpeechToTextResponse_DecodeStringDuration covers the originally
+// reported provider shape: verbose_json with the top-level duration quoted
+// as a string ("206.34125"). Before flexFloat64 this failed the whole
+// struct unmarshal and the request fell to the word-count fallback, billing
+// 0 for whisper services.
+func TestSpeechToTextResponse_DecodeStringDuration(t *testing.T) {
+	raw := []byte(`{
+		"task": "transcribe",
+		"duration": "206.34125",
+		"text": "Hello there."
+	}`)
+	var resp SpeechToTextResponse
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		t.Fatalf("unmarshal string-duration response: %v", err)
+	}
+	if resp.Duration != 206.34125 {
+		t.Errorf("Duration = %v, want 206.34125", resp.Duration)
+	}
+	got := effectiveUsage(&resp)
+	if got == nil || !isDurationUsage(got) || got.Seconds != 206.34125 {
+		t.Errorf("effectiveUsage() = %+v, want duration usage with Seconds=206.34125", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
Fixes a billing bug where speech-to-text responses with string-encoded duration values (e.g., `"206.34125"` instead of `206.34125`) would fail JSON unmarshaling and fall through to the word-count estimator, resulting in zero billing for whisper services.

## Changes
- **Introduced `flexFloat64` type**: A custom float64 that unmarshals from JSON numbers, quoted strings, null, and empty strings. Rejects non-numeric or non-finite strings ("abc", "Inf", "NaN") to route through existing parse-failure recovery rather than accepting garbage values.
- **Updated `SpeechToTextUsage.Seconds`**: Changed from `float64` to `flexFloat64` to handle both numeric and string-encoded fractional seconds.
- **Updated `SpeechToTextResponse.Duration`**: Changed from `float64` to `flexFloat64` to handle verbose_json responses where providers quote the duration field.
- **Updated type conversions**: Added explicit `float64()` casts where `flexFloat64` values are used in math operations (e.g., `billableSeconds`).
- **Updated recovery code paths**: Cast recovered duration values to `flexFloat64` when creating fallback usage objects.
- **Added comprehensive tests**: 
  - Test cases for string-encoded seconds (whole numbers, fractional, empty string, null)
  - Test cases verifying rejection of garbage values (non-numeric, infinite, NaN)
  - Test case for the originally reported provider shape (verbose_json with quoted duration)

## Implementation Details
The `flexFloat64.UnmarshalJSON` implementation:
- Handles JSON null and empty strings by decoding to 0 (un-billable, same as absent field)
- Parses quoted strings via `strconv.ParseFloat` with validation for non-finite values
- Falls back to standard float64 unmarshaling for numeric JSON values
- Returns errors for non-numeric or non-finite strings so responses route through subtitle timeline recovery and estimator fallback

https://claude.ai/code/session_01NkQ9gumzgQtHcSJXEAubWN