### PR TITLE
feat(inference): classified rejection metric + bounded rejection logging (#542)

### DIFF
--- a/api/inference/internal/ctrl/request.go
+++ b/api/inference/internal/ctrl/request.go
@@ -19,6 +19,7 @@ import (
 	constant "github.com/0glabs/0g-serving-broker/inference/const"
 	"github.com/0glabs/0g-serving-broker/inference/contract"
 	"github.com/0glabs/0g-serving-broker/inference/model"
+	"github.com/0glabs/0g-serving-broker/inference/monitor"
 )
 
 // EphemeralTokenId is the special token ID reserved for ephemeral tokens.
@@ -281,6 +282,7 @@ func (c *Ctrl) ValidateRequestWithEstimatedFee(ctx *gin.Context, req model.Reque
 		fetchedAccount, err := c.contract.GetUserAccount(ctx, userAddress)
 		if err != nil {
 			ctx.Set("ignoreError", true)
+			ctx.Set(monitor.CtxKeyRejectionReason, monitor.RejectionAccountNotExist)
 			return errors.Wrap(err, "get account from contract, account not exist")
 		}
 		contractAccount = &fetchedAccount
@@ -292,6 +294,7 @@ func (c *Ctrl) ValidateRequestWithEstimatedFee(ctx *gin.Context, req model.Reque
 	if contractAccount.Acknowledged == false {
 		// User-caused error: user hasn't acknowledged the provider
 		ctx.Set("ignoreError", true)
+		ctx.Set(monitor.CtxKeyRejectionReason, monitor.RejectionNotAcknowledged)
 		return errors.New("user not acknowledge the provider, please use acknowledgeProviderSigner function in sdk first, it will take effect in 2 minutes")
 	}
 
@@ -419,6 +422,7 @@ func (c *Ctrl) validateBalanceAdequacy(ctx *gin.Context, account model.User, fee
 		return nil
 	}
 	ctx.Set("ignoreError", true)
+	ctx.Set(monitor.CtxKeyRejectionReason, monitor.RejectionInsufficientBal)
 
 	// Convert neuron to 0G for display (1 0G = 10^18 neuron)
 	divisor := new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)

--- a/api/inference/internal/ctrl/request.go
+++ b/api/inference/internal/ctrl/request.go
@@ -281,6 +281,11 @@ func (c *Ctrl) ValidateRequestWithEstimatedFee(ctx *gin.Context, req model.Reque
 	if contractAccount == nil {
 		fetchedAccount, err := c.contract.GetUserAccount(ctx, userAddress)
 		if err != nil {
+			// Any GetUserAccount failure is labeled account_not_exist (the
+			// dominant cause — a not-yet-funded user). A transport/RPC failure
+			// would also land here, but GetUserAccount already logs the
+			// underlying error at error level regardless of ignoreError, so it
+			// is not silenced — see docs/design/rejection-observability.md.
 			ctx.Set("ignoreError", true)
 			ctx.Set(monitor.CtxKeyRejectionReason, monitor.RejectionAccountNotExist)
 			return errors.Wrap(err, "get account from contract, account not exist")

--- a/api/inference/internal/proxy/proxy.go
+++ b/api/inference/internal/proxy/proxy.go
@@ -48,6 +48,12 @@ type Proxy struct {
 	// caller hammering a single chatKey. Reuses PerUserRateLimiter with IP as
 	// the key — see handleImageServeRoute.
 	imageServeLimiter *middleware.PerUserRateLimiter
+
+	// rejections records and periodically summarizes rejected requests. It
+	// replaces the per-request rejection warnings (one log line per rejection,
+	// unbounded under a flood) with a Prometheus counter plus a bounded
+	// periodic summary log. See rejection.go.
+	rejections *rejectionAggregator
 }
 
 func New(ctrl *ctrl.Ctrl, engine *gin.Engine, allowOrigins []string, enableMonitor bool, concurrencyConfig config.ConcurrencyLimitConfig, logger log.Logger) *Proxy {
@@ -150,6 +156,8 @@ func New(ctrl *ctrl.Ctrl, engine *gin.Engine, allowOrigins []string, enableMonit
 	// Keyed by client IP; the IP field lives outside the per-user keyspace so
 	// it never starves user-scoped limits.
 	p.imageServeLimiter = middleware.NewPerUserRateLimiter(120, 30, nil)
+
+	p.rejections = newRejectionAggregator(logger, rejectionFlushInterval)
 
 	logger.Infof("Concurrency limits: global=%d, per-user=%d",
 		concurrencyConfig.MaxGlobalConcurrent, concurrencyConfig.MaxPerUserConcurrent)
@@ -301,6 +309,9 @@ func (p *Proxy) Close() {
 	}
 	if p.perUserIPMLimiter != nil {
 		p.perUserIPMLimiter.Stop()
+	}
+	if p.rejections != nil {
+		p.rejections.stop()
 	}
 }
 
@@ -506,21 +517,24 @@ func (p *Proxy) proxyHTTPRequest(ctx *gin.Context) {
 	// blocking critical operations, but still subject to the global limit.
 	// Rate limit is checked first (cheap, no slot to release) before concurrency.
 	if !isWhitelisted {
+		// Per-event rejection logging was removed here: under a sustained
+		// rate-limit flood it produced one log line per request (the 150k-line
+		// log-amplification vector in #542). Rejections are now recorded to the
+		// Prometheus counter and summarized periodically by p.rejections.
 		if !middleware.CheckPerUserRateLimit(p.perUserRateLimiter, ctx, userAddress) {
-			p.logger.Warnf("Per-user rate limit exceeded: user=%s", userAddress)
+			p.rejections.record(monitor.RejectionRateLimit, userAddress)
 			return
 		}
 		if !middleware.CheckPerUserTPMLimit(p.perUserTPMLimiter, ctx, userAddress, svcType) {
-			p.logger.Warnf("Per-user TPM limit exceeded: user=%s", userAddress)
+			p.rejections.record(monitor.RejectionTPMLimit, userAddress)
 			return
 		}
 		if !middleware.CheckPerUserIPMLimit(p.perUserIPMLimiter, ctx, userAddress, svcType) {
-			p.logger.Warnf("Per-user IPM limit exceeded: user=%s", userAddress)
+			p.rejections.record(monitor.RejectionIPMLimit, userAddress)
 			return
 		}
 		if !middleware.CheckPerUserConcurrency(p.perUserConcurrencyLimiter, ctx, userAddress) {
-			p.logger.Warnf("Per-user concurrency limit reached: user=%s, active=%d",
-				userAddress, p.perUserConcurrencyLimiter.GetActiveForUser(userAddress))
+			p.rejections.record(monitor.RejectionConcurrency, userAddress)
 			return
 		}
 		defer p.perUserConcurrencyLimiter.Release(userAddress)
@@ -588,11 +602,13 @@ func (p *Proxy) proxyHTTPRequest(ctx *gin.Context) {
 	// Check if user is rate-limited due to excessive model mismatch attempts
 	rateLimiter := ctrl.GetRateLimiter()
 	if blocked, blockedUntil := rateLimiter.IsBlocked(userAddress); blocked {
-		// User is blocked - return error immediately without processing
+		// User is blocked - return error immediately without processing.
+		// Recorded (not per-event logged) because a blocked client that keeps
+		// retrying would otherwise emit one warning per request until the block
+		// expires — the same unbounded-log concern as the rate-limit gate.
 		ctx.Set("ignoreError", true)
 		remainingTime := blockedUntil.Sub(time.Now())
-		p.logger.Warnf("User blocked due to excessive model mismatch attempts: user=%s, blocked_until=%s, remaining=%v",
-			userAddress, blockedUntil.Format(time.RFC3339), remainingTime)
+		p.rejections.record(monitor.RejectionModelMismatch, userAddress)
 
 		ctx.JSON(http.StatusTooManyRequests, gin.H{
 			"error": fmt.Sprintf("Rate limit exceeded: too many invalid model requests. Please try again in %v", remainingTime.Round(time.Minute)),
@@ -720,6 +736,13 @@ func (p *Proxy) proxyHTTPRequest(ctx *gin.Context) {
 
 	p.logger.Debugf("request saved: %v", req)
 	if err := p.ctrl.ValidateRequestWithEstimatedFee(ctx, req, expectedInputFee); err != nil {
+		// The billing/validation gate is where "high RPS, zero revenue" requests
+		// silently die: ValidateRequestWithEstimatedFee sets ignoreError on the
+		// user-caused paths (insufficient balance, not acknowledged, account not
+		// exist), so handleBrokerError logs nothing. Record the classified reason
+		// it stashed in the context (defaulting to upstream_error for unclassified
+		// server-side failures) so these rejections are observable again.
+		p.rejections.record(rejectionReasonFromContext(ctx), userAddress)
 		p.handleBrokerError(ctx, err, "validate request")
 		return
 	}

--- a/api/inference/internal/proxy/rejection.go
+++ b/api/inference/internal/proxy/rejection.go
@@ -42,7 +42,7 @@ const maxRejectionUsersPerReason = 256
 // reasonBucket accumulates rejections for one reason between flushes.
 type reasonBucket struct {
 	total    int64
-	users    map[string]int64 // truncated address -> count, capped at maxRejectionUsersPerReason
+	users    map[string]int64 // full lowercase address -> count, capped at maxRejectionUsersPerReason
 	overflow int64            // count for addresses not tracked because the cap was hit
 }
 
@@ -60,9 +60,10 @@ type rejectionAggregator struct {
 	mu      sync.Mutex
 	buckets map[string]*reasonBucket
 
-	ticker *time.Ticker
-	done   chan struct{}
-	wg     sync.WaitGroup
+	ticker   *time.Ticker
+	done     chan struct{}
+	wg       sync.WaitGroup
+	stopOnce sync.Once
 }
 
 func newRejectionAggregator(logger log.Logger, interval time.Duration) *rejectionAggregator {
@@ -79,12 +80,19 @@ func newRejectionAggregator(logger log.Logger, interval time.Duration) *rejectio
 }
 
 // record increments both the Prometheus counter (real-time, per-reason) and the
-// in-memory aggregate used for periodic logging. user is the raw address; it is
-// truncated before being stored so full addresses never reach the logs
-// (CLAUDE.md logging guidance). An empty user is recorded against the reason
-// total only.
+// in-memory aggregate used for periodic logging. The counter is incremented even
+// on a nil receiver so a Proxy built outside New() (e.g. the test helper, which
+// omits the aggregator) still records the metric without panicking — matching
+// the nil-tolerance the sibling limiter fields already rely on. Addresses are
+// stored in full but only ever emitted truncated (see topUsers), keeping full
+// addresses out of the logs per CLAUDE.md while avoiding the distinct-user
+// undercount that truncating-as-key would cause when two wallets share the
+// 6+4-char prefix. An empty user is recorded against the reason total only.
 func (a *rejectionAggregator) record(reason, user string) {
 	monitor.RecordRejection(reason)
+	if a == nil {
+		return
+	}
 
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -98,7 +106,7 @@ func (a *rejectionAggregator) record(reason, user string) {
 	if user == "" {
 		return
 	}
-	key := truncateAddr(strings.ToLower(user))
+	key := strings.ToLower(user)
 	if _, tracked := b.users[key]; tracked {
 		b.users[key]++
 		return
@@ -148,7 +156,9 @@ func overflowSuffix(overflow int64) string {
 }
 
 // topUsers returns up to n "addr=count" pairs sorted by count descending, for
-// the rejection summary line. Ties are broken by address for stable output.
+// the rejection summary line. Addresses are truncated here (at emit) so full
+// addresses never reach the logs while the map keeps full addresses for an
+// accurate distinct count. Ties are broken by address for stable output.
 func topUsers(users map[string]int64, n int) string {
 	if len(users) == 0 {
 		return "n/a"
@@ -172,14 +182,18 @@ func topUsers(users map[string]int64, n int) string {
 	}
 	parts := make([]string, len(pairs))
 	for i, p := range pairs {
-		parts[i] = fmt.Sprintf("%s=%d", p.addr, p.count)
+		parts[i] = fmt.Sprintf("%s=%d", truncateAddr(p.addr), p.count)
 	}
 	return strings.Join(parts, ", ")
 }
 
 // stop halts the background flush goroutine after emitting a final summary.
+// Guarded by sync.Once so a double Close() (or a test calling stop twice) can't
+// panic on "close of closed channel" — matching PerUserTPMLimiter.Stop().
 func (a *rejectionAggregator) stop() {
-	a.ticker.Stop()
-	close(a.done)
-	a.wg.Wait()
+	a.stopOnce.Do(func() {
+		a.ticker.Stop()
+		close(a.done)
+		a.wg.Wait()
+	})
 }

--- a/api/inference/internal/proxy/rejection.go
+++ b/api/inference/internal/proxy/rejection.go
@@ -1,0 +1,185 @@
+package proxy
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/0glabs/0g-serving-broker/common/log"
+	"github.com/0glabs/0g-serving-broker/inference/monitor"
+)
+
+// rejectionReasonFromContext reads the classified rejection reason that the
+// validation gate stashed under monitor.CtxKeyRejectionReason. When the gate
+// failed for an unclassified (server-side) reason the key is absent, so we fall
+// back to upstream_error rather than mislabeling it as a user-caused rejection.
+func rejectionReasonFromContext(ctx *gin.Context) string {
+	if v, ok := ctx.Get(monitor.CtxKeyRejectionReason); ok {
+		if reason, ok := v.(string); ok && reason != "" {
+			return reason
+		}
+	}
+	return monitor.RejectionUpstreamError
+}
+
+// rejectionFlushInterval is how often accumulated rejection counts are summarized
+// into a single log line per reason. One line per reason per interval bounds log
+// volume regardless of request rate — the fix for the per-event warning spam
+// that turned a single underfunded client into a 150k-line/day log flood.
+const rejectionFlushInterval = 60 * time.Second
+
+// maxRejectionUsersPerReason caps how many distinct user addresses are tracked
+// per reason between flushes. A spray of distinct addresses (e.g. an abuser
+// rotating wallets) is bounded here: addresses beyond the cap are folded into an
+// overflow tally rather than growing the map without limit. The cap is generous
+// enough that real top-offender attribution survives for normal traffic.
+const maxRejectionUsersPerReason = 256
+
+// reasonBucket accumulates rejections for one reason between flushes.
+type reasonBucket struct {
+	total    int64
+	users    map[string]int64 // truncated address -> count, capped at maxRejectionUsersPerReason
+	overflow int64            // count for addresses not tracked because the cap was hit
+}
+
+// rejectionAggregator turns per-request rejections into bounded, periodic
+// summary logs while leaving the real-time signal to the Prometheus counter
+// (incremented separately via monitor.RecordRejection). It exists because the
+// previous code logged one warning per rejected request — under a sustained
+// rejection flood that is an unbounded, disk-filling log-amplification vector,
+// and it also buried the (silent) billing-gate rejections that motivated this
+// whole change.
+type rejectionAggregator struct {
+	logger   log.Logger
+	interval time.Duration
+
+	mu      sync.Mutex
+	buckets map[string]*reasonBucket
+
+	ticker *time.Ticker
+	done   chan struct{}
+	wg     sync.WaitGroup
+}
+
+func newRejectionAggregator(logger log.Logger, interval time.Duration) *rejectionAggregator {
+	a := &rejectionAggregator{
+		logger:   logger,
+		interval: interval,
+		buckets:  make(map[string]*reasonBucket),
+		done:     make(chan struct{}),
+	}
+	a.ticker = time.NewTicker(interval)
+	a.wg.Add(1)
+	go a.run()
+	return a
+}
+
+// record increments both the Prometheus counter (real-time, per-reason) and the
+// in-memory aggregate used for periodic logging. user is the raw address; it is
+// truncated before being stored so full addresses never reach the logs
+// (CLAUDE.md logging guidance). An empty user is recorded against the reason
+// total only.
+func (a *rejectionAggregator) record(reason, user string) {
+	monitor.RecordRejection(reason)
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	b := a.buckets[reason]
+	if b == nil {
+		b = &reasonBucket{users: make(map[string]int64)}
+		a.buckets[reason] = b
+	}
+	b.total++
+	if user == "" {
+		return
+	}
+	key := truncateAddr(strings.ToLower(user))
+	if _, tracked := b.users[key]; tracked {
+		b.users[key]++
+		return
+	}
+	if len(b.users) >= maxRejectionUsersPerReason {
+		b.overflow++
+		return
+	}
+	b.users[key] = 1
+}
+
+func (a *rejectionAggregator) run() {
+	defer a.wg.Done()
+	for {
+		select {
+		case <-a.done:
+			a.flush() // final summary so counts since the last tick aren't lost on shutdown
+			return
+		case <-a.ticker.C:
+			a.flush()
+		}
+	}
+}
+
+// flush emits one log line per reason that saw rejections since the last flush,
+// then resets the accumulators. Reasons with zero activity produce no output.
+func (a *rejectionAggregator) flush() {
+	a.mu.Lock()
+	buckets := a.buckets
+	a.buckets = make(map[string]*reasonBucket)
+	a.mu.Unlock()
+
+	for reason, b := range buckets {
+		if b.total == 0 {
+			continue
+		}
+		a.logger.Warnf("request rejections [%s]: %d in last %s across %d user(s)%s; top: %s",
+			reason, b.total, a.interval, len(b.users), overflowSuffix(b.overflow), topUsers(b.users, 3))
+	}
+}
+
+func overflowSuffix(overflow int64) string {
+	if overflow == 0 {
+		return ""
+	}
+	return fmt.Sprintf(" (+%d from untracked addrs)", overflow)
+}
+
+// topUsers returns up to n "addr=count" pairs sorted by count descending, for
+// the rejection summary line. Ties are broken by address for stable output.
+func topUsers(users map[string]int64, n int) string {
+	if len(users) == 0 {
+		return "n/a"
+	}
+	type pair struct {
+		addr  string
+		count int64
+	}
+	pairs := make([]pair, 0, len(users))
+	for addr, count := range users {
+		pairs = append(pairs, pair{addr, count})
+	}
+	sort.Slice(pairs, func(i, j int) bool {
+		if pairs[i].count != pairs[j].count {
+			return pairs[i].count > pairs[j].count
+		}
+		return pairs[i].addr < pairs[j].addr
+	})
+	if len(pairs) > n {
+		pairs = pairs[:n]
+	}
+	parts := make([]string, len(pairs))
+	for i, p := range pairs {
+		parts[i] = fmt.Sprintf("%s=%d", p.addr, p.count)
+	}
+	return strings.Join(parts, ", ")
+}
+
+// stop halts the background flush goroutine after emitting a final summary.
+func (a *rejectionAggregator) stop() {
+	a.ticker.Stop()
+	close(a.done)
+	a.wg.Wait()
+}

--- a/api/inference/internal/proxy/rejection_test.go
+++ b/api/inference/internal/proxy/rejection_test.go
@@ -1,0 +1,147 @@
+package proxy
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/0glabs/0g-serving-broker/inference/monitor"
+)
+
+// captureLogger embeds noopLogger (from proxy_test.go) and records Warnf lines
+// so a test can assert on the aggregated rejection summary.
+type captureLogger struct {
+	noopLogger
+	mu    sync.Mutex
+	lines []string
+}
+
+func (c *captureLogger) Warnf(format string, args ...interface{}) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.lines = append(c.lines, fmt.Sprintf(format, args...))
+}
+
+func (c *captureLogger) all() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return strings.Join(c.lines, "\n")
+}
+
+// newTestAggregator builds an aggregator WITHOUT starting the flush goroutine,
+// so tests drive record()/flush() deterministically.
+func newTestAggregator(logger *captureLogger) *rejectionAggregator {
+	return &rejectionAggregator{
+		logger:   logger,
+		interval: time.Minute,
+		buckets:  make(map[string]*reasonBucket),
+	}
+}
+
+func TestRejectionAggregator_FlushSummarizesPerReason(t *testing.T) {
+	logger := &captureLogger{}
+	a := newTestAggregator(logger)
+
+	// 5 rejections for one user, 2 reasons.
+	for i := 0; i < 5; i++ {
+		a.record(monitor.RejectionInsufficientBal, "0x4870000000000000000000000000000000a4E9")
+	}
+	a.record(monitor.RejectionRateLimit, "0x1111000000000000000000000000000000002222")
+
+	a.flush()
+
+	out := logger.all()
+	if !strings.Contains(out, monitor.RejectionInsufficientBal) {
+		t.Fatalf("expected insufficient_balance summary, got: %q", out)
+	}
+	// One aggregated line per reason — never one line per event.
+	if got := len(logger.lines); got != 2 {
+		t.Fatalf("expected 2 summary lines (one per reason), got %d: %q", got, out)
+	}
+	if !strings.Contains(out, "5 in last") {
+		t.Fatalf("expected total of 5 for insufficient_balance, got: %q", out)
+	}
+
+	// After a flush the buckets reset: a second flush with no new activity is silent.
+	a.flush()
+	if got := len(logger.lines); got != 2 {
+		t.Fatalf("flush after reset should emit nothing, got %d lines", got)
+	}
+}
+
+func TestRejectionAggregator_BoundsTrackedUsers(t *testing.T) {
+	logger := &captureLogger{}
+	a := newTestAggregator(logger)
+
+	// Spray far more distinct addresses than the per-reason cap. The map must
+	// not grow without bound; the excess is folded into the overflow tally.
+	total := maxRejectionUsersPerReason + 50
+	for i := 0; i < total; i++ {
+		a.record(monitor.RejectionRateLimit, addrForIndex(i))
+	}
+
+	b := a.buckets[monitor.RejectionRateLimit]
+	if b == nil {
+		t.Fatal("expected a bucket for rate_limit")
+	}
+	if len(b.users) != maxRejectionUsersPerReason {
+		t.Fatalf("tracked users not capped: got %d, want %d", len(b.users), maxRejectionUsersPerReason)
+	}
+	if b.overflow != 50 {
+		t.Fatalf("overflow miscounted: got %d, want 50", b.overflow)
+	}
+	if b.total != int64(total) {
+		t.Fatalf("total miscounted: got %d, want %d", b.total, total)
+	}
+
+	a.flush()
+	if !strings.Contains(logger.all(), "from untracked addrs") {
+		t.Fatalf("expected overflow note in summary, got: %q", logger.all())
+	}
+}
+
+func TestTopUsers_OrdersByCountDescending(t *testing.T) {
+	users := map[string]int64{
+		"0xaaa": 3,
+		"0xbbb": 10,
+		"0xccc": 1,
+		"0xddd": 7,
+	}
+	got := topUsers(users, 2)
+	// Highest two: 0xbbb=10, 0xddd=7.
+	if !strings.HasPrefix(got, "0xbbb=10") {
+		t.Fatalf("expected highest count first, got: %q", got)
+	}
+	if strings.Contains(got, "0xccc") {
+		t.Fatalf("expected only top 2, got: %q", got)
+	}
+}
+
+func TestTopUsers_EmptyIsNA(t *testing.T) {
+	if got := topUsers(nil, 3); got != "n/a" {
+		t.Fatalf("expected n/a for empty, got %q", got)
+	}
+}
+
+// addrForIndex produces a distinct, well-formed 40-hex-char address per index.
+func addrForIndex(i int) string {
+	const hexDigits = "0123456789abcdef"
+	var sb strings.Builder
+	sb.WriteString("0x")
+	// Encode i across the last few nibbles; rest zero-padded. 40 hex chars total.
+	body := make([]byte, 40)
+	for j := range body {
+		body[j] = '0'
+	}
+	n := i
+	pos := 39
+	for n > 0 && pos >= 0 {
+		body[pos] = hexDigits[n&0xf]
+		n >>= 4
+		pos--
+	}
+	sb.Write(body)
+	return sb.String()
+}

--- a/api/inference/internal/proxy/rejection_test.go
+++ b/api/inference/internal/proxy/rejection_test.go
@@ -125,6 +125,32 @@ func TestTopUsers_EmptyIsNA(t *testing.T) {
 	}
 }
 
+func TestRejectionAggregator_NilReceiverRecordDoesNotPanic(t *testing.T) {
+	// A Proxy built outside New() (e.g. the test helper) has a nil aggregator.
+	// record must still fire the metric without panicking.
+	var a *rejectionAggregator
+	a.record(monitor.RejectionRateLimit, "0x4870000000000000000000000000000000a4E9")
+}
+
+func TestRejectionAggregator_StopIsIdempotent(t *testing.T) {
+	a := newRejectionAggregator(&captureLogger{}, time.Hour)
+	a.stop()
+	a.stop() // second call must not panic on a closed channel
+}
+
+func TestRejectionAggregator_DistinctTruncationCollisionsCountedSeparately(t *testing.T) {
+	logger := &captureLogger{}
+	a := newTestAggregator(logger)
+	// Two addresses that share the 6+4 truncation prefix but differ in the
+	// middle must be counted as two distinct users, not merged.
+	a.record(monitor.RejectionRateLimit, "0x4870aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa4E9")
+	a.record(monitor.RejectionRateLimit, "0x4870bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb4E9")
+	b := a.buckets[monitor.RejectionRateLimit]
+	if got := len(b.users); got != 2 {
+		t.Fatalf("expected 2 distinct users despite shared truncation prefix, got %d", got)
+	}
+}
+
 // addrForIndex produces a distinct, well-formed 40-hex-char address per index.
 func addrForIndex(i int) string {
 	const hexDigits = "0123456789abcdef"

--- a/api/inference/monitor/server.go
+++ b/api/inference/monitor/server.go
@@ -52,7 +52,47 @@ var (
 	// isn't being parsed (e.g. an async provider that doesn't echo seconds), so
 	// it must be alertable rather than a silent skip.
 	VideoBillingSkippedTotal prometheus.Counter
+
+	// RequestRejectedTotal counts requests rejected before they reach the
+	// upstream, labeled by a low-cardinality `reason` (see the Rejection*
+	// constants). This is the primary signal for the "high RPS, near-zero
+	// revenue" failure mode: a flood of admission/billing-gate rejections that
+	// otherwise produce no log line shows up here within scrape interval, e.g.
+	// broker_requests_rejected_total{reason="insufficient_balance"} climbing
+	// while broker_requests_total stays flat. The reason label is sourced only
+	// from the bounded constant set below — never from raw user/error strings —
+	// so cardinality stays fixed. A per-user breakdown is deliberately NOT a
+	// label here (that would be unbounded); operators get top-N offenders from
+	// the periodic aggregated rejection log instead.
+	RequestRejectedTotal *prometheus.CounterVec
 )
+
+// Rejection reason label values for RequestRejectedTotal. These are the only
+// strings ever passed to RecordRejection, keeping the metric's cardinality
+// bounded. Group: admission gates (rate/tpm/ipm/concurrency/model_mismatch),
+// billing gates (insufficient_balance/not_acknowledged/account_not_exist), and
+// catch-alls (upstream_error/client_canceled) for paths whose specific cause
+// isn't classified.
+const (
+	RejectionRateLimit       = "rate_limit"
+	RejectionTPMLimit        = "tpm_limit"
+	RejectionIPMLimit        = "ipm_limit"
+	RejectionConcurrency     = "concurrency"
+	RejectionModelMismatch   = "model_mismatch"
+	RejectionInsufficientBal = "insufficient_balance"
+	RejectionNotAcknowledged = "not_acknowledged"
+	RejectionAccountNotExist = "account_not_exist"
+	RejectionUpstreamError   = "upstream_error"
+	RejectionClientCanceled  = "client_canceled"
+)
+
+// CtxKeyRejectionReason is the gin context key under which a request handler
+// records WHY a request was rejected, using one of the Rejection* constants.
+// The billing/validation gate lives in the ctrl package but its caller (the
+// proxy) owns rejection recording, so the reason is passed across that boundary
+// via the context rather than by threading a return value through several
+// signatures. An unset key means "not a classified rejection".
+const CtxKeyRejectionReason = "rejectionReason"
 
 // PrometheusInit registers all broker metrics. serverName (the ServingURL)
 // and providerAddress (the provider's on-chain address, as registered in the
@@ -231,11 +271,21 @@ func PrometheusInit(serverName, providerAddress string) {
 		},
 	)
 
+	RequestRejectedTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name:        "broker_requests_rejected_total",
+			Help:        "Total number of requests rejected before reaching the upstream, labeled by reason (rate_limit, tpm_limit, ipm_limit, concurrency, model_mismatch, insufficient_balance, not_acknowledged, account_not_exist, upstream_error, client_canceled).",
+			ConstLabels: constLabels,
+		},
+		[]string{"reason"},
+	)
+
 	prometheus.MustRegister(WhitelistRequestsTotal)
 	prometheus.MustRegister(WhitelistInputTokensTotal)
 	prometheus.MustRegister(WhitelistOutputTokensTotal)
 	prometheus.MustRegister(WhitelistAudioSecondsTotal)
 	prometheus.MustRegister(VideoBillingSkippedTotal)
+	prometheus.MustRegister(RequestRejectedTotal)
 }
 
 // StartDAUUpdater starts a background goroutine that periodically queries the database
@@ -415,6 +465,16 @@ func RecordVideoBillingSkipped() {
 		return
 	}
 	VideoBillingSkippedTotal.Inc()
+}
+
+// RecordRejection increments the rejected-request counter for the given reason.
+// reason must be one of the Rejection* constants so the metric stays bounded.
+// Safe to call before PrometheusInit (no-op when monitoring is disabled).
+func RecordRejection(reason string) {
+	if RequestRejectedTotal == nil {
+		return
+	}
+	RequestRejectedTotal.WithLabelValues(reason).Inc()
 }
 
 // RecordWhitelistRequest increments the whitelist request counter for the given

--- a/api/inference/monitor/server.go
+++ b/api/inference/monitor/server.go
@@ -71,8 +71,10 @@ var (
 // strings ever passed to RecordRejection, keeping the metric's cardinality
 // bounded. Group: admission gates (rate/tpm/ipm/concurrency/model_mismatch),
 // billing gates (insufficient_balance/not_acknowledged/account_not_exist), and
-// catch-alls (upstream_error/client_canceled) for paths whose specific cause
-// isn't classified.
+// the upstream_error catch-all for validation failures whose specific cause
+// isn't classified. Every constant here has a live emit site — a reason is not
+// declared until it is actually recorded, so the metric's label set never
+// advertises a value that can't appear.
 const (
 	RejectionRateLimit       = "rate_limit"
 	RejectionTPMLimit        = "tpm_limit"
@@ -83,7 +85,6 @@ const (
 	RejectionNotAcknowledged = "not_acknowledged"
 	RejectionAccountNotExist = "account_not_exist"
 	RejectionUpstreamError   = "upstream_error"
-	RejectionClientCanceled  = "client_canceled"
 )
 
 // CtxKeyRejectionReason is the gin context key under which a request handler
@@ -274,7 +275,7 @@ func PrometheusInit(serverName, providerAddress string) {
 	RequestRejectedTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name:        "broker_requests_rejected_total",
-			Help:        "Total number of requests rejected before reaching the upstream, labeled by reason (rate_limit, tpm_limit, ipm_limit, concurrency, model_mismatch, insufficient_balance, not_acknowledged, account_not_exist, upstream_error, client_canceled).",
+			Help:        "Total number of requests rejected before reaching the upstream, labeled by reason (rate_limit, tpm_limit, ipm_limit, concurrency, model_mismatch, insufficient_balance, not_acknowledged, account_not_exist, upstream_error).",
 			ConstLabels: constLabels,
 		},
 		[]string{"reason"},

--- a/docs/design/rejection-observability.md
+++ b/docs/design/rejection-observability.md
@@ -1,0 +1,104 @@
+# Rejection Observability Design
+
+This document describes how the broker makes **rejected requests** observable — the
+classified Prometheus counter, the bounded rejection summary log, and the recommended
+production log level. It exists because of a real incident where a provider saw
+sustained 15–30 RPS with near-zero revenue and there was **no way to diagnose it from
+logs or dashboards**: requests were dying silently at the billing gate.
+
+## The problem it solves
+
+A request can be rejected at several points before it ever reaches the upstream model:
+
+```
+POST /chat/completions
+  │
+  ├─ per-user RPM limit            → reject (rate_limit)
+  ├─ per-user TPM limit            → reject (tpm_limit)
+  ├─ per-user IPM limit            → reject (ipm_limit)
+  ├─ per-user concurrency limit    → reject (concurrency)
+  ├─ model-mismatch block          → reject (model_mismatch)
+  ├─ billing / balance gate ───────┐
+  │     ├─ account not on contract → reject (account_not_exist)
+  │     ├─ provider not acknowledged → reject (not_acknowledged)
+  │     └─ locked balance below reserve → reject (insufficient_balance)
+  │
+  ▼
+  upstream model (billable)
+```
+
+Before this change, the billing-gate rejections were **completely silent**:
+`ValidateRequestWithEstimatedFee` sets `ignoreError` on the user-caused paths, and
+`handleBrokerError` skips logging whenever `ignoreError` is set. So a flood of
+underfunded requests produced **no log line and no metric** — the "high RPS, zero
+revenue" funnel was invisible. Meanwhile the rate-limit gate had the opposite problem:
+it logged **one warning per rejected request**, which under a sustained flood is an
+unbounded, disk-filling log-amplification vector (one incident produced a 191 MB /
+1.17 M-line log for a single provider in one day).
+
+## Metric: `broker_requests_rejected_total`
+
+A single counter, labeled only by a **bounded** `reason`:
+
+```
+broker_requests_rejected_total{reason="rate_limit"}
+broker_requests_rejected_total{reason="tpm_limit"}
+broker_requests_rejected_total{reason="ipm_limit"}
+broker_requests_rejected_total{reason="concurrency"}
+broker_requests_rejected_total{reason="model_mismatch"}
+broker_requests_rejected_total{reason="insufficient_balance"}
+broker_requests_rejected_total{reason="not_acknowledged"}
+broker_requests_rejected_total{reason="account_not_exist"}
+broker_requests_rejected_total{reason="upstream_error"}   # unclassified server-side validation failure
+broker_requests_rejected_total{reason="client_canceled"}
+```
+
+The counter is incremented **even when `ignoreError` suppresses the per-request log**,
+so observability is decoupled from HTTP-error verbosity. With it, "high RPS + zero
+revenue" becomes immediately obvious as `reason="insufficient_balance"` climbing while
+`broker_requests_total` stays flat:
+
+```promql
+sum by (reason) (rate(broker_requests_rejected_total[5m]))
+```
+
+> **Naming.** The metric follows the existing `broker_*` family
+> (`broker_requests_total`, `broker_requests_errors_total`) so it sits alongside them
+> on existing dashboards. Issue #542 referenced it as `inference_request_rejected_total`;
+> the `broker_` prefix was chosen for consistency.
+
+### Why `reason` is the only label
+
+`reason` is sourced exclusively from a fixed constant set (`monitor.Rejection*`), so
+cardinality is bounded. A per-user label is deliberately **not** used — user addresses
+are unbounded and would explode series count. Top offenders are surfaced through the
+aggregated log instead (below).
+
+## Bounded rejection summary log
+
+Per-event rejection logging is replaced by a periodic aggregator
+(`api/inference/internal/proxy/rejection.go`). Every `rejectionFlushInterval` (60s) it
+emits **at most one line per reason** that saw activity:
+
+```
+request rejections [insufficient_balance]: 189231 in last 1m0s across 3 user(s); top: 0x4870…a4E9=189000, ...
+```
+
+Properties:
+
+- **Bounded volume** — one line per reason per interval, independent of request rate.
+  A flood can no longer fill the disk through the log path.
+- **Bounded memory** — distinct addresses tracked per reason are capped
+  (`maxRejectionUsersPerReason`); the excess is folded into a `(+N from untracked addrs)`
+  overflow tally rather than growing the map.
+- **Truncated addresses** — full addresses never reach the log (per CLAUDE.md guidance).
+- **Final flush on shutdown** — `Proxy.Close()` stops the aggregator after one last flush.
+
+## Recommended production log level
+
+Run mainnet at **`level: info`** (the built-in default). At `level: debug` the proxy
+emits ~3+ verbose lines per request (`Proxy: method=...`, `ReadAll success`, full
+`request saved` struct, signature lines) — even for silently-rejected requests — which
+is what amplified the incident log to 191 MB/day. The classified counter plus the
+aggregated summary above provide the diagnosis that `debug` was being abused for, at a
+tiny fraction of the volume. Reserve `debug` for short, targeted investigations.

--- a/docs/design/rejection-observability.md
+++ b/docs/design/rejection-observability.md
@@ -50,8 +50,15 @@ broker_requests_rejected_total{reason="insufficient_balance"}
 broker_requests_rejected_total{reason="not_acknowledged"}
 broker_requests_rejected_total{reason="account_not_exist"}
 broker_requests_rejected_total{reason="upstream_error"}   # unclassified server-side validation failure
-broker_requests_rejected_total{reason="client_canceled"}
 ```
+
+> `account_not_exist` is recorded whenever the contract account lookup
+> (`GetUserAccount`) fails. That lookup logs the underlying error at `error`
+> level in the contract layer regardless of `ignoreError`, so a genuine
+> RPC/node outage is never silent — but it does count under `account_not_exist`
+> rather than a transport-error reason. A sustained spike there with healthy
+> chain RPC means real not-yet-funded accounts; correlate with the contract-layer
+> error log to rule out an RPC outage.
 
 The counter is incremented **even when `ignoreError` suppresses the per-request log**,
 so observability is decoupled from HTTP-error verbosity. With it, "high RPS + zero


### PR DESCRIPTION
Closes #542.

## Problem

When a provider sees **high RPS but near-zero revenue**, there was **no way to diagnose it** from logs or dashboards. Two opposite failure modes met in the middle:

- **Billing-gate rejections were completely silent.** A request could pass rate-limiting, get `request saved`, then vanish before reaching the upstream. `ValidateRequestWithEstimatedFee` sets `ignoreError` on the user-caused paths (insufficient balance / not acknowledged / account not exist), and `handleBrokerError` skips logging when `ignoreError` is set — so ~190k rejections/day produced **zero log lines and zero metrics**. The real incident root cause (locked balance below the 3 0G `MinimumLockedBalance` reserve) was only found by querying the contract by hand.
- **Rate-limit rejections were over-logged.** One warning per rejected request — an unbounded, disk-filling log-amplification vector under a flood (one incident: 191 MB / 1.17M lines for a single provider in one day).

## Changes

1. **Classified Prometheus counter** `broker_requests_rejected_total{reason}` (monitor package), incremented at **every** early-return gate — rate_limit, tpm_limit, ipm_limit, concurrency, model_mismatch, insufficient_balance, not_acknowledged, account_not_exist, upstream_error — **even when `ignoreError` suppresses the HTTP-error log**. `reason` is sourced only from a bounded constant set, so cardinality is fixed. No per-user label (that would be unbounded); top offenders come from the aggregated log instead.

   ```promql
   sum by (reason) (rate(broker_requests_rejected_total[5m]))
   ```
   "High RPS + zero revenue" now shows up immediately as `reason="insufficient_balance"` climbing while `broker_requests_total` stays flat.

2. **Billing-gate reasons classified** — `ctrl` stashes the reason in a gin context key at each user-caused rejection; the proxy reads it (defaulting to `upstream_error` for unclassified server-side failures).

3. **Bounded rejection summary log** (`internal/proxy/rejection.go`) replaces the per-event warnings: **one line per reason per 60s**, with per-reason distinct-user tracking capped (excess folded into an overflow tally) and truncated addresses. Lifecycle tied to `Proxy.New`/`Close` (final flush on shutdown).

   ```
   request rejections [insufficient_balance]: 189231 in last 1m0s across 3 user(s); top: 0x4870…a4E9=189000, ...
   ```

4. **Docs** — `docs/design/rejection-observability.md` covers the metric, reasons, aggregated logging, and the recommended production log level (**`info`, not `debug`** — `debug` emits 3+ verbose lines/request and was what amplified the incident log; the default is already `info`).

## Acceptance criteria

- ✅ A flood of insufficient-balance requests is visible on the dashboard within a scrape interval via `broker_requests_rejected_total{reason="insufficient_balance"}`.
- ✅ Log volume under a sustained rejection flood is bounded (one line/reason/60s), not one line per request.

## Naming note

Metric is named `broker_requests_rejected_total` (not the issue's `inference_request_rejected_total`) for consistency with the existing `broker_*` family already wired into dashboards (`broker_requests_total`, `broker_requests_errors_total`).

## Testing

- `go build ./...` ✅
- `go vet` (proxy/monitor/ctrl) ✅
- New unit tests in `rejection_test.go`: per-reason flush summarization, reset-after-flush, distinct-user cap + overflow, top-N ordering. ✅
- Pre-existing `make lint` failures are environmental typecheck noise (golangci-lint built against a different Go toolchain — `could not import sync/atomic ... unsupported version: 2`); none reference the new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)