### PR TITLE
feat(inference): enforce model expirationDate by rejecting requests

### DIFF
--- a/api/inference/config/config.go
+++ b/api/inference/config/config.go
@@ -146,10 +146,22 @@ func (m *ModelInfo) Validate(serviceType string) error {
 // returning false when none is configured. Resolution mirrors /v1/models
 // metadata: a per-model pricing entry's own ModelInfo wins wholesale (no
 // field-level fallback), otherwise the service-level ModelInfo applies.
+//
+// In multi-model mode a model that resolves to no pricing entry (unknown, with
+// no wildcard) returns false rather than inheriting the service-level
+// expiration — such a request is not one this service serves, so it is left to
+// the allowlist to reject as "not supported" instead of being mislabeled
+// "expired".
 func (s *Service) ModelExpiration(model string) (time.Time, bool) {
 	mi := s.ModelInfo
-	if mp := s.GetModelPricing(model); mp != nil && mp.ModelInfo != nil {
-		mi = mp.ModelInfo
+	if s.HasMultiModelPricing() {
+		mp := s.GetModelPricing(model)
+		if mp == nil {
+			return time.Time{}, false
+		}
+		if mp.ModelInfo != nil {
+			mi = mp.ModelInfo
+		}
 	}
 	if mi != nil && !mi.expiresAt.IsZero() {
 		return mi.expiresAt, true

--- a/api/inference/config/config.go
+++ b/api/inference/config/config.go
@@ -93,12 +93,17 @@ type ModelInfo struct {
 	SupportedFormats    []string               `yaml:"supportedFormats"`    // Optional. API formats this model supports, e.g., ["openai", "anthropic"]. Defaults to ["openai"] if omitted.
 	DefaultParameters   map[string]interface{} `yaml:"defaultParameters"`   // Optional. Default values for parameters, e.g., {"temperature": 0.7, "top_p": 0.9}
 	TeeType             string                 `yaml:"teeType"`             // Optional. TEE hardware type, e.g., "TDX", "SEV", "SGX", "H100"
-	ExpirationDate      string                 `yaml:"expirationDate"`      // Optional. Model availability expiration in RFC3339 format, e.g., "2026-12-31T00:00:00Z"
+	ExpirationDate      string                 `yaml:"expirationDate"`      // Optional. Model availability expiration in RFC3339 format, e.g., "2026-12-31T00:00:00Z". After this instant the broker rejects requests for the model with HTTP 410.
 
 	// VideoSizeRatios maps output resolution (e.g., "1280x720") to a cost multiplier.
 	// Used for video generation billing: fee = seconds × sizeRatio × outputPrice.
 	// Defaults are applied if not configured (see DefaultVideoSizeRatios).
 	VideoSizeRatios map[string]float64 `yaml:"videoSizeRatios"`
+
+	// expiresAt is the parsed form of ExpirationDate, populated by Validate at
+	// load time so request-path expiration checks never re-parse the string.
+	// Zero value means no expiration is configured.
+	expiresAt time.Time `yaml:"-"`
 }
 
 // Validate checks that all required ModelInfo fields are set.
@@ -124,7 +129,32 @@ func (m *ModelInfo) Validate(serviceType string) error {
 	if len(m.SupportedParameters) == 0 {
 		return fmt.Errorf("service.modelInfo.supportedParameters is required")
 	}
+	// Parse the optional expiration once at load time so the request path never
+	// re-parses it. An unparseable value is a config error (fail fast) rather
+	// than a silently ignored string.
+	if m.ExpirationDate != "" {
+		t, err := time.Parse(time.RFC3339, m.ExpirationDate)
+		if err != nil {
+			return fmt.Errorf("service.modelInfo.expirationDate %q is not valid RFC3339 (e.g. \"2026-12-31T00:00:00Z\"): %w", m.ExpirationDate, err)
+		}
+		m.expiresAt = t
+	}
 	return nil
+}
+
+// ModelExpiration resolves the availability expiration for the given model,
+// returning false when none is configured. Resolution mirrors /v1/models
+// metadata: a per-model pricing entry's own ModelInfo wins wholesale (no
+// field-level fallback), otherwise the service-level ModelInfo applies.
+func (s *Service) ModelExpiration(model string) (time.Time, bool) {
+	mi := s.ModelInfo
+	if mp := s.GetModelPricing(model); mp != nil && mp.ModelInfo != nil {
+		mi = mp.ModelInfo
+	}
+	if mi != nil && !mi.expiresAt.IsZero() {
+		return mi.expiresAt, true
+	}
+	return time.Time{}, false
 }
 
 type Service struct {

--- a/api/inference/config/config_test.go
+++ b/api/inference/config/config_test.go
@@ -1789,4 +1789,43 @@ func TestService_ModelExpiration(t *testing.T) {
 			t.Errorf("ModelExpiration(m1) = %v, ok=%v; want %v, true", got, ok, wantTime)
 		}
 	})
+
+	t.Run("multi-model unknown model does not inherit service-level expiration", func(t *testing.T) {
+		svcMI := validModelInfo()
+		svcMI.ExpirationDate = exp
+		if err := svcMI.Validate("chatbot"); err != nil {
+			t.Fatal(err)
+		}
+		s := &Service{
+			ModelInfo:    svcMI,
+			ModelPricing: []ModelPricingEntry{{Model: "m1"}},
+		}
+		if err := s.BuildModelPricingMap(); err != nil {
+			t.Fatal(err)
+		}
+		// "unknown" has no entry and there is no wildcard; it is not served by
+		// this broker, so expiration must defer to the allowlist (ok=false)
+		// rather than mislabel it as expired via the service-level fallback.
+		if _, ok := s.ModelExpiration("unknown"); ok {
+			t.Error("expected ok=false for an unknown model in multi-model mode")
+		}
+	})
+
+	t.Run("multi-model wildcard expiration applies to any served model", func(t *testing.T) {
+		wildMI := validModelInfo()
+		wildMI.ExpirationDate = exp
+		if err := wildMI.Validate("chatbot"); err != nil {
+			t.Fatal(err)
+		}
+		s := &Service{
+			ModelPricing: []ModelPricingEntry{{Model: ModelWildcard, ModelInfo: wildMI}},
+		}
+		if err := s.BuildModelPricingMap(); err != nil {
+			t.Fatal(err)
+		}
+		got, ok := s.ModelExpiration("any-model-name")
+		if !ok || !got.Equal(wantTime) {
+			t.Errorf("ModelExpiration(any-model-name) = %v, ok=%v; want %v, true", got, ok, wantTime)
+		}
+	})
 }

--- a/api/inference/config/config_test.go
+++ b/api/inference/config/config_test.go
@@ -1679,3 +1679,114 @@ func TestScaledUnits_Overflow(t *testing.T) {
 		t.Errorf("scaledUnits(5,2.25) = %d, err %v; want 12", u, err)
 	}
 }
+
+func TestModelInfo_Validate_ExpirationDate(t *testing.T) {
+	t.Run("valid RFC3339 parses into expiresAt", func(t *testing.T) {
+		m := validModelInfo()
+		m.ExpirationDate = "2026-12-31T00:00:00Z"
+		if err := m.Validate("chatbot"); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		want, _ := time.Parse(time.RFC3339, "2026-12-31T00:00:00Z")
+		if !m.expiresAt.Equal(want) {
+			t.Errorf("expiresAt = %v, want %v", m.expiresAt, want)
+		}
+	})
+
+	t.Run("empty leaves expiresAt zero", func(t *testing.T) {
+		m := validModelInfo()
+		if err := m.Validate("chatbot"); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if !m.expiresAt.IsZero() {
+			t.Errorf("expiresAt = %v, want zero", m.expiresAt)
+		}
+	})
+
+	t.Run("malformed date is rejected", func(t *testing.T) {
+		m := validModelInfo()
+		m.ExpirationDate = "2026-12-31" // missing time + zone
+		err := m.Validate("chatbot")
+		if err == nil || !strings.Contains(err.Error(), "expirationDate") {
+			t.Errorf("expected expirationDate error, got %v", err)
+		}
+	})
+}
+
+func TestService_ModelExpiration(t *testing.T) {
+	exp := "2026-12-31T00:00:00Z"
+	wantTime, _ := time.Parse(time.RFC3339, exp)
+
+	t.Run("no expiration configured", func(t *testing.T) {
+		s := &Service{ModelInfo: validModelInfo()}
+		if err := s.ModelInfo.Validate("chatbot"); err != nil {
+			t.Fatal(err)
+		}
+		if _, ok := s.ModelExpiration("anything"); ok {
+			t.Error("expected ok=false when no expiration configured")
+		}
+	})
+
+	t.Run("single-model service-level expiration", func(t *testing.T) {
+		mi := validModelInfo()
+		mi.ExpirationDate = exp
+		if err := mi.Validate("chatbot"); err != nil {
+			t.Fatal(err)
+		}
+		s := &Service{ModelType: "m1", ModelInfo: mi}
+		got, ok := s.ModelExpiration("m1")
+		if !ok || !got.Equal(wantTime) {
+			t.Errorf("ModelExpiration = %v, ok=%v; want %v, true", got, ok, wantTime)
+		}
+	})
+
+	t.Run("multi-model per-entry expiration wins over service-level", func(t *testing.T) {
+		entryMI := validModelInfo()
+		entryMI.ExpirationDate = exp
+		if err := entryMI.Validate("chatbot"); err != nil {
+			t.Fatal(err)
+		}
+		svcMI := validModelInfo() // no expiration
+		if err := svcMI.Validate("chatbot"); err != nil {
+			t.Fatal(err)
+		}
+		s := &Service{
+			ModelInfo: svcMI,
+			ModelPricing: []ModelPricingEntry{
+				{Model: "expired", ModelInfo: entryMI},
+				{Model: "fresh", ModelInfo: svcMI},
+			},
+		}
+		if err := s.BuildModelPricingMap(); err != nil {
+			t.Fatal(err)
+		}
+		// Entry with its own ModelInfo (no expiry) does NOT inherit service-level —
+		// matches /v1/models resolution where per-entry ModelInfo wins wholesale.
+		if _, ok := s.ModelExpiration("fresh"); ok {
+			t.Error("expected ok=false for entry whose ModelInfo has no expiration")
+		}
+		got, ok := s.ModelExpiration("expired")
+		if !ok || !got.Equal(wantTime) {
+			t.Errorf("ModelExpiration(expired) = %v, ok=%v; want %v, true", got, ok, wantTime)
+		}
+	})
+
+	t.Run("multi-model entry without ModelInfo falls back to service-level", func(t *testing.T) {
+		svcMI := validModelInfo()
+		svcMI.ExpirationDate = exp
+		if err := svcMI.Validate("chatbot"); err != nil {
+			t.Fatal(err)
+		}
+		s := &Service{
+			ModelInfo:    svcMI,
+			ModelPricing: []ModelPricingEntry{{Model: "m1"}},
+		}
+		if err := s.BuildModelPricingMap(); err != nil {
+			t.Fatal(err)
+		}
+		got, ok := s.ModelExpiration("m1")
+		if !ok || !got.Equal(wantTime) {
+			t.Errorf("ModelExpiration(m1) = %v, ok=%v; want %v, true", got, ok, wantTime)
+		}
+	})
+}

--- a/api/inference/integration/config/config.mainnet.yml
+++ b/api/inference/integration/config/config.mainnet.yml
@@ -94,7 +94,7 @@ service:
   #     temperature: 0.7
   #     top_p: 0.9
   #   teeType: "TDX"
-  #   expirationDate: "2026-12-31T00:00:00Z"
+  #   expirationDate: "2026-12-31T00:00:00Z"  # After this instant, requests for the model are rejected with HTTP 410.
 
 # Network configuration for blockchain connection (0G mainnet)
 network:

--- a/api/inference/integration/config/config.testnet.yml
+++ b/api/inference/integration/config/config.testnet.yml
@@ -94,7 +94,7 @@ service:
   #     temperature: 0.7
   #     top_p: 0.9
   #   teeType: "TDX"
-  #   expirationDate: "2026-12-31T00:00:00Z"
+  #   expirationDate: "2026-12-31T00:00:00Z"  # After this instant, requests for the model are rejected with HTTP 410.
 
 # Network configuration for blockchain connection (0G testnet)
 network:

--- a/api/inference/integration/provider/config.example.yaml
+++ b/api/inference/integration/provider/config.example.yaml
@@ -53,7 +53,7 @@ service:
   #     temperature: 0.7
   #     top_p: 0.9
   #   teeType: "TDX"
-  #   expirationDate: "2026-12-31T00:00:00Z"  # Model availability expiration (RFC3339)
+  #   expirationDate: "2026-12-31T00:00:00Z"  # Model availability expiration (RFC3339). After this instant, requests for the model are rejected with HTTP 410.
   #   supportedParameters:
   #     - temperature
   #     - top_p

--- a/api/inference/integration_test/expiration_test.go
+++ b/api/inference/integration_test/expiration_test.go
@@ -1,0 +1,100 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/0glabs/0g-serving-broker/inference/config"
+)
+
+// chatbotModelInfo returns a complete, valid ModelInfo for a chatbot model with
+// the given RFC3339 expiration. Calling Validate mirrors production loadConfig,
+// which is where the expiration string is parsed into the internal time used by
+// the request-path expiration gate.
+func chatbotModelInfo(t *testing.T, expiration string) *config.ModelInfo {
+	t.Helper()
+	mi := &config.ModelInfo{
+		Name:          "GPT-4o",
+		Description:   "test model",
+		ContextLength: 4096,
+		Architecture: &config.ModelArchitecture{
+			Modality:         "text->text",
+			InputModalities:  []string{"text"},
+			OutputModalities: []string{"text"},
+		},
+		SupportedParameters: []string{"temperature"},
+		ExpirationDate:      expiration,
+	}
+	if err := mi.Validate("chatbot"); err != nil {
+		t.Fatalf("validate model info: %v", err)
+	}
+	return mi
+}
+
+// TestChatbotFlow_ModelExpired verifies that a request for a model whose
+// expirationDate is in the past is rejected with HTTP 410 before it is ever
+// forwarded upstream — for any user, including the request that would otherwise
+// bill normally. The mock provider asserts it receives no request.
+func TestChatbotFlow_ModelExpired(t *testing.T) {
+	mockProvider := newMockChatbotProvider(t)
+	t.Cleanup(func() { mockProvider.Close() })
+
+	env := setupTestEnv(t, func(cfg *config.Config) {
+		cfg.Service.TargetURL = mockProvider.URL
+		cfg.Service.Type = "chatbot"
+		cfg.Service.ModelType = "gpt-4o"
+		cfg.Service.TargetSeparated = true
+		cfg.Service.ModelInfo = chatbotModelInfo(t, "2020-01-01T00:00:00Z")
+	})
+
+	reqBody := `{"model":"gpt-4o","messages":[{"role":"user","content":"Hi"}],"stream":false}`
+	req := httptest.NewRequest("POST", "/v1/proxy/chat/completions", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", createAuthHeader(t, env.privateKey, env.providerAddr))
+
+	w := httptest.NewRecorder()
+	env.engine.ServeHTTP(w, req)
+
+	if w.Code != http.StatusGone {
+		t.Fatalf("expected 410, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := w.Header().Get("Cache-Control"); got != "no-store" {
+		t.Errorf("expected Cache-Control no-store, got %q", got)
+	}
+	if body := w.Body.String(); !strings.Contains(body, "expired") {
+		t.Errorf("expected expiration message in body, got %s", body)
+	}
+}
+
+// TestChatbotFlow_ModelNotExpired verifies the gate does not over-block: a model
+// with a future expirationDate is served normally.
+func TestChatbotFlow_ModelNotExpired(t *testing.T) {
+	mockProvider := newMockChatbotProvider(t)
+	t.Cleanup(func() { mockProvider.Close() })
+
+	future := time.Now().Add(24 * time.Hour).UTC().Format(time.RFC3339)
+	env := setupTestEnv(t, func(cfg *config.Config) {
+		cfg.Service.TargetURL = mockProvider.URL
+		cfg.Service.Type = "chatbot"
+		cfg.Service.ModelType = "gpt-4o"
+		cfg.Service.TargetSeparated = true
+		cfg.Service.ModelInfo = chatbotModelInfo(t, future)
+	})
+
+	reqBody := `{"model":"gpt-4o","messages":[{"role":"user","content":"Hi"}],"stream":false}`
+	req := httptest.NewRequest("POST", "/v1/proxy/chat/completions", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", createAuthHeader(t, env.privateKey, env.providerAddr))
+
+	w := httptest.NewRecorder()
+	env.engine.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for unexpired model, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/api/inference/internal/proxy/proxy.go
+++ b/api/inference/internal/proxy/proxy.go
@@ -624,6 +624,24 @@ func (p *Proxy) proxyHTTPRequest(ctx *gin.Context) {
 		return
 	}
 
+	// Reject requests for an expired model before any further processing. This
+	// runs ahead of the whitelist branch on purpose: an expired model is
+	// unavailable to everyone, including whitelisted users.
+	modelForExpiry := reqModelName
+	if modelForExpiry == "" {
+		modelForExpiry = p.ctrl.Service.ModelType
+	}
+	if exp, ok := p.ctrl.Service.ModelExpiration(modelForExpiry); ok && time.Now().After(exp) {
+		ctx.Set("ignoreError", true)
+		ctx.Set(monitor.CtxKeyRejectionReason, monitor.RejectionModelExpired)
+		p.rejections.record(monitor.RejectionModelExpired, userAddress)
+		ctx.JSON(http.StatusGone, gin.H{
+			"error": fmt.Sprintf("model %q is no longer available (expired at %s)",
+				modelForExpiry, exp.Format(time.RFC3339)),
+		})
+		return
+	}
+
 	// Whitelisted users bypass billing but still need normal response processing
 	if isWhitelisted {
 		// Sanitize path for logging - never log query parameters that may contain sensitive data

--- a/api/inference/internal/proxy/proxy.go
+++ b/api/inference/internal/proxy/proxy.go
@@ -635,6 +635,10 @@ func (p *Proxy) proxyHTTPRequest(ctx *gin.Context) {
 		ctx.Set("ignoreError", true)
 		ctx.Set(monitor.CtxKeyRejectionReason, monitor.RejectionModelExpired)
 		p.rejections.record(monitor.RejectionModelExpired, userAddress)
+		// 410 is cacheable by default; an operator can re-enable the model by
+		// extending expirationDate and restarting, so forbid caching to ensure
+		// the rejection never outlives the config that produced it.
+		ctx.Header("Cache-Control", "no-store")
 		ctx.JSON(http.StatusGone, gin.H{
 			"error": fmt.Sprintf("model %q is no longer available (expired at %s)",
 				modelForExpiry, exp.Format(time.RFC3339)),

--- a/api/inference/monitor/server.go
+++ b/api/inference/monitor/server.go
@@ -85,6 +85,7 @@ const (
 	RejectionNotAcknowledged = "not_acknowledged"
 	RejectionAccountNotExist = "account_not_exist"
 	RejectionUpstreamError   = "upstream_error"
+	RejectionModelExpired    = "model_expired"
 )
 
 // CtxKeyRejectionReason is the gin context key under which a request handler


### PR DESCRIPTION
Related issue: 0gfoundation/0g-router#459

## Summary

The `expirationDate` field in `ModelInfo` was display-only — surfaced in `/v1/models` but never enforced. This wires it into the request path so an expired model becomes actually unavailable: after the configured instant, requests for the model are rejected with **HTTP 410 Gone** before being forwarded upstream.

## What changed

- **Parse + validate at load** (`config/config.go`): `ModelInfo.Validate` now parses `expirationDate` as RFC3339 once at startup, failing fast on malformed values (previously a bad date was silently accepted). The parsed time is cached in an unexported `expiresAt` field so the request path never re-parses.
- **Resolution helper** (`Service.ModelExpiration`): resolves per-model `ModelInfo` first, falling back to service-level `ModelInfo`, mirroring `/v1/models` metadata resolution. In multi-model mode an unknown model (no pricing entry, no wildcard) returns "no expiration" so it's left to the allowlist to reject as "not supported" rather than mislabeled "expired".
- **Enforcement gate** (`internal/proxy/proxy.go`): rejects expired-model requests with **410 Gone** in the proxy admission flow, placed *ahead of the whitelist branch* so it applies to everyone, including whitelisted users. Sets `Cache-Control: no-store` (410 is cacheable by default, and a model can be re-enabled by extending `expirationDate` and restarting, so the rejection must not outlive its config). Records a `model_expired` rejection metric.

## Semantics / operational notes

- Expiration is **not persisted** — it's recomputed per request from config + wall clock. A running broker auto-expires a model when the clock passes the date; an operator re-enables it by editing config and restarting (config has no hot-reload). Fully reversible, no stuck state.
- Scope is **per-model**. For a single-model provider this is effectively "reject all requests"; for multi-model only the expired model is affected.

## Tests

- Unit (`config`): RFC3339 parse/validate (incl. malformed rejection), and `ModelExpiration` resolution across single-model, multi-model per-entry override, service-level fallback, unknown-model deferral, and wildcard.
- Integration (`integration_test`, testcontainers MySQL + seeded caches, no live contract): an expired model is rejected with `410 + Cache-Control: no-store` before reaching upstream; a model with a future expiration is served normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)