### PR TITLE
feat(inference): per-address rate/concurrency limit overrides

### DIFF
--- a/api/common/middleware/per_user_concurrency.go
+++ b/api/common/middleware/per_user_concurrency.go
@@ -3,35 +3,87 @@ package middleware
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 
 	"github.com/gin-gonic/gin"
 )
 
+// normalizeUserID lowercases a per-user limiter key. User keys are Ethereum
+// addresses, which are case-insensitive, so normalizing here keeps a single
+// bucket per user regardless of the casing a client sends and lets
+// operator-configured overrides match reliably.
+func normalizeUserID(userID string) string {
+	return strings.ToLower(userID)
+}
+
+// normalizeOverrideKeys returns a copy of m with every key lowercased via
+// normalizeUserID, so a per-address override matches regardless of the casing
+// the caller supplied. Returns nil for a nil/empty input (the "no overrides"
+// sentinel). On a case-collision the last entry wins. Normalizing here — at the
+// one place the map enters a limiter — means callers cannot create a
+// silently-non-matching override by passing a checksummed (mixed-case) key.
+func normalizeOverrideKeys[V any](m map[string]V) map[string]V {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]V, len(m))
+	for k, v := range m {
+		out[normalizeUserID(k)] = v
+	}
+	return out
+}
+
 // PerUserConcurrencyLimiter limits the number of concurrent requests per user.
 // This prevents a single user from monopolizing backend resources.
+//
+// A per-address override map grants specific users a cap above (or below) the
+// shared default without changing the default for everyone else. This lets a
+// heavy partner be granted more headroom than the shared default while still
+// being bounded below the global concurrency limit. Override keys are matched
+// case-insensitively (the constructor lowercases them); a value of 0 is ignored
+// so a per-user cap can only be set to a positive number.
 type PerUserConcurrencyLimiter struct {
 	maxPerUser int
+	overrides  map[string]int // normalized address -> per-user cap (>0); nil if none
 	active     map[string]int
 	mu         sync.Mutex
 }
 
 // NewPerUserConcurrencyLimiter creates a per-user concurrency limiter.
-// maxPerUser: maximum concurrent requests allowed per user address.
-func NewPerUserConcurrencyLimiter(maxPerUser int) *PerUserConcurrencyLimiter {
+// maxPerUser: default maximum concurrent requests allowed per user address.
+// overrides: optional per-address caps; keys are lowercased internally so any
+// casing matches. Pass nil for none.
+func NewPerUserConcurrencyLimiter(maxPerUser int, overrides map[string]int) *PerUserConcurrencyLimiter {
 	return &PerUserConcurrencyLimiter{
 		maxPerUser: maxPerUser,
+		overrides:  normalizeOverrideKeys(overrides),
 		active:     make(map[string]int),
 	}
+}
+
+// MaxForUser returns the effective concurrency cap for a user, honoring any
+// per-address override.
+func (l *PerUserConcurrencyLimiter) MaxForUser(userID string) int {
+	userID = normalizeUserID(userID)
+	if ov, ok := l.overrides[userID]; ok && ov > 0 {
+		return ov
+	}
+	return l.maxPerUser
 }
 
 // Acquire attempts to acquire a slot for the given user.
 // Returns true if acquired, false if the user has reached their limit.
 func (l *PerUserConcurrencyLimiter) Acquire(userID string) bool {
+	userID = normalizeUserID(userID)
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	if l.active[userID] >= l.maxPerUser {
+	limit := l.maxPerUser
+	if ov, ok := l.overrides[userID]; ok && ov > 0 {
+		limit = ov
+	}
+	if l.active[userID] >= limit {
 		return false
 	}
 	l.active[userID]++
@@ -40,6 +92,7 @@ func (l *PerUserConcurrencyLimiter) Acquire(userID string) bool {
 
 // Release releases a slot for the given user.
 func (l *PerUserConcurrencyLimiter) Release(userID string) {
+	userID = normalizeUserID(userID)
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
@@ -51,6 +104,7 @@ func (l *PerUserConcurrencyLimiter) Release(userID string) {
 
 // GetActiveForUser returns the current concurrent request count for a user.
 func (l *PerUserConcurrencyLimiter) GetActiveForUser(userID string) int {
+	userID = normalizeUserID(userID)
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	return l.active[userID]
@@ -75,7 +129,7 @@ func CheckPerUserConcurrency(limiter *PerUserConcurrencyLimiter, c *gin.Context,
 		c.JSON(http.StatusTooManyRequests, gin.H{
 			"error": fmt.Sprintf(
 				"Too many concurrent requests. You have %d active requests (limit: %d). Please wait for some to complete.",
-				active, limiter.maxPerUser,
+				active, limiter.MaxForUser(userAddress),
 			),
 		})
 		c.Abort()

--- a/api/common/middleware/per_user_limit_override_test.go
+++ b/api/common/middleware/per_user_limit_override_test.go
@@ -1,0 +1,175 @@
+package middleware
+
+import "testing"
+
+// TestPerUserConcurrencyOverride verifies that a per-address override raises the
+// cap for the configured user while everyone else stays on the default, and
+// that matching is case-insensitive (overrides stored lowercase must match a
+// mixed-case address from a session token).
+func TestPerUserConcurrencyOverride(t *testing.T) {
+	const partner = "0xabc0000000000000000000000000000000000001"
+	limiter := NewPerUserConcurrencyLimiter(2, map[string]int{partner: 4})
+
+	// Default user: capped at 2.
+	other := "0xdef0000000000000000000000000000000000002"
+	if got := limiter.MaxForUser(other); got != 2 {
+		t.Fatalf("default MaxForUser = %d, want 2", got)
+	}
+	if !limiter.Acquire(other) || !limiter.Acquire(other) {
+		t.Fatal("default user should acquire 2 slots")
+	}
+	if limiter.Acquire(other) {
+		t.Fatal("default user should be blocked at the 3rd slot")
+	}
+
+	// Overridden partner, addressed with checksum-style mixed case, gets 4.
+	mixed := "0xABC0000000000000000000000000000000000001"
+	if got := limiter.MaxForUser(mixed); got != 4 {
+		t.Fatalf("override MaxForUser = %d, want 4", got)
+	}
+	for i := 0; i < 4; i++ {
+		if !limiter.Acquire(mixed) {
+			t.Fatalf("overridden partner should acquire slot %d", i+1)
+		}
+	}
+	if limiter.Acquire(partner) {
+		t.Fatal("overridden partner should be blocked at the 5th slot (lowercase shares the bucket)")
+	}
+
+	// Releasing via a different casing must free the same bucket.
+	limiter.Release(mixed)
+	if !limiter.Acquire(partner) {
+		t.Fatal("partner should reacquire after release regardless of casing")
+	}
+}
+
+// TestPerUserOverrideKeyNormalization verifies the constructor lowercases
+// override map keys, so an override built with a checksummed (mixed-case) key
+// still matches a lowercase lookup — the contract is enforced at the type, not
+// delegated to callers.
+func TestPerUserOverrideKeyNormalization(t *testing.T) {
+	mixedKey := "0xABC0000000000000000000000000000000000001"
+	lower := "0xabc0000000000000000000000000000000000001"
+
+	conc := NewPerUserConcurrencyLimiter(2, map[string]int{mixedKey: 5})
+	if got := conc.MaxForUser(lower); got != 5 {
+		t.Fatalf("concurrency MaxForUser = %d, want 5 (mixed-case key must normalize)", got)
+	}
+
+	rl := NewPerUserRateLimiter(60, 1, map[string]RateOverride{mixedKey: {Burst: 3}})
+	for i := 0; i < 3; i++ {
+		if !rl.Allow(lower) {
+			t.Fatalf("rate request %d should pass under normalized mixed-case key", i+1)
+		}
+	}
+	if rl.Allow(lower) {
+		t.Fatal("rate request should be limited after burst 3 (override matched via normalized key)")
+	}
+}
+
+// TestPerUserRateLimiterOverride verifies a per-address burst override grants a
+// larger immediate allowance than the default, matched case-insensitively.
+func TestPerUserRateLimiterOverride(t *testing.T) {
+	const partner = "0xabc0000000000000000000000000000000000001"
+	// Default burst 1; partner override burst 3. Rate kept tiny so refill does
+	// not interfere within the test.
+	limiter := NewPerUserRateLimiter(60, 1, map[string]RateOverride{partner: {Burst: 3}})
+
+	other := "0xdef0000000000000000000000000000000000002"
+	if !limiter.Allow(other) {
+		t.Fatal("default user first request should pass")
+	}
+	if limiter.Allow(other) {
+		t.Fatal("default user second request should be limited (burst 1)")
+	}
+
+	mixed := "0xABC0000000000000000000000000000000000001"
+	for i := 0; i < 3; i++ {
+		if !limiter.Allow(mixed) {
+			t.Fatalf("overridden partner request %d should pass (burst 3)", i+1)
+		}
+	}
+	if limiter.Allow(partner) {
+		t.Fatal("overridden partner should be limited after exhausting burst 3")
+	}
+}
+
+// TestEffectiveLimitReportsOverride verifies the override-aware accessors used
+// in client-facing 429 messages report the user's effective limit, not the
+// shared default.
+func TestEffectiveLimitReportsOverride(t *testing.T) {
+	const partner = "0xabc0000000000000000000000000000000000001"
+	other := "0xdef0000000000000000000000000000000000002"
+
+	rl := NewPerUserRateLimiter(30, 5, map[string]RateOverride{partner: {Rate: 120}})
+	if got := rl.EffectiveRPM(other); got != 30 {
+		t.Fatalf("default EffectiveRPM = %d, want 30", got)
+	}
+	if got := rl.EffectiveRPM("0xABC0000000000000000000000000000000000001"); got != 120 {
+		t.Fatalf("override EffectiveRPM = %d, want 120 (case-insensitive)", got)
+	}
+
+	tl := NewPerUserTPMLimiter(60000, 1000, map[string]RateOverride{partner: {Rate: 900000}})
+	defer tl.Stop()
+	if got := tl.EffectiveTPM(other); got != 60000 {
+		t.Fatalf("default EffectiveTPM = %d, want 60000", got)
+	}
+	if got := tl.EffectiveTPM(partner); got != 900000 {
+		t.Fatalf("override EffectiveTPM = %d, want 900000", got)
+	}
+}
+
+// TestOverrideHeaderLimitReflectsOverride locks the fix for the prior regression
+// where the X-RateLimit-Limit header used the shared default while Remaining was
+// already override-aware, so an uplifted user saw the wrong (default) limit. The
+// header limit must now reflect the user's override.
+//
+// Note: this does NOT assert Remaining <= Limit. Remaining reports the
+// token-bucket budget (burst), which can legitimately exceed the per-minute rate
+// (burst headroom) — true even for the default config when burst > rate. The
+// header pair is not required to satisfy Remaining <= Limit.
+func TestOverrideHeaderLimitReflectsOverride(t *testing.T) {
+	const partner = "0xabc0000000000000000000000000000000000001"
+
+	rl := NewPerUserRateLimiter(30, 5, map[string]RateOverride{partner: {Rate: 120}})
+	if got := rl.EffectiveRPM(partner); got != 120 {
+		t.Fatalf("header RPM limit = %d, want 120 (override, not default)", got)
+	}
+	if rl.EffectiveRPM(partner) == rl.DefaultRPM() {
+		t.Fatal("overridden user's header RPM limit must differ from the default")
+	}
+
+	tl := NewPerUserTPMLimiter(60000, 1000, map[string]RateOverride{partner: {Rate: 900000}})
+	defer tl.Stop()
+	if got := tl.EffectiveTPM(partner); got != 900000 {
+		t.Fatalf("header TPM limit = %d, want 900000 (override, not default)", got)
+	}
+	if tl.EffectiveTPM(partner) == tl.DefaultTPM() {
+		t.Fatal("overridden user's header TPM limit must differ from the default")
+	}
+}
+
+// TestPerUserTPMOverrideConsumeChunks verifies ConsumeTokens depletes the
+// overridden bucket using the limiter's own (larger) burst, so a partner with a
+// raised TPM burst is not throttled below their configured allowance.
+func TestPerUserTPMOverrideConsumeChunks(t *testing.T) {
+	const partner = "0xabc0000000000000000000000000000000000001"
+	// Default burst 100; partner burst 1000. Rate tiny to avoid refill noise.
+	limiter := NewPerUserTPMLimiter(600, 100, map[string]RateOverride{partner: {Burst: 1000}})
+	defer limiter.Stop()
+
+	// Partner has budget initially.
+	if !limiter.Allow(partner) {
+		t.Fatal("partner should have initial token budget")
+	}
+	// Consume 900 tokens — within the 1000 burst, so budget remains positive.
+	limiter.ConsumeTokens(partner, 900)
+	if !limiter.Allow(partner) {
+		t.Fatal("partner should still have budget after consuming 900 of 1000")
+	}
+	// Consume the remainder plus overflow — drives the bucket non-positive.
+	limiter.ConsumeTokens(partner, 200)
+	if limiter.Allow(partner) {
+		t.Fatal("partner should be out of budget after consuming beyond burst")
+	}
+}

--- a/api/common/middleware/per_user_ratelimit.go
+++ b/api/common/middleware/per_user_ratelimit.go
@@ -11,31 +11,66 @@ import (
 	"golang.org/x/time/rate"
 )
 
+// RateOverride specifies a per-address rate and burst that supersedes a
+// limiter's defaults. Rate is expressed in the limiter's natural per-minute
+// unit (RPM for the request limiter; TPM/IPM for the token limiter). A zero
+// field means "inherit the limiter default", so an override can raise only the
+// burst, only the rate, or both. Because 0 means inherit, an override cannot
+// set a rate of 0 to block a user; to throttle hard, configure a small positive
+// value rather than 0.
+type RateOverride struct {
+	Rate  int // per-minute rate; 0 = inherit default (cannot express "block")
+	Burst int // burst size; 0 = inherit default
+}
+
 // PerUserRateLimiter enforces a requests-per-minute limit for each user address.
 // This is the primary defense against cancel-retry abuse, where an attacker
 // sends requests and immediately cancels them to waste GPU resources.
 // Unlike concurrency limits (which only cap simultaneous in-flight requests),
 // rate limits cap the total request throughput per user over time.
+//
+// A per-address override map grants specific users a different rate/burst than
+// the shared default. Override keys are matched case-insensitively (the
+// constructor lowercases them).
 type PerUserRateLimiter struct {
-	limiters map[string]*rate.Limiter
-	mu       sync.Mutex
-	rate     rate.Limit // tokens per second
-	burst    int        // max burst size
+	limiters  map[string]*rate.Limiter
+	mu        sync.Mutex
+	rate      rate.Limit              // tokens per second
+	burst     int                     // max burst size
+	overrides map[string]RateOverride // normalized address -> override; nil if none
 }
 
 // NewPerUserRateLimiter creates a per-user rate limiter.
-// rpm: maximum requests per minute per user.
-// burst: maximum burst size (requests allowed in a short spike).
-func NewPerUserRateLimiter(rpm int, burst int) *PerUserRateLimiter {
+// rpm: default maximum requests per minute per user.
+// burst: default maximum burst size (requests allowed in a short spike).
+// overrides: optional per-address rate/burst; keys are lowercased internally so
+// any casing matches. Pass nil for none.
+func NewPerUserRateLimiter(rpm int, burst int, overrides map[string]RateOverride) *PerUserRateLimiter {
 	rl := &PerUserRateLimiter{
-		limiters: make(map[string]*rate.Limiter),
-		rate:     rate.Limit(float64(rpm) / 60.0), // convert RPM to per-second
-		burst:    burst,
+		limiters:  make(map[string]*rate.Limiter),
+		rate:      rate.Limit(float64(rpm) / 60.0), // convert RPM to per-second
+		burst:     burst,
+		overrides: normalizeOverrideKeys(overrides),
 	}
 
 	go rl.cleanup()
 
 	return rl
+}
+
+// limitsFor returns the effective rate and burst for a user, applying any
+// per-address override on top of the defaults.
+func (rl *PerUserRateLimiter) limitsFor(userID string) (rate.Limit, int) {
+	r, b := rl.rate, rl.burst
+	if ov, ok := rl.overrides[userID]; ok {
+		if ov.Rate > 0 {
+			r = rate.Limit(float64(ov.Rate) / 60.0)
+		}
+		if ov.Burst > 0 {
+			b = ov.Burst
+		}
+	}
+	return r, b
 }
 
 // cleanup periodically removes idle user entries to prevent memory growth.
@@ -46,8 +81,10 @@ func (rl *PerUserRateLimiter) cleanup() {
 	for range ticker.C {
 		rl.mu.Lock()
 		for userID, limiter := range rl.limiters {
-			// Remove users whose bucket is full (idle)
-			if limiter.Tokens() >= float64(rl.burst) {
+			// Remove users whose bucket is full (idle). Compare against the
+			// limiter's own burst so overridden users (which may carry a larger
+			// burst) are not evicted prematurely.
+			if limiter.Tokens() >= float64(limiter.Burst()) {
 				delete(rl.limiters, userID)
 			}
 		}
@@ -58,10 +95,12 @@ func (rl *PerUserRateLimiter) cleanup() {
 // Allow checks whether the user is within their rate limit.
 // Returns true if the request is allowed, false if rate limited.
 func (rl *PerUserRateLimiter) Allow(userID string) bool {
+	userID = normalizeUserID(userID)
 	rl.mu.Lock()
 	limiter, exists := rl.limiters[userID]
 	if !exists {
-		limiter = rate.NewLimiter(rl.rate, rl.burst)
+		r, b := rl.limitsFor(userID)
+		limiter = rate.NewLimiter(r, b)
 		rl.limiters[userID] = limiter
 	}
 	rl.mu.Unlock()
@@ -69,22 +108,34 @@ func (rl *PerUserRateLimiter) Allow(userID string) bool {
 	return limiter.Allow()
 }
 
-// RPM returns the configured requests-per-minute value.
-func (rl *PerUserRateLimiter) RPM() int {
+// DefaultRPM returns the configured default requests-per-minute value (the cap
+// for users without an override). For the limit actually enforced on a specific
+// user, use EffectiveRPM.
+func (rl *PerUserRateLimiter) DefaultRPM() int {
 	return int(math.Round(float64(rl.rate) * 60))
+}
+
+// EffectiveRPM returns the requests-per-minute limit in force for a user,
+// accounting for any per-address override, so client-facing messages report
+// the limit actually being enforced rather than the shared default.
+func (rl *PerUserRateLimiter) EffectiveRPM(userID string) int {
+	r, _ := rl.limitsFor(normalizeUserID(userID))
+	return int(math.Round(float64(r) * 60))
 }
 
 // GetRemainingWithReset returns the remaining request budget and reset time for a user.
 func (rl *PerUserRateLimiter) GetRemainingWithReset(userID string) (remaining int, resetSeconds float64) {
+	userID = normalizeUserID(userID)
 	rl.mu.Lock()
 	limiter, exists := rl.limiters[userID]
 	rl.mu.Unlock()
 	if !exists {
-		return rl.burst, 0
+		_, b := rl.limitsFor(userID)
+		return b, 0
 	}
 	tokens := limiter.Tokens()
 	if tokens < 0 {
-		resetSeconds = math.Abs(tokens) / float64(rl.rate)
+		resetSeconds = math.Abs(tokens) / float64(limiter.Limit())
 		return 0, resetSeconds
 	}
 	return int(tokens), 0
@@ -102,8 +153,8 @@ func CheckPerUserRateLimit(limiter *PerUserRateLimiter, c *gin.Context, userAddr
 		c.Set("ignoreError", true)
 
 		msg := fmt.Sprintf(
-			"Rate limit exceeded. Please slow down your request rate (limit: %.0f requests/min).",
-			float64(limiter.rate)*60,
+			"Rate limit exceeded. Please slow down your request rate (limit: %d requests/min).",
+			limiter.EffectiveRPM(userAddress),
 		)
 		path := c.Request.URL.Path
 		if IsAnthropicEndpoint(path) {

--- a/api/common/middleware/per_user_tpm_ratelimit.go
+++ b/api/common/middleware/per_user_tpm_ratelimit.go
@@ -21,34 +21,54 @@ import (
 // actual token count. If a large request drives the bucket deeply negative,
 // subsequent checks fail until enough time passes to refill.
 type PerUserTPMLimiter struct {
-	limiters map[string]*rate.Limiter
-	mu       sync.Mutex
-	rate     rate.Limit // tokens per second
-	burst    int        // max burst size (token count)
-	tpm      int        // original TPM value for display
-	stopCh   chan struct{}
-	stopOnce sync.Once
+	limiters  map[string]*rate.Limiter
+	mu        sync.Mutex
+	rate      rate.Limit              // tokens per second
+	burst     int                     // max burst size (token count)
+	tpm       int                     // original TPM value for display
+	overrides map[string]RateOverride // normalized address -> override; nil if none
+	stopCh    chan struct{}
+	stopOnce  sync.Once
 }
 
 // NewPerUserTPMLimiter creates a per-user token rate limiter.
-// tpm: maximum tokens per minute per user.
-// burst: maximum burst size (tokens allowed in a short spike).
-func NewPerUserTPMLimiter(tpm int, burst int) *PerUserTPMLimiter {
+// tpm: default maximum tokens per minute per user.
+// burst: default maximum burst size (tokens allowed in a short spike).
+// overrides: optional per-address rate/burst; keys are lowercased internally so
+// any casing matches. Pass nil for none.
+func NewPerUserTPMLimiter(tpm int, burst int, overrides map[string]RateOverride) *PerUserTPMLimiter {
 	if burst <= 0 {
 		burst = 1 // minimum burst of 1 token to prevent infinite loop in ConsumeTokens
 	}
 
 	rl := &PerUserTPMLimiter{
-		limiters: make(map[string]*rate.Limiter),
-		rate:     rate.Limit(float64(tpm) / 60.0), // convert TPM to per-second
-		burst:    burst,
-		tpm:      tpm,
-		stopCh:   make(chan struct{}),
+		limiters:  make(map[string]*rate.Limiter),
+		rate:      rate.Limit(float64(tpm) / 60.0), // convert TPM to per-second
+		burst:     burst,
+		tpm:       tpm,
+		overrides: normalizeOverrideKeys(overrides),
+		stopCh:    make(chan struct{}),
 	}
 
 	go rl.cleanup()
 
 	return rl
+}
+
+// limitsFor returns the effective rate and burst for a user, applying any
+// per-address override on top of the defaults. The returned burst is always
+// >= 1 so ConsumeTokens never loops forever.
+func (rl *PerUserTPMLimiter) limitsFor(userID string) (rate.Limit, int) {
+	r, b := rl.rate, rl.burst
+	if ov, ok := rl.overrides[userID]; ok {
+		if ov.Rate > 0 {
+			r = rate.Limit(float64(ov.Rate) / 60.0)
+		}
+		if ov.Burst > 0 {
+			b = ov.Burst
+		}
+	}
+	return r, b
 }
 
 // Stop gracefully shuts down the cleanup goroutine. Safe to call multiple times.
@@ -68,8 +88,10 @@ func (rl *PerUserTPMLimiter) cleanup() {
 		case <-ticker.C:
 			rl.mu.Lock()
 			for userID, limiter := range rl.limiters {
-				// Remove users whose bucket is full (idle)
-				if limiter.Tokens() >= float64(rl.burst) {
+				// Remove users whose bucket is full (idle). Compare against the
+				// limiter's own burst so overridden users (which may carry a
+				// larger burst) are not evicted prematurely.
+				if limiter.Tokens() >= float64(limiter.Burst()) {
 					delete(rl.limiters, userID)
 				}
 			}
@@ -82,10 +104,12 @@ func (rl *PerUserTPMLimiter) cleanup() {
 
 // getLimiter returns the rate limiter for a user, creating one if needed.
 func (rl *PerUserTPMLimiter) getLimiter(userID string) *rate.Limiter {
+	userID = normalizeUserID(userID)
 	rl.mu.Lock()
 	limiter, exists := rl.limiters[userID]
 	if !exists {
-		limiter = rate.NewLimiter(rl.rate, rl.burst)
+		r, b := rl.limitsFor(userID)
+		limiter = rate.NewLimiter(r, b)
 		rl.limiters[userID] = limiter
 	}
 	rl.mu.Unlock()
@@ -107,12 +131,13 @@ func (rl *PerUserTPMLimiter) ConsumeTokens(userID string, tokens int) {
 		return
 	}
 	limiter := rl.getLimiter(userID)
+	burst := limiter.Burst() // may differ from rl.burst for overridden users
 	now := time.Now()
 	remaining := tokens
 	for remaining > 0 {
 		n := remaining
-		if n > rl.burst {
-			n = rl.burst
+		if n > burst {
+			n = burst
 		}
 		limiter.ReserveN(now, n)
 		remaining -= n
@@ -122,23 +147,36 @@ func (rl *PerUserTPMLimiter) ConsumeTokens(userID string, tokens int) {
 // GetRemaining returns the remaining token budget and estimated reset time for a user.
 // This is a read-only operation that does not create a limiter entry for unknown users.
 func (rl *PerUserTPMLimiter) GetRemaining(userID string) (remaining int, resetSeconds float64) {
+	userID = normalizeUserID(userID)
 	rl.mu.Lock()
 	limiter, exists := rl.limiters[userID]
 	rl.mu.Unlock()
 	if !exists {
-		return rl.burst, 0
+		_, b := rl.limitsFor(userID)
+		return b, 0
 	}
 	tokens := limiter.Tokens()
 	if tokens < 0 {
-		resetSeconds = math.Abs(tokens) / float64(rl.rate)
+		resetSeconds = math.Abs(tokens) / float64(limiter.Limit())
 		return 0, resetSeconds
 	}
 	return int(tokens), 0
 }
 
-// TPM returns the configured tokens-per-minute value.
-func (rl *PerUserTPMLimiter) TPM() int {
+// DefaultTPM returns the configured default per-minute value (tokens for a TPM
+// limiter, images for an IPM limiter) — the cap for users without an override.
+// For the limit actually enforced on a specific user, use EffectiveTPM.
+func (rl *PerUserTPMLimiter) DefaultTPM() int {
 	return rl.tpm
+}
+
+// EffectiveTPM returns the per-minute limit in force for a user (tokens for a
+// TPM limiter, images for an IPM limiter), accounting for any per-address
+// override, so client-facing messages report the enforced limit rather than the
+// shared default.
+func (rl *PerUserTPMLimiter) EffectiveTPM(userID string) int {
+	r, _ := rl.limitsFor(normalizeUserID(userID))
+	return int(math.Round(float64(r) * 60))
 }
 
 // CheckPerUserTPMLimit checks per-user TPM limit for token-based services (chatbot, speech-to-text).
@@ -160,14 +198,14 @@ func CheckPerUserTPMLimit(limiter *PerUserTPMLimiter, c *gin.Context, userAddres
 				"type": "error",
 				"error": gin.H{
 					"type":    "rate_limit_error",
-					"message": fmt.Sprintf("Token rate limit exceeded. Please wait %.0f seconds (limit: %d tokens/min).", resetSecs, limiter.tpm),
+					"message": fmt.Sprintf("Token rate limit exceeded. Please wait %.0f seconds (limit: %d tokens/min).", resetSecs, limiter.EffectiveTPM(userAddress)),
 				},
 			})
 		} else {
 			c.JSON(http.StatusTooManyRequests, gin.H{
 				"error": gin.H{
 					"type":    "rate_limit_error",
-					"message": fmt.Sprintf("Token rate limit exceeded. Please wait %.0f seconds (limit: %d tokens/min).", resetSecs, limiter.tpm),
+					"message": fmt.Sprintf("Token rate limit exceeded. Please wait %.0f seconds (limit: %d tokens/min).", resetSecs, limiter.EffectiveTPM(userAddress)),
 				},
 			})
 		}
@@ -196,14 +234,14 @@ func CheckPerUserIPMLimit(limiter *PerUserTPMLimiter, c *gin.Context, userAddres
 				"type": "error",
 				"error": gin.H{
 					"type":    "rate_limit_error",
-					"message": fmt.Sprintf("Image rate limit exceeded. Please wait %.0f seconds (limit: %d images/min).", resetSecs, limiter.tpm),
+					"message": fmt.Sprintf("Image rate limit exceeded. Please wait %.0f seconds (limit: %d images/min).", resetSecs, limiter.EffectiveTPM(userAddress)),
 				},
 			})
 		} else {
 			c.JSON(http.StatusTooManyRequests, gin.H{
 				"error": gin.H{
 					"type":    "rate_limit_error",
-					"message": fmt.Sprintf("Image rate limit exceeded. Please wait %.0f seconds (limit: %d images/min).", resetSecs, limiter.tpm),
+					"message": fmt.Sprintf("Image rate limit exceeded. Please wait %.0f seconds (limit: %d images/min).", resetSecs, limiter.EffectiveTPM(userAddress)),
 				},
 			})
 		}

--- a/api/inference/config/config.go
+++ b/api/inference/config/config.go
@@ -466,6 +466,34 @@ type ConcurrencyLimitConfig struct {
 	PerUserTPMBurst      int `yaml:"perUserTPMBurst"`      // Max burst size for per-user TPM limit (default: 0)
 	PerUserIPM           int `yaml:"perUserIPM"`           // Max images per minute per user (default: 0 = disabled, text-to-image/image-editing)
 	PerUserIPMBurst      int `yaml:"perUserIPMBurst"`      // Max burst size for per-user IPM limit (default: 0)
+
+	// PerUserOverrides grants specific addresses different per-user limits than
+	// the shared defaults above, without changing the limit for everyone else.
+	// Intended for heavy partners who legitimately need more headroom. Overrides
+	// only take effect for dimensions that are globally enabled (e.g. an RPM
+	// override is ignored when PerUserRPM == 0). Overrides never raise the global
+	// concurrency cap (MaxGlobalConcurrent), so a single user still cannot exceed
+	// total backend capacity.
+	PerUserOverrides []PerUserLimitOverride `yaml:"perUserOverrides"`
+}
+
+// PerUserLimitOverride sets the per-user limits for a single address. A zero
+// field inherits the corresponding global default, so an operator can override
+// only the dimension they care about (e.g. just MaxConcurrent). A positive
+// value below the default lowers the cap for that user; because 0 means
+// inherit, a limit cannot be set to exactly 0 (to throttle hard, use a small
+// positive value). Negative values are invalid and treated as inherit (with a
+// startup warning). Addresses are matched case-insensitively; a malformed
+// address is rejected at startup with a warning.
+type PerUserLimitOverride struct {
+	UserAddress   string `yaml:"userAddress"`   // Address this override applies to (case-insensitive)
+	MaxConcurrent int    `yaml:"maxConcurrent"` // Per-user concurrency cap (0 = inherit MaxPerUserConcurrent)
+	RPM           int    `yaml:"rpm"`           // Requests per minute (0 = inherit PerUserRPM)
+	Burst         int    `yaml:"burst"`         // RPM burst size (0 = inherit PerUserBurst)
+	TPM           int    `yaml:"tpm"`           // Tokens per minute (0 = inherit PerUserTPM)
+	TPMBurst      int    `yaml:"tpmBurst"`      // TPM burst size (0 = inherit PerUserTPMBurst)
+	IPM           int    `yaml:"ipm"`           // Images per minute (0 = inherit PerUserIPM)
+	IPMBurst      int    `yaml:"ipmBurst"`      // IPM burst size (0 = inherit PerUserIPMBurst)
 }
 
 // AsyncConfig defines configuration for async job processing.
@@ -1036,6 +1064,7 @@ func GetConfig() *Config {
 				PerUserTPMBurst:      0,
 				PerUserIPM:           0, // disabled by default
 				PerUserIPMBurst:      0,
+				PerUserOverrides:     nil,
 			},
 			Async: AsyncConfig{
 				Enabled:           true,

--- a/api/inference/internal/proxy/override_build_test.go
+++ b/api/inference/internal/proxy/override_build_test.go
@@ -1,0 +1,53 @@
+package proxy
+
+import (
+	"testing"
+
+	"github.com/0glabs/0g-serving-broker/inference/config"
+)
+
+// TestBuildPerUserOverrides verifies address validation, casing normalization,
+// TPM-burst flooring, and that invalid / empty / no-op entries are dropped
+// rather than silently stored under a key no real user can match.
+func TestBuildPerUserOverrides(t *testing.T) {
+	const ctxLen = 1000
+	const partnerLower = "0xabc0000000000000000000000000000000000001"
+
+	overrides := []config.PerUserLimitOverride{
+		{UserAddress: "0xABC0000000000000000000000000000000000001", MaxConcurrent: 40, TPM: 900000, TPMBurst: 500},
+		{UserAddress: "not-an-address", MaxConcurrent: 99},          // invalid -> skipped
+		{UserAddress: "   ", MaxConcurrent: 99},                     // empty -> skipped
+		{UserAddress: "0xDEF0000000000000000000000000000000000002"}, // no positive limits -> no-op, skipped
+	}
+
+	conc, rpm, tpm, ipm := buildPerUserOverrides(overrides, ctxLen, noopLogger{})
+
+	// Valid entry stored under the lowercase key.
+	if conc[partnerLower] != 40 {
+		t.Fatalf("conc[%s] = %d, want 40", partnerLower, conc[partnerLower])
+	}
+	// TPM burst floored up to context length (500 -> 1000); rate preserved.
+	if got := tpm[partnerLower]; got.Burst != ctxLen || got.Rate != 900000 {
+		t.Fatalf("tpm override = %+v, want {Rate:900000 Burst:1000}", got)
+	}
+	// Only the one valid entry survives; invalid/empty/no-op are absent.
+	if len(conc) != 1 {
+		t.Fatalf("conc map size = %d, want 1 (invalid/empty/no-op must be skipped)", len(conc))
+	}
+	if _, ok := conc["0xdef0000000000000000000000000000000000002"]; ok {
+		t.Fatal("no-op entry (no positive limits) should not be stored")
+	}
+	// No RPM/IPM fields were set on the valid entry, so those maps stay empty.
+	if len(rpm) != 0 || len(ipm) != 0 {
+		t.Fatalf("rpm=%d ipm=%d, want both 0", len(rpm), len(ipm))
+	}
+}
+
+// TestBuildPerUserOverrides_Empty verifies the no-overrides path returns nil
+// maps (the "no overrides" sentinel the limiters expect).
+func TestBuildPerUserOverrides_Empty(t *testing.T) {
+	conc, rpm, tpm, ipm := buildPerUserOverrides(nil, 1000, noopLogger{})
+	if conc != nil || rpm != nil || tpm != nil || ipm != nil {
+		t.Fatalf("expected all nil maps for empty input, got conc=%v rpm=%v tpm=%v ipm=%v", conc, rpm, tpm, ipm)
+	}
+}

--- a/api/inference/internal/proxy/proxy.go
+++ b/api/inference/internal/proxy/proxy.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/gin-contrib/cors"
 	"github.com/google/uuid"
 	"golang.org/x/time/rate"
@@ -63,6 +64,16 @@ func New(ctrl *ctrl.Ctrl, engine *gin.Engine, allowOrigins []string, enableMonit
 		concurrencyConfig.MaxPerUserConcurrent = 5
 	}
 
+	// Resolve per-address overrides into one map per limiter dimension. Keys are
+	// lowercase addresses; only dimensions whose global limiter is enabled below
+	// will actually consult these maps.
+	contextLength := 0
+	if ctrl.Service.ModelInfo != nil {
+		contextLength = ctrl.Service.ModelInfo.ContextLength
+	}
+	concOverrides, rpmOverrides, tpmOverrides, ipmOverrides := buildPerUserOverrides(
+		concurrencyConfig.PerUserOverrides, contextLength, logger)
+
 	p := &Proxy{
 		allowOrigins: allowOrigins,
 		ctrl:         ctrl,
@@ -72,7 +83,7 @@ func New(ctrl *ctrl.Ctrl, engine *gin.Engine, allowOrigins []string, enableMonit
 		rateLimiter: middleware.NewRateLimiter(rate.Limit(15), 20),
 		// Configure concurrency limiter to match backend GPU capacity
 		concurrencyLimiter:        middleware.NewConcurrencyLimiter(concurrencyConfig.MaxGlobalConcurrent),
-		perUserConcurrencyLimiter: middleware.NewPerUserConcurrencyLimiter(concurrencyConfig.MaxPerUserConcurrent),
+		perUserConcurrencyLimiter: middleware.NewPerUserConcurrencyLimiter(concurrencyConfig.MaxPerUserConcurrent, concOverrides),
 	}
 
 	// Initialize per-user rate limiter if configured
@@ -81,7 +92,7 @@ func New(ctrl *ctrl.Ctrl, engine *gin.Engine, allowOrigins []string, enableMonit
 		if burst <= 0 {
 			burst = 10
 		}
-		p.perUserRateLimiter = middleware.NewPerUserRateLimiter(concurrencyConfig.PerUserRPM, burst)
+		p.perUserRateLimiter = middleware.NewPerUserRateLimiter(concurrencyConfig.PerUserRPM, burst, rpmOverrides)
 		logger.Infof("Per-user rate limit: %d RPM, burst=%d", concurrencyConfig.PerUserRPM, burst)
 	}
 
@@ -96,12 +107,12 @@ func New(ctrl *ctrl.Ctrl, engine *gin.Engine, allowOrigins []string, enableMonit
 		}
 		// Ensure burst >= context_length so a single max-context request doesn't
 		// drive the bucket deeply negative and cause excessive lockout.
-		if ctrl.Service.ModelInfo != nil && ctrl.Service.ModelInfo.ContextLength > tpmBurst {
+		if contextLength > tpmBurst {
 			logger.Infof("TPM burst %d < context_length %d, raising burst to context_length",
-				tpmBurst, ctrl.Service.ModelInfo.ContextLength)
-			tpmBurst = ctrl.Service.ModelInfo.ContextLength
+				tpmBurst, contextLength)
+			tpmBurst = contextLength
 		}
-		p.perUserTPMLimiter = middleware.NewPerUserTPMLimiter(concurrencyConfig.PerUserTPM, tpmBurst)
+		p.perUserTPMLimiter = middleware.NewPerUserTPMLimiter(concurrencyConfig.PerUserTPM, tpmBurst, tpmOverrides)
 		logger.Infof("Per-user token limit: %d TPM, burst=%d", concurrencyConfig.PerUserTPM, tpmBurst)
 	}
 
@@ -114,8 +125,22 @@ func New(ctrl *ctrl.Ctrl, engine *gin.Engine, allowOrigins []string, enableMonit
 				ipmBurst = 1
 			}
 		}
-		p.perUserIPMLimiter = middleware.NewPerUserTPMLimiter(concurrencyConfig.PerUserIPM, ipmBurst)
+		p.perUserIPMLimiter = middleware.NewPerUserTPMLimiter(concurrencyConfig.PerUserIPM, ipmBurst, ipmOverrides)
 		logger.Infof("Per-user image limit: %d IPM, burst=%d", concurrencyConfig.PerUserIPM, ipmBurst)
+	}
+
+	// Warn about overrides that target a globally-disabled dimension: they were
+	// parsed and Info-logged, but no limiter consults them, so they silently take
+	// no effect. Surfacing this prevents an operator from believing a partner was
+	// uplifted when the corresponding global limit is off.
+	if len(rpmOverrides) > 0 && p.perUserRateLimiter == nil {
+		logger.Warnf("PerUserOverride: %d RPM override(s) set but perUserRPM is disabled (0); they will NOT take effect", len(rpmOverrides))
+	}
+	if len(tpmOverrides) > 0 && p.perUserTPMLimiter == nil {
+		logger.Warnf("PerUserOverride: %d TPM override(s) set but perUserTPM is disabled (0); they will NOT take effect", len(tpmOverrides))
+	}
+	if len(ipmOverrides) > 0 && p.perUserIPMLimiter == nil {
+		logger.Warnf("PerUserOverride: %d IPM override(s) set but perUserIPM is disabled (0); they will NOT take effect", len(ipmOverrides))
 	}
 
 	// Per-IP limit for the unauthenticated image-serve route. Chosen loose so
@@ -124,7 +149,7 @@ func New(ctrl *ctrl.Ctrl, engine *gin.Engine, allowOrigins []string, enableMonit
 	// 120 * image_size per IP per minute; tighten via config if ever needed.
 	// Keyed by client IP; the IP field lives outside the per-user keyspace so
 	// it never starves user-scoped limits.
-	p.imageServeLimiter = middleware.NewPerUserRateLimiter(120, 30)
+	p.imageServeLimiter = middleware.NewPerUserRateLimiter(120, 30, nil)
 
 	logger.Infof("Concurrency limits: global=%d, per-user=%d",
 		concurrencyConfig.MaxGlobalConcurrent, concurrencyConfig.MaxPerUserConcurrent)
@@ -178,6 +203,94 @@ func New(ctrl *ctrl.Ctrl, engine *gin.Engine, allowOrigins []string, enableMonit
 	}
 
 	return p
+}
+
+// buildPerUserOverrides converts the operator-supplied per-address override
+// list into one map per limiter dimension, keyed by lowercase address. A zero
+// field in an entry means "inherit the global default", so it is simply not
+// written into that dimension's map. TPM bursts are floored to context_length
+// (matching the default-burst logic) so a single max-context request from an
+// overridden user does not drive their bucket deeply negative.
+//
+// Entries are still recorded for dimensions that may be globally disabled; the
+// caller only wires a map into a limiter that it actually constructs, so an
+// override for a disabled dimension is harmlessly ignored.
+func buildPerUserOverrides(overrides []config.PerUserLimitOverride, contextLength int, logger log.Logger) (
+	conc map[string]int,
+	rpm, tpm, ipm map[string]middleware.RateOverride,
+) {
+	if len(overrides) == 0 {
+		return nil, nil, nil, nil
+	}
+
+	conc = make(map[string]int)
+	rpm = make(map[string]middleware.RateOverride)
+	tpm = make(map[string]middleware.RateOverride)
+	ipm = make(map[string]middleware.RateOverride)
+
+	seen := make(map[string]struct{})
+	for _, o := range overrides {
+		raw := strings.TrimSpace(o.UserAddress)
+		// Validate the address format the same way the whitelist path does, so a
+		// typo'd / malformed address is rejected with an operator-visible warning
+		// rather than being silently stored under a key no real user can match.
+		if !ethcommon.IsHexAddress(raw) {
+			logger.Warnf("PerUserOverride: invalid address format %q, skipping", o.UserAddress)
+			continue
+		}
+		addr := strings.ToLower(raw)
+		if _, dup := seen[addr]; dup {
+			logger.Warnf("PerUserOverride: duplicate entry for %s, later entry overrides earlier", truncateAddr(addr))
+		}
+		seen[addr] = struct{}{}
+
+		// A negative value is never a valid "inherit" request (0 means inherit);
+		// surface it so a templating bug producing -1 doesn't silently degrade a
+		// partner to the default limits.
+		if o.MaxConcurrent < 0 || o.RPM < 0 || o.Burst < 0 || o.TPM < 0 || o.TPMBurst < 0 || o.IPM < 0 || o.IPMBurst < 0 {
+			logger.Warnf("PerUserOverride %s: negative value(s) treated as inherit-default", truncateAddr(addr))
+		}
+
+		applied := false
+		if o.MaxConcurrent > 0 {
+			conc[addr] = o.MaxConcurrent
+			applied = true
+		}
+		if o.RPM > 0 || o.Burst > 0 {
+			rpm[addr] = middleware.RateOverride{Rate: o.RPM, Burst: o.Burst}
+			applied = true
+		}
+		if o.TPM > 0 || o.TPMBurst > 0 {
+			tpmBurst := o.TPMBurst
+			if tpmBurst > 0 && contextLength > tpmBurst {
+				tpmBurst = contextLength
+			}
+			tpm[addr] = middleware.RateOverride{Rate: o.TPM, Burst: tpmBurst}
+			applied = true
+		}
+		if o.IPM > 0 || o.IPMBurst > 0 {
+			ipm[addr] = middleware.RateOverride{Rate: o.IPM, Burst: o.IPMBurst}
+			applied = true
+		}
+		if !applied {
+			logger.Warnf("PerUserOverride %s: no positive limits set, entry is a no-op (check for typo'd field names)", truncateAddr(addr))
+			continue
+		}
+		logger.Infof("PerUserOverride: %s concurrent=%d rpm=%d/%d tpm=%d/%d ipm=%d/%d",
+			truncateAddr(addr), o.MaxConcurrent, o.RPM, o.Burst, o.TPM, o.TPMBurst, o.IPM, o.IPMBurst)
+	}
+
+	return conc, rpm, tpm, ipm
+}
+
+// truncateAddr shortens an Ethereum address for logging (first 6 + last 4
+// characters), following the CLAUDE.md guidance to avoid logging full
+// addresses. Short or empty inputs are returned unchanged.
+func truncateAddr(addr string) string {
+	if len(addr) <= 12 {
+		return addr
+	}
+	return addr[:6] + "…" + addr[len(addr)-4:]
 }
 
 // Close releases resources held by the Proxy (e.g., background goroutines).
@@ -436,7 +549,10 @@ func (p *Proxy) proxyHTTPRequest(ctx *gin.Context) {
 		if p.perUserRateLimiter != nil {
 			remaining, resetSecs := p.perUserRateLimiter.GetRemainingWithReset(userAddress)
 			rpmInfo = &middleware.RateLimitInfo{
-				Limit:     p.perUserRateLimiter.RPM(),
+				// Effective (override-aware) limit so the X-RateLimit-Limit header
+				// stays consistent with the override-aware Remaining below; otherwise
+				// an uplifted user could see Remaining > Limit.
+				Limit:     p.perUserRateLimiter.EffectiveRPM(userAddress),
 				Remaining: remaining,
 				ResetSecs: resetSecs,
 			}
@@ -449,7 +565,7 @@ func (p *Proxy) proxyHTTPRequest(ctx *gin.Context) {
 			if p.perUserTPMLimiter != nil {
 				remaining, resetSecs := p.perUserTPMLimiter.GetRemaining(userAddress)
 				resourceInfo = &middleware.RateLimitInfo{
-					Limit:     p.perUserTPMLimiter.TPM(),
+					Limit:     p.perUserTPMLimiter.EffectiveTPM(userAddress),
 					Remaining: remaining,
 					ResetSecs: resetSecs,
 				}
@@ -459,7 +575,7 @@ func (p *Proxy) proxyHTTPRequest(ctx *gin.Context) {
 			if p.perUserIPMLimiter != nil {
 				remaining, resetSecs := p.perUserIPMLimiter.GetRemaining(userAddress)
 				resourceInfo = &middleware.RateLimitInfo{
-					Limit:     p.perUserIPMLimiter.TPM(),
+					Limit:     p.perUserIPMLimiter.EffectiveTPM(userAddress),
 					Remaining: remaining,
 					ResetSecs: resetSecs,
 				}

--- a/api/inference/internal/proxy/proxy_test.go
+++ b/api/inference/internal/proxy/proxy_test.go
@@ -64,13 +64,13 @@ func TestTargetRoute_VideoSubpathsNotInTargetRoute(t *testing.T) {
 
 func TestAuthRequiredPrefixes_MatchesVideoSubpaths(t *testing.T) {
 	tests := []struct {
-		path      string
+		path        string
 		shouldMatch bool
 	}{
 		{"/videos/video-123", true},
 		{"/videos/video-123/content", true},
 		{"/videos/", true},
-		{"/videos", false},           // exact /videos goes through TargetRoute
+		{"/videos", false},             // exact /videos goes through TargetRoute
 		{"/attestation/report", false}, // should NOT match auth prefix
 		{"/images/generations", false}, // should NOT match auth prefix
 	}
@@ -142,22 +142,22 @@ func (noopLogger) Warningf(string, ...interface{}) {}
 func (noopLogger) Errorf(string, ...interface{})   {}
 func (noopLogger) Fatalf(string, ...interface{})   {}
 func (noopLogger) Panicf(string, ...interface{})   {}
-func (noopLogger) Debug(...interface{})             {}
-func (noopLogger) Info(...interface{})              {}
-func (noopLogger) Print(...interface{})             {}
-func (noopLogger) Warn(...interface{})              {}
-func (noopLogger) Warning(...interface{})           {}
-func (noopLogger) Error(...interface{})             {}
-func (noopLogger) Fatal(...interface{})             {}
-func (noopLogger) Panic(...interface{})             {}
-func (noopLogger) Debugln(...interface{})           {}
-func (noopLogger) Infoln(...interface{})            {}
-func (noopLogger) Println(...interface{})           {}
-func (noopLogger) Warnln(...interface{})            {}
-func (noopLogger) Warningln(...interface{})         {}
-func (noopLogger) Errorln(...interface{})           {}
-func (noopLogger) Fatalln(...interface{})           {}
-func (noopLogger) Panicln(...interface{})           {}
+func (noopLogger) Debug(...interface{})            {}
+func (noopLogger) Info(...interface{})             {}
+func (noopLogger) Print(...interface{})            {}
+func (noopLogger) Warn(...interface{})             {}
+func (noopLogger) Warning(...interface{})          {}
+func (noopLogger) Error(...interface{})            {}
+func (noopLogger) Fatal(...interface{})            {}
+func (noopLogger) Panic(...interface{})            {}
+func (noopLogger) Debugln(...interface{})          {}
+func (noopLogger) Infoln(...interface{})           {}
+func (noopLogger) Println(...interface{})          {}
+func (noopLogger) Warnln(...interface{})           {}
+func (noopLogger) Warningln(...interface{})        {}
+func (noopLogger) Errorln(...interface{})          {}
+func (noopLogger) Fatalln(...interface{})          {}
+func (noopLogger) Panicln(...interface{})          {}
 
 func (n noopLogger) WithFields(_ logrus.Fields) log.Logger { return n }
 func (noopLogger) InnerLogger() *logrus.Logger             { return logrus.New() }
@@ -285,7 +285,7 @@ func TestHandleImageServeRoute_ShapeFailDoesNotConsumeRateLimit(t *testing.T) {
 	// Budget of 1 per "minute" at 60 RPM, burst 1 — simulates a drained bucket
 	// if the shape-fail path consumed a token. Using PerUserRateLimiter so we
 	// depend on the production primitive, not a test fake.
-	p.imageServeLimiter = middleware.NewPerUserRateLimiter(60, 1)
+	p.imageServeLimiter = middleware.NewPerUserRateLimiter(60, 1, nil)
 
 	// 3 shape-fail requests with the same RemoteAddr. Each SHOULD return false
 	// (unhandled) without touching the limiter.


### PR DESCRIPTION
## Why

A heavy partner connecting **directly** to the provider broker keeps hitting the per-user concurrency cap (`Too many concurrent requests... limit: 10`). Today the broker only has two tiers — a shared default for everyone, or full whitelist exemption — so we can't give one partner more headroom without either raising the default for *all* users (rejected) or letting them saturate the single GPU. Multiple API keys don't help either: per-user limits key on the **wallet address**, and all of a wallet's tokens share one bucket.

This adds a middle tier: **per-address overrides** that raise (or lower) one user's limits while leaving everyone else on the default and keeping them bounded by the global concurrency cap.

## What

- **Config** (`ConcurrencyLimitConfig.PerUserOverrides`): a list of per-address `{maxConcurrent, rpm, burst, tpm, tpmBurst, ipm, ipmBurst}`. A `0` field inherits the global default, so you can override just the dimension you care about. `0` means *inherit* (not "block") — to throttle hard, use a small positive value; negatives are treated as inherit with a startup warning.
- **Limiters**: the three per-user limiters accept an optional override map. Keys are lowercased **inside the constructor**, and every limiter entry point normalizes the lookup key, so an override matches regardless of address casing and a single address always maps to one bucket. An override only takes effect for a dimension whose global limiter is enabled; an override on a disabled dimension is warned about at startup.
- **Safety**: the global concurrency semaphore is independent of overrides — an uplifted user is still bounded by total backend (single-GPU) capacity.
- **Wiring** (`buildPerUserOverrides`): validates each address with `common.IsHexAddress` (skip + warn on malformed, matching the existing whitelist path), warns on duplicate / negative / no-op entries, floors TPM burst to `context_length`, logs truncated addresses.
- **Client signals**: `X-RateLimit-Limit` headers and 429 messages now report the user's **effective** (override-aware) limit via new `EffectiveRPM`/`EffectiveTPM` accessors. The former default accessors are renamed `DefaultRPM`/`DefaultTPM` so the default-vs-effective distinction is explicit at every call site.

## Example config

```yaml
concurrencyLimit:
  maxGlobalConcurrent: 64
  maxPerUserConcurrent: 10      # everyone else unchanged
  perUserRPM: 200
  perUserTPM: 800000
  perUserOverrides:
    - userAddress: "0x<partner-wallet>"
      maxConcurrent: 40          # raised for this partner, still < global 64
      # rpm/tpm omitted -> inherit defaults
```

## Tests

New tests cover override matching, case-insensitive keying, constructor key normalization, TPM burst flooring + consumption chunking, effective-limit reporting, and address validation / no-op rejection in `buildPerUserOverrides`. `go build ./...`, `go vet`, and `go test ./common/... ./inference/...` all pass.

## Review

Went through 5 rounds of deep review (general correctness, security differential, silent-failure, API sharp-edges) until two consecutive rounds were clean. HIGH-level findings fixed along the way: address validation parity with the whitelist path, constructor key normalization (mixed-case footgun), and the `X-RateLimit-Limit` header using the default instead of the effective limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)