### PR TITLE
feat(inference): USD per-image pricing for image services

### DIFF
--- a/api/inference/config/config.go
+++ b/api/inference/config/config.go
@@ -184,6 +184,18 @@ type Service struct {
 	// tokens, decimal string.  Required iff PriceDenomination == "USD".
 	OutputPriceUSDPerMillionTokens string `yaml:"outputPriceUSDPerMillionTokens"`
 
+	// OutputPriceUSDPerImage is the USD price per generated image for a
+	// USD-denominated image-generation / image-editing service (decimal string,
+	// e.g. "0.04" = $0.04 per image). It is REQUIRED — and the per-1M-token USD
+	// fields are forbidden — for those service types under USD denomination,
+	// because an image bills per image, not per token. At config load it is
+	// normalized into OutputPriceUSDPerMillionTokens (×1e6, with the input side
+	// fixed at "0") so the existing token-shaped USD machinery (price feed,
+	// on-chain ceiling, wei conversion, /v1/models display) prices and advertises
+	// it unchanged — the pipeline's ÷1e6 quantum cancels the ×1e6 normalization to
+	// yield wei-per-image. Mirrors OutputPriceUSDPerSecond for video. See validate.
+	OutputPriceUSDPerImage string `yaml:"outputPriceUSDPerImage"`
+
 	// ModelPricing defines per-model pricing for centralized providers that serve multiple models.
 	// When configured, the broker validates requested models against this allowlist
 	// and bills at model-specific rates instead of the single on-chain price.
@@ -882,31 +894,65 @@ func loadConfig(cfg *Config) error {
 		cfg.Service.PriceDenomination = constant.PriceDenominationNative
 	}
 	cfg.Service.PriceDenomination = strings.ToUpper(cfg.Service.PriceDenomination)
+	// Image generation / editing bill per image, so under USD denomination they
+	// use service.outputPriceUSDPerImage instead of the per-1M-token fields.
+	isImageType := cfg.Service.Type == constant.ServiceTypeTextToImage ||
+		cfg.Service.Type == constant.ServiceTypeImageEditing
 	switch cfg.Service.PriceDenomination {
 	case constant.PriceDenominationNative:
 		if cfg.Service.InputPriceUSDPerMillionTokens != "" || cfg.Service.OutputPriceUSDPerMillionTokens != "" {
 			return fmt.Errorf("invalid config: service.inputPriceUSDPerMillionTokens / service.outputPriceUSDPerMillionTokens must be empty when priceDenomination is '%s'", constant.PriceDenominationNative)
 		}
+		if cfg.Service.OutputPriceUSDPerImage != "" {
+			return fmt.Errorf("invalid config: service.outputPriceUSDPerImage is only valid when priceDenomination is '%s'", constant.PriceDenominationUSD)
+		}
 	case constant.PriceDenominationUSD:
-		// With multi-model pricing the per-model entries carry the USD prices and
-		// the service-level USD fields are derived (max-over-models) later in this
-		// function, so they may legitimately be empty here.
-		multiModelUSD := len(cfg.Service.ModelPricing) > 0
-		if !multiModelUSD && (cfg.Service.InputPriceUSDPerMillionTokens == "" || cfg.Service.OutputPriceUSDPerMillionTokens == "") {
-			return fmt.Errorf("invalid config: service.inputPriceUSDPerMillionTokens and service.outputPriceUSDPerMillionTokens are required when priceDenomination is '%s'", constant.PriceDenominationUSD)
-		}
-		if cfg.Service.InputPriceUSDPerMillionTokens != "" {
-			if err := validateUSDPriceString("service.inputPriceUSDPerMillionTokens", cfg.Service.InputPriceUSDPerMillionTokens); err != nil {
-				return err
-			}
-		}
-		if cfg.Service.OutputPriceUSDPerMillionTokens != "" {
-			if err := validateUSDPriceString("service.outputPriceUSDPerMillionTokens", cfg.Service.OutputPriceUSDPerMillionTokens); err != nil {
-				return err
-			}
-		}
 		if cfg.Service.InputPrice != "" || cfg.Service.OutputPrice != "" {
 			return fmt.Errorf("invalid config: service.inputPrice / service.outputPrice must be empty when priceDenomination is '%s' (use the USD fields)", constant.PriceDenominationUSD)
+		}
+		if isImageType {
+			// USD image service: outputPriceUSDPerImage is mandatory; the per-1M-token
+			// fields are forbidden (image bills per image, not per token).
+			if cfg.Service.InputPriceUSDPerMillionTokens != "" || cfg.Service.OutputPriceUSDPerMillionTokens != "" {
+				return fmt.Errorf("invalid config: service.inputPriceUSDPerMillionTokens / service.outputPriceUSDPerMillionTokens must be empty for service type '%s' under USD denomination (use service.outputPriceUSDPerImage)", cfg.Service.Type)
+			}
+			if cfg.Service.OutputPriceUSDPerImage == "" {
+				return fmt.Errorf("invalid config: service.outputPriceUSDPerImage is required for service type '%s' when priceDenomination is '%s'", cfg.Service.Type, constant.PriceDenominationUSD)
+			}
+			if err := validateUSDPriceString("service.outputPriceUSDPerImage", cfg.Service.OutputPriceUSDPerImage); err != nil {
+				return err
+			}
+			// Normalize per-image USD into the per-1M-unit representation the shared USD
+			// pipeline consumes: the "unit" is one image, the input side is 0. Parse the
+			// trimmed value (validateUSDPriceString trims before validating) so a padded
+			// string that passed validation can't slip a nil into the multiply.
+			perImage, ok := new(big.Rat).SetString(strings.TrimSpace(cfg.Service.OutputPriceUSDPerImage))
+			if !ok {
+				return fmt.Errorf("invalid config: service.outputPriceUSDPerImage %q is not a valid decimal", cfg.Service.OutputPriceUSDPerImage)
+			}
+			cfg.Service.OutputPriceUSDPerMillionTokens = ratToDecimalString(new(big.Rat).Mul(perImage, big.NewRat(1_000_000, 1)))
+			cfg.Service.InputPriceUSDPerMillionTokens = "0"
+		} else {
+			if cfg.Service.OutputPriceUSDPerImage != "" {
+				return fmt.Errorf("invalid config: service.outputPriceUSDPerImage is only valid for image service types ('%s' / '%s'), got '%s'", constant.ServiceTypeTextToImage, constant.ServiceTypeImageEditing, cfg.Service.Type)
+			}
+			// With multi-model pricing the per-model entries carry the USD prices and
+			// the service-level USD fields are derived (max-over-models) later in this
+			// function, so they may legitimately be empty here.
+			multiModelUSD := len(cfg.Service.ModelPricing) > 0
+			if !multiModelUSD && (cfg.Service.InputPriceUSDPerMillionTokens == "" || cfg.Service.OutputPriceUSDPerMillionTokens == "") {
+				return fmt.Errorf("invalid config: service.inputPriceUSDPerMillionTokens and service.outputPriceUSDPerMillionTokens are required when priceDenomination is '%s'", constant.PriceDenominationUSD)
+			}
+			if cfg.Service.InputPriceUSDPerMillionTokens != "" {
+				if err := validateUSDPriceString("service.inputPriceUSDPerMillionTokens", cfg.Service.InputPriceUSDPerMillionTokens); err != nil {
+					return err
+				}
+			}
+			if cfg.Service.OutputPriceUSDPerMillionTokens != "" {
+				if err := validateUSDPriceString("service.outputPriceUSDPerMillionTokens", cfg.Service.OutputPriceUSDPerMillionTokens); err != nil {
+					return err
+				}
+			}
 		}
 		if err := validatePriceFeedConfig(&cfg.PriceFeed); err != nil {
 			return err

--- a/api/inference/config/config_test.go
+++ b/api/inference/config/config_test.go
@@ -1019,6 +1019,131 @@ service:
 	}
 }
 
+func TestLoadConfig_USDImagePerImage(t *testing.T) {
+	// USD image service: operator gives outputPriceUSDPerImage; loadConfig
+	// normalizes it into the per-1M-unit USD representation (×1e6) with the input
+	// side fixed at 0, so the shared USD pipeline prices it unchanged.
+	for _, svcType := range []string{"text-to-image", "image-editing"} {
+		t.Run(svcType, func(t *testing.T) {
+			configPath := writeTestConfig(t, `
+service:
+  servingUrl: "http://example.com"
+  targetUrl: "http://backend:8000"
+  type: "`+svcType+`"
+  model: "stable-diffusion-xl"
+  verifiability: "TeeML"
+  priceDenomination: "USD"
+  outputPriceUSDPerImage: "0.04"
+priceFeed:
+  sources: ["coingecko"]
+`)
+			t.Setenv("CONFIG_FILE", configPath)
+
+			cfg := &Config{}
+			if err := loadConfig(cfg); err != nil {
+				t.Fatalf("loadConfig failed: %v", err)
+			}
+			if cfg.Service.OutputPriceUSDPerImage != "0.04" {
+				t.Errorf("raw per-image preserved: got %q want 0.04", cfg.Service.OutputPriceUSDPerImage)
+			}
+			if cfg.Service.OutputPriceUSDPerMillionTokens != "40000" {
+				t.Errorf("normalized output: got %q want 40000", cfg.Service.OutputPriceUSDPerMillionTokens)
+			}
+			if cfg.Service.InputPriceUSDPerMillionTokens != "0" {
+				t.Errorf("input side: got %q want 0", cfg.Service.InputPriceUSDPerMillionTokens)
+			}
+		})
+	}
+}
+
+func TestLoadConfig_USDImageRequiresPerImage(t *testing.T) {
+	configPath := writeTestConfig(t, `
+service:
+  servingUrl: "http://example.com"
+  targetUrl: "http://backend:8000"
+  type: "text-to-image"
+  model: "stable-diffusion-xl"
+  verifiability: "TeeML"
+  priceDenomination: "USD"
+priceFeed:
+  sources: ["coingecko"]
+`)
+	t.Setenv("CONFIG_FILE", configPath)
+
+	cfg := &Config{}
+	err := loadConfig(cfg)
+	if err == nil || !strings.Contains(err.Error(), "outputPriceUSDPerImage is required") {
+		t.Errorf("expected error about required outputPriceUSDPerImage, got %v", err)
+	}
+}
+
+func TestLoadConfig_USDImageRejectsPerMillion(t *testing.T) {
+	configPath := writeTestConfig(t, `
+service:
+  servingUrl: "http://example.com"
+  targetUrl: "http://backend:8000"
+  type: "text-to-image"
+  model: "stable-diffusion-xl"
+  verifiability: "TeeML"
+  priceDenomination: "USD"
+  outputPriceUSDPerImage: "0.04"
+  outputPriceUSDPerMillionTokens: "40000"
+priceFeed:
+  sources: ["coingecko"]
+`)
+	t.Setenv("CONFIG_FILE", configPath)
+
+	cfg := &Config{}
+	err := loadConfig(cfg)
+	if err == nil || !strings.Contains(err.Error(), "use service.outputPriceUSDPerImage") {
+		t.Errorf("expected error rejecting per-1M-token fields for image service, got %v", err)
+	}
+}
+
+func TestLoadConfig_USDPerImageRejectedForNonImage(t *testing.T) {
+	configPath := writeTestConfig(t, `
+service:
+  servingUrl: "http://example.com"
+  targetUrl: "http://backend:8000"
+  type: "chatbot"
+  model: "gpt-4"
+  verifiability: "TeeML"
+  priceDenomination: "USD"
+  inputPriceUSDPerMillionTokens: "0.50"
+  outputPriceUSDPerMillionTokens: "1.50"
+  outputPriceUSDPerImage: "0.04"
+priceFeed:
+  sources: ["coingecko"]
+`)
+	t.Setenv("CONFIG_FILE", configPath)
+
+	cfg := &Config{}
+	err := loadConfig(cfg)
+	if err == nil || !strings.Contains(err.Error(), "only valid for image service types") {
+		t.Errorf("expected error rejecting outputPriceUSDPerImage for chatbot, got %v", err)
+	}
+}
+
+func TestLoadConfig_NativeRejectsPerImage(t *testing.T) {
+	configPath := writeTestConfig(t, `
+service:
+  servingUrl: "http://example.com"
+  targetUrl: "http://backend:8000"
+  type: "text-to-image"
+  model: "stable-diffusion-xl"
+  verifiability: "TeeML"
+  outputPrice: "5000000000000"
+  outputPriceUSDPerImage: "0.04"
+`)
+	t.Setenv("CONFIG_FILE", configPath)
+
+	cfg := &Config{}
+	err := loadConfig(cfg)
+	if err == nil || !strings.Contains(err.Error(), "outputPriceUSDPerImage is only valid when priceDenomination is") {
+		t.Errorf("expected error rejecting outputPriceUSDPerImage under NATIVE, got %v", err)
+	}
+}
+
 func TestService_IsCentralized(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/api/inference/internal/handler/models.go
+++ b/api/inference/internal/handler/models.go
@@ -62,14 +62,9 @@ type ModelCacheTokenBilling struct {
 }
 
 // ModelPricing holds per-token pricing in the smallest unit (wei).
-//
-// Prompt/Completion carry omitempty so per-unit modalities (image generation /
-// image editing) can omit the per-token fields entirely and advertise only the
-// modality they actually bill (image), rather than surfacing a per-token price
-// an OpenAI-compatible client would misread.
 type ModelPricing struct {
-	Prompt            string                  `json:"prompt,omitempty"`
-	Completion        string                  `json:"completion,omitempty"`
+	Prompt            string                  `json:"prompt"`
+	Completion        string                  `json:"completion"`
 	Image             string                  `json:"image,omitempty"`
 	Video             string                  `json:"video,omitempty"`
 	TieredPricing     []ModelPricingTier      `json:"tiered_pricing,omitempty"`
@@ -81,8 +76,8 @@ type ModelPricing struct {
 // Values are derived from the configured USD-per-1M-tokens by exact big.Rat
 // division — no float precision loss.
 type ModelPricingUSD struct {
-	Prompt     string `json:"prompt,omitempty"`
-	Completion string `json:"completion,omitempty"`
+	Prompt     string `json:"prompt"`
+	Completion string `json:"completion"`
 	// Image is the USD price per generated image for a USD-denominated
 	// image-generation / image-editing model (decimal string). Mutually
 	// exclusive with the per-token prompt/completion fields above; derived from
@@ -358,12 +353,14 @@ func (h *Handler) GetModels(ctx *gin.Context) {
 
 	// Native per-unit pricing keyed by modality. Image generation / editing bill
 	// per generated image (OutputPrice is the per-image price), surfaced under
-	// `image` only — the per-token prompt/completion fields are left empty so an
-	// OpenAI-compatible client doesn't misread a per-token rate. Video keeps its
-	// existing shape (prompt/completion plus the per-second `video`). Token
-	// modalities use prompt/completion.
+	// `image`; the per-token prompt/completion fields don't apply, so they report
+	// 0 rather than a misleading per-token rate. Video keeps its existing shape
+	// (prompt/completion plus the per-second `video`). Token modalities use
+	// prompt/completion.
 	switch svc.Type {
 	case constant.ServiceTypeTextToImage, constant.ServiceTypeImageEditing:
+		obj.Pricing.Prompt = svc.InputPrice
+		obj.Pricing.Completion = "0"
 		obj.Pricing.Image = svc.OutputPrice
 	case constant.ServiceTypeVideoGeneration:
 		obj.Pricing.Prompt = svc.InputPrice
@@ -444,15 +441,15 @@ func (h *Handler) GetModels(ctx *gin.Context) {
 	switch {
 	case isImageType && svc.OutputPriceUSDPerMillionTokens != "":
 		// Image bills per generated image, not per token: surface the per-image
-		// USD under `image` only (mirrors the native pricing.image), omitting the
-		// per-token prompt/completion fields. Deriving with the same ÷1e6 used by
+		// USD under `image` (mirrors the native pricing.image) and report the
+		// per-token prompt/completion as 0. Deriving with the same ÷1e6 used by
 		// the wei conversion keeps pricing_usd.image consistent with pricing.image.
 		image, imageErr := pricefeed.USDPerMillionStringToPerToken(svc.OutputPriceUSDPerMillionTokens)
 		if imageErr != nil {
 			h.logger.Warnf("GetModels: derive per-image USD price from %q failed (omitting PricingUSD block): %v",
 				svc.OutputPriceUSDPerMillionTokens, imageErr)
 		} else {
-			obj.PricingUSD = &ModelPricingUSD{Image: image}
+			obj.PricingUSD = &ModelPricingUSD{Prompt: "0", Completion: "0", Image: image}
 		}
 	case svc.InputPriceUSDPerMillionTokens != "" && svc.OutputPriceUSDPerMillionTokens != "":
 		prompt, promptErr := pricefeed.USDPerMillionStringToPerToken(svc.InputPriceUSDPerMillionTokens)

--- a/api/inference/internal/handler/models.go
+++ b/api/inference/internal/handler/models.go
@@ -359,7 +359,10 @@ func (h *Handler) GetModels(ctx *gin.Context) {
 	// prompt/completion.
 	switch svc.Type {
 	case constant.ServiceTypeTextToImage, constant.ServiceTypeImageEditing:
-		obj.Pricing.Prompt = svc.InputPrice
+		// Image bills per generated image (under `image`); there is no per-token
+		// charge — the input fee is fixed at 0 in the request path — so report both
+		// prompt and completion as 0 rather than a misleading per-token rate.
+		obj.Pricing.Prompt = "0"
 		obj.Pricing.Completion = "0"
 		obj.Pricing.Image = svc.OutputPrice
 	case constant.ServiceTypeVideoGeneration:

--- a/api/inference/internal/handler/models.go
+++ b/api/inference/internal/handler/models.go
@@ -62,9 +62,14 @@ type ModelCacheTokenBilling struct {
 }
 
 // ModelPricing holds per-token pricing in the smallest unit (wei).
+//
+// Prompt/Completion carry omitempty so per-unit modalities (image generation /
+// image editing) can omit the per-token fields entirely and advertise only the
+// modality they actually bill (image), rather than surfacing a per-token price
+// an OpenAI-compatible client would misread.
 type ModelPricing struct {
-	Prompt            string                  `json:"prompt"`
-	Completion        string                  `json:"completion"`
+	Prompt            string                  `json:"prompt,omitempty"`
+	Completion        string                  `json:"completion,omitempty"`
 	Image             string                  `json:"image,omitempty"`
 	Video             string                  `json:"video,omitempty"`
 	TieredPricing     []ModelPricingTier      `json:"tiered_pricing,omitempty"`
@@ -76,8 +81,14 @@ type ModelPricing struct {
 // Values are derived from the configured USD-per-1M-tokens by exact big.Rat
 // division — no float precision loss.
 type ModelPricingUSD struct {
-	Prompt     string `json:"prompt"`
-	Completion string `json:"completion"`
+	Prompt     string `json:"prompt,omitempty"`
+	Completion string `json:"completion,omitempty"`
+	// Image is the USD price per generated image for a USD-denominated
+	// image-generation / image-editing model (decimal string). Mutually
+	// exclusive with the per-token prompt/completion fields above; derived from
+	// OutputPriceUSDPerMillionTokens with the same ÷1e6 the wei conversion uses,
+	// so it stays consistent with the native pricing.image value.
+	Image string `json:"image,omitempty"`
 	// Video is the USD price per effective output second for a USD-denominated
 	// video-generation model (decimal string). Mutually exclusive with the
 	// per-token prompt/completion fields above.
@@ -324,10 +335,7 @@ func (h *Handler) GetModels(ctx *gin.Context) {
 		Type:          svc.Type,
 		Verifiability: svc.Verifiability,
 		TeeAttested:   svc.TeeSignerAcknowledged,
-		Pricing: &ModelPricing{
-			Prompt:     svc.InputPrice,
-			Completion: svc.OutputPrice,
-		},
+		Pricing:       &ModelPricing{},
 	}
 
 	if svc.CreatedAt != nil {
@@ -348,14 +356,22 @@ func (h *Handler) GetModels(ctx *gin.Context) {
 		obj.ExpirationDate = cfg.ModelInfo.ExpirationDate
 	}
 
-	// Set image pricing from output price for image service types
-	if svc.Type == constant.ServiceTypeTextToImage || svc.Type == constant.ServiceTypeImageEditing {
+	// Native per-unit pricing keyed by modality. Image generation / editing bill
+	// per generated image (OutputPrice is the per-image price), surfaced under
+	// `image` only — the per-token prompt/completion fields are left empty so an
+	// OpenAI-compatible client doesn't misread a per-token rate. Video keeps its
+	// existing shape (prompt/completion plus the per-second `video`). Token
+	// modalities use prompt/completion.
+	switch svc.Type {
+	case constant.ServiceTypeTextToImage, constant.ServiceTypeImageEditing:
 		obj.Pricing.Image = svc.OutputPrice
-	}
-
-	// Set video pricing from output price for video service type
-	if svc.Type == constant.ServiceTypeVideoGeneration {
+	case constant.ServiceTypeVideoGeneration:
+		obj.Pricing.Prompt = svc.InputPrice
+		obj.Pricing.Completion = svc.OutputPrice
 		obj.Pricing.Video = svc.OutputPrice
+	default:
+		obj.Pricing.Prompt = svc.InputPrice
+		obj.Pricing.Completion = svc.OutputPrice
 	}
 
 	// Populate tiered pricing from config
@@ -424,7 +440,21 @@ func (h *Handler) GetModels(ctx *gin.Context) {
 	// list — but the log signal prevents "PricingUSD silently missing"
 	// from going undiagnosed.
 	var priceFeedOut *PriceFeedState
-	if svc.InputPriceUSDPerMillionTokens != "" && svc.OutputPriceUSDPerMillionTokens != "" {
+	isImageType := svc.Type == constant.ServiceTypeTextToImage || svc.Type == constant.ServiceTypeImageEditing
+	switch {
+	case isImageType && svc.OutputPriceUSDPerMillionTokens != "":
+		// Image bills per generated image, not per token: surface the per-image
+		// USD under `image` only (mirrors the native pricing.image), omitting the
+		// per-token prompt/completion fields. Deriving with the same ÷1e6 used by
+		// the wei conversion keeps pricing_usd.image consistent with pricing.image.
+		image, imageErr := pricefeed.USDPerMillionStringToPerToken(svc.OutputPriceUSDPerMillionTokens)
+		if imageErr != nil {
+			h.logger.Warnf("GetModels: derive per-image USD price from %q failed (omitting PricingUSD block): %v",
+				svc.OutputPriceUSDPerMillionTokens, imageErr)
+		} else {
+			obj.PricingUSD = &ModelPricingUSD{Image: image}
+		}
+	case svc.InputPriceUSDPerMillionTokens != "" && svc.OutputPriceUSDPerMillionTokens != "":
 		prompt, promptErr := pricefeed.USDPerMillionStringToPerToken(svc.InputPriceUSDPerMillionTokens)
 		completion, completionErr := pricefeed.USDPerMillionStringToPerToken(svc.OutputPriceUSDPerMillionTokens)
 		switch {

--- a/api/inference/internal/handler/models_test.go
+++ b/api/inference/internal/handler/models_test.go
@@ -388,6 +388,92 @@ func TestGetModels_ImagePricingForImageTypes(t *testing.T) {
 	}
 }
 
+// TestGetModels_ImagePricingUSD pins the USD-denominated image-service shape:
+// the per-image price surfaces under pricing.image (wei) and pricing_usd.image
+// (USD), while the per-token prompt/completion fields are omitted entirely on
+// both blocks — an image model bills per image, not per token, so a per-token
+// rate would mislead OpenAI-compatible clients.
+func TestGetModels_ImagePricingUSD(t *testing.T) {
+	types := []string{"text-to-image", "image-editing"}
+	for _, svcType := range types {
+		t.Run(svcType, func(t *testing.T) {
+			mock := &mockModelsCtrl{
+				service: model.Service{
+					ModelType:   "stable-diffusion-xl",
+					Type:        svcType,
+					InputPrice:  "0",
+					OutputPrice: "126963160000000000",
+					// USD per 1M images: 0.04 × 1e6 → per-image USD is 0.04.
+					InputPriceUSDPerMillionTokens:  "0",
+					OutputPriceUSDPerMillionTokens: "40000",
+				},
+				serviceConfig:  config.Service{},
+				priceFeedIsUSD: true,
+			}
+
+			h := newModelsTestHandler(mock)
+			w := performRequest(h.GetModels, "GET", "/v1/models", "", nil)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("expected status 200, got %d", w.Code)
+			}
+
+			var resp ModelListResponse
+			if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+				t.Fatalf("failed to parse response: %v", err)
+			}
+			m := resp.Data[0]
+
+			// Native pricing: image only.
+			if m.Pricing.Image != "126963160000000000" {
+				t.Errorf("pricing.image = %q, want 126963160000000000", m.Pricing.Image)
+			}
+			if m.Pricing.Prompt != "" {
+				t.Errorf("pricing.prompt = %q, want empty for image service", m.Pricing.Prompt)
+			}
+			if m.Pricing.Completion != "" {
+				t.Errorf("pricing.completion = %q, want empty for image service", m.Pricing.Completion)
+			}
+
+			// USD pricing: image only.
+			if m.PricingUSD == nil {
+				t.Fatal("expected pricing_usd to be present for USD image service")
+			}
+			if m.PricingUSD.Image != "0.04" {
+				t.Errorf("pricing_usd.image = %q, want 0.04", m.PricingUSD.Image)
+			}
+			if m.PricingUSD.Prompt != "" {
+				t.Errorf("pricing_usd.prompt = %q, want empty for image service", m.PricingUSD.Prompt)
+			}
+			if m.PricingUSD.Completion != "" {
+				t.Errorf("pricing_usd.completion = %q, want empty for image service", m.PricingUSD.Completion)
+			}
+
+			// Raw-JSON check: the per-token keys must be absent, not present-and-empty.
+			var raw map[string]interface{}
+			if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
+				t.Fatalf("parse raw: %v", err)
+			}
+			data := raw["data"].([]interface{})
+			modelMap := data[0].(map[string]interface{})
+			pricing := modelMap["pricing"].(map[string]interface{})
+			if _, exists := pricing["prompt"]; exists {
+				t.Error("pricing.prompt key should be absent for image service")
+			}
+			if _, exists := pricing["completion"]; exists {
+				t.Error("pricing.completion key should be absent for image service")
+			}
+			pricingUSD := modelMap["pricing_usd"].(map[string]interface{})
+			if _, exists := pricingUSD["prompt"]; exists {
+				t.Error("pricing_usd.prompt key should be absent for image service")
+			}
+			if _, exists := pricingUSD["completion"]; exists {
+				t.Error("pricing_usd.completion key should be absent for image service")
+			}
+		})
+	}
+}
+
 func TestGetModels_ServiceError(t *testing.T) {
 	mock := &mockModelsCtrl{
 		serviceErr: errors.New("contract unreachable"),

--- a/api/inference/internal/handler/models_test.go
+++ b/api/inference/internal/handler/models_test.go
@@ -390,9 +390,9 @@ func TestGetModels_ImagePricingForImageTypes(t *testing.T) {
 
 // TestGetModels_ImagePricingUSD pins the USD-denominated image-service shape:
 // the per-image price surfaces under pricing.image (wei) and pricing_usd.image
-// (USD), while the per-token prompt/completion fields are omitted entirely on
-// both blocks — an image model bills per image, not per token, so a per-token
-// rate would mislead OpenAI-compatible clients.
+// (USD), while the per-token prompt/completion fields report 0 (an image model
+// bills per image, not per token, so a per-token rate would mislead
+// OpenAI-compatible clients).
 func TestGetModels_ImagePricingUSD(t *testing.T) {
 	types := []string{"text-to-image", "image-editing"}
 	for _, svcType := range types {
@@ -424,51 +424,29 @@ func TestGetModels_ImagePricingUSD(t *testing.T) {
 			}
 			m := resp.Data[0]
 
-			// Native pricing: image only.
+			// Native pricing: per-image price under image; per-token fields are 0.
 			if m.Pricing.Image != "126963160000000000" {
 				t.Errorf("pricing.image = %q, want 126963160000000000", m.Pricing.Image)
 			}
-			if m.Pricing.Prompt != "" {
-				t.Errorf("pricing.prompt = %q, want empty for image service", m.Pricing.Prompt)
+			if m.Pricing.Prompt != "0" {
+				t.Errorf("pricing.prompt = %q, want 0 for image service", m.Pricing.Prompt)
 			}
-			if m.Pricing.Completion != "" {
-				t.Errorf("pricing.completion = %q, want empty for image service", m.Pricing.Completion)
+			if m.Pricing.Completion != "0" {
+				t.Errorf("pricing.completion = %q, want 0 for image service", m.Pricing.Completion)
 			}
 
-			// USD pricing: image only.
+			// USD pricing: per-image USD under image; per-token fields are 0.
 			if m.PricingUSD == nil {
 				t.Fatal("expected pricing_usd to be present for USD image service")
 			}
 			if m.PricingUSD.Image != "0.04" {
 				t.Errorf("pricing_usd.image = %q, want 0.04", m.PricingUSD.Image)
 			}
-			if m.PricingUSD.Prompt != "" {
-				t.Errorf("pricing_usd.prompt = %q, want empty for image service", m.PricingUSD.Prompt)
+			if m.PricingUSD.Prompt != "0" {
+				t.Errorf("pricing_usd.prompt = %q, want 0 for image service", m.PricingUSD.Prompt)
 			}
-			if m.PricingUSD.Completion != "" {
-				t.Errorf("pricing_usd.completion = %q, want empty for image service", m.PricingUSD.Completion)
-			}
-
-			// Raw-JSON check: the per-token keys must be absent, not present-and-empty.
-			var raw map[string]interface{}
-			if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
-				t.Fatalf("parse raw: %v", err)
-			}
-			data := raw["data"].([]interface{})
-			modelMap := data[0].(map[string]interface{})
-			pricing := modelMap["pricing"].(map[string]interface{})
-			if _, exists := pricing["prompt"]; exists {
-				t.Error("pricing.prompt key should be absent for image service")
-			}
-			if _, exists := pricing["completion"]; exists {
-				t.Error("pricing.completion key should be absent for image service")
-			}
-			pricingUSD := modelMap["pricing_usd"].(map[string]interface{})
-			if _, exists := pricingUSD["prompt"]; exists {
-				t.Error("pricing_usd.prompt key should be absent for image service")
-			}
-			if _, exists := pricingUSD["completion"]; exists {
-				t.Error("pricing_usd.completion key should be absent for image service")
+			if m.PricingUSD.Completion != "0" {
+				t.Errorf("pricing_usd.completion = %q, want 0 for image service", m.PricingUSD.Completion)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Image-generation / image-editing services bill **per generated image**, but the broker's pricing config and `GET /v1/models` output were token-shaped, producing two problems:

1. **Misleading API output** — `pricing.completion` carried the per-image price (duplicating `image`), and `pricing_usd` had no `image` field at all (the per-image USD showed up as `pricing_usd.completion`). An OpenAI-compatible client would misread these as per-token rates.
2. **Awkward config** — a USD image service had to express its price through `outputPriceUSDPerMillionTokens` (e.g. `"40000"` for $0.04/image), which is semantically "USD per 1M images" and easy to get wrong.

This PR fixes both: a dedicated `service.outputPriceUSDPerImage` config field, and a clean image-only shape in the models API.

## Changes

### 1. `pricing_usd.image` in `GET /v1/models` (`internal/handler/models.go`)
- Added an `Image` field to `ModelPricingUSD`.
- For image service types, the per-image price is surfaced under `pricing.image` (wei) and `pricing_usd.image` (USD); the per-token `prompt`/`completion` fields report `0` (image bills per image, not per token).
- Video keeps its existing shape; no `omitempty` changes, so other modalities are unaffected.

### 2. `service.outputPriceUSDPerImage` config (`config/config.go`)
- New service-level field for USD-denominated image services, mirroring the existing `outputPriceUSDPerSecond` for video.
- **Mandatory** for `text-to-image` / `image-editing` under `priceDenomination: "USD"`; the per-1M-token USD fields are **forbidden** for those types.
- Forbidden for non-image types and under NATIVE denomination.
- Normalized at config load into `outputPriceUSDPerMillionTokens` (×1e6, input side fixed at `"0"`) so the existing price-feed / on-chain / display pipeline consumes it unchanged (the pipeline's ÷1e6 quantum cancels the ×1e6).

## How pricing flows end-to-end

### USD mode (new)

```yaml
service:
  type: "text-to-image"          # or image-editing
  model: "stable-diffusion-xl"
  priceDenomination: "USD"
  outputPriceUSDPerImage: "0.04"  # the only price you configure
priceFeed:
  sources: ["coingecko", "binance"]
  updateInterval: "1h"
  stalenessThreshold: "2h"
```

- **Config load** normalizes: `outputPriceUSDPerMillionTokens = "40000"`, `inputPriceUSDPerMillionTokens = "0"`.
- **On-chain price is auto-derived** — `PriceUpdateProcessor` converts USD→wei with the live rate and syncs it on-chain; you never hand-set the wei price. e.g. at rate ≈ 0.315 USD/0G → `OutputPrice ≈ 126963160000000000` wei (floor-quantized), `InputPrice = 0`.
- **Billing**: `fee = OutputPrice(wei) × imageNum`.
- **`GET /v1/models`**:

```json
{
  "data": [{
    "id": "stable-diffusion-xl",
    "type": "text-to-image",
    "pricing":     { "prompt": "0", "completion": "0", "image": "126963160000000000" },
    "pricing_usd": { "prompt": "0", "completion": "0", "image": "0.04" }
  }],
  "price_feed": { "rate_usd_per_og": "0.31500000", "is_stale": false }
}
```

`pricing.image` (wei) and `pricing_usd.image` (USD) stay consistent via the shared ÷1e6.

### NATIVE mode (for comparison)

```yaml
service:
  type: "text-to-image"
  model: "stable-diffusion-xl"
  priceDenomination: "NATIVE"        # default
  outputPrice: "126963160000000000"  # the on-chain per-image wei price, set directly
```

Output has no `pricing_usd` / `price_feed`:

```json
"pricing": { "prompt": "0", "completion": "0", "image": "126963160000000000" }
```

## ⚠️ Breaking change

This is a **breaking config change**: an existing USD `text-to-image` / `image-editing` service configured with `outputPriceUSDPerMillionTokens` will now fail to load and must switch to `outputPriceUSDPerImage`. Update any live image-service configs before upgrading.

## Testing

- `internal/handler`: `TestGetModels_ImagePricingUSD` (both image types) asserting `pricing.image` / `pricing_usd.image` populated and per-token fields = `"0"`.
- `config`: normalization (both image types), missing field, per-1M-token rejection for image, per-image rejection for non-image, per-image rejection under NATIVE.
- `go build ./...`, plus `config` / `handler` / `event` test suites all green.

https://claude.ai/code/session_01GRo1wsj3EB1mJbQ7YyLi1u

---
_Generated by [Claude Code](https://claude.ai/code/session_01GRo1wsj3EB1mJbQ7YyLi1u)_