### PR TITLE
feat(inference): unified failure-attribution metric (source/code/model/status)

### DIFF
--- a/api/inference/internal/ctrl/proxy.go
+++ b/api/inference/internal/ctrl/proxy.go
@@ -434,6 +434,10 @@ func (c *Ctrl) handleBrokerError(ctx *gin.Context, err error, context string) {
 }
 
 func (c *Ctrl) handleServiceError(ctx *gin.Context, resp *http.Response) {
+	// Attribute this failure to the provider, not the broker, in the unified
+	// failure metric (broker_request_failures_total). Set before any early
+	// return so even an unreadable upstream body is counted as upstream.
+	ctx.Set(monitor.CtxKeyFailureSource, monitor.FailureSourceUpstream)
 	statusCode := resp.StatusCode
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/api/inference/internal/proxy/proxy.go
+++ b/api/inference/internal/proxy/proxy.go
@@ -522,19 +522,19 @@ func (p *Proxy) proxyHTTPRequest(ctx *gin.Context) {
 		// log-amplification vector in #542). Rejections are now recorded to the
 		// Prometheus counter and summarized periodically by p.rejections.
 		if !middleware.CheckPerUserRateLimit(p.perUserRateLimiter, ctx, userAddress) {
-			p.rejections.record(monitor.RejectionRateLimit, userAddress)
+			p.rejections.record(ctx, monitor.RejectionRateLimit, userAddress)
 			return
 		}
 		if !middleware.CheckPerUserTPMLimit(p.perUserTPMLimiter, ctx, userAddress, svcType) {
-			p.rejections.record(monitor.RejectionTPMLimit, userAddress)
+			p.rejections.record(ctx, monitor.RejectionTPMLimit, userAddress)
 			return
 		}
 		if !middleware.CheckPerUserIPMLimit(p.perUserIPMLimiter, ctx, userAddress, svcType) {
-			p.rejections.record(monitor.RejectionIPMLimit, userAddress)
+			p.rejections.record(ctx, monitor.RejectionIPMLimit, userAddress)
 			return
 		}
 		if !middleware.CheckPerUserConcurrency(p.perUserConcurrencyLimiter, ctx, userAddress) {
-			p.rejections.record(monitor.RejectionConcurrency, userAddress)
+			p.rejections.record(ctx, monitor.RejectionConcurrency, userAddress)
 			return
 		}
 		defer p.perUserConcurrencyLimiter.Release(userAddress)
@@ -608,7 +608,7 @@ func (p *Proxy) proxyHTTPRequest(ctx *gin.Context) {
 		// expires — the same unbounded-log concern as the rate-limit gate.
 		ctx.Set("ignoreError", true)
 		remainingTime := blockedUntil.Sub(time.Now())
-		p.rejections.record(monitor.RejectionModelMismatch, userAddress)
+		p.rejections.record(ctx, monitor.RejectionModelMismatch, userAddress)
 
 		ctx.JSON(http.StatusTooManyRequests, gin.H{
 			"error": fmt.Sprintf("Rate limit exceeded: too many invalid model requests. Please try again in %v", remainingTime.Round(time.Minute)),
@@ -633,8 +633,8 @@ func (p *Proxy) proxyHTTPRequest(ctx *gin.Context) {
 	}
 	if exp, ok := p.ctrl.Service.ModelExpiration(modelForExpiry); ok && time.Now().After(exp) {
 		ctx.Set("ignoreError", true)
-		ctx.Set(monitor.CtxKeyRejectionReason, monitor.RejectionModelExpired)
-		p.rejections.record(monitor.RejectionModelExpired, userAddress)
+		// record stamps CtxKeyRejectionReason for the unified failure metric.
+		p.rejections.record(ctx, monitor.RejectionModelExpired, userAddress)
 		// 410 is cacheable by default; an operator can re-enable the model by
 		// extending expirationDate and restarting, so forbid caching to ensure
 		// the rejection never outlives the config that produced it.
@@ -764,7 +764,7 @@ func (p *Proxy) proxyHTTPRequest(ctx *gin.Context) {
 		// exist), so handleBrokerError logs nothing. Record the classified reason
 		// it stashed in the context (defaulting to upstream_error for unclassified
 		// server-side failures) so these rejections are observable again.
-		p.rejections.record(rejectionReasonFromContext(ctx), userAddress)
+		p.rejections.record(ctx, rejectionReasonFromContext(ctx), userAddress)
 		p.handleBrokerError(ctx, err, "validate request")
 		return
 	}

--- a/api/inference/internal/proxy/proxy.go
+++ b/api/inference/internal/proxy/proxy.go
@@ -195,6 +195,23 @@ func New(ctrl *ctrl.Ctrl, engine *gin.Engine, allowOrigins []string, enableMonit
 
 	p.serviceGroup.Use(cors.New(corsConfig))
 
+	// TrackMetrics is registered BEFORE the admission middlewares below so its
+	// post-c.Next() recording wraps them. The concrete case this fixes is the
+	// global concurrency limiter: it aborts with 503 at the middleware level
+	// (before the handler), so on the old ordering — TrackMetrics last — that
+	// 503 never reached the metrics and the broker looked failure-free precisely
+	// while shedding the most load. Now the abort unwinds back through
+	// TrackMetrics, which counts it (source=broker, status="Service
+	// Unavailable"). This also makes the concurrency limiter's ignoreError flag
+	// live again: it keeps the 503 out of ErrorCount while FailureCount still
+	// records it. (RateLimitMiddleware is a no-op; the size limit 413 and the
+	// per-user 429s are emitted inside the handler, so those were already
+	// wrapped regardless of order.) Registered AFTER cors so cross-origin
+	// preflight OPTIONS that cors short-circuits are not counted as traffic.
+	if enableMonitor {
+		p.serviceGroup.Use(monitor.TrackMetrics())
+	}
+
 	// Apply rate limiting middleware
 	p.serviceGroup.Use(middleware.RateLimitMiddleware(p.rateLimiter))
 
@@ -205,10 +222,6 @@ func New(ctrl *ctrl.Ctrl, engine *gin.Engine, allowOrigins []string, enableMonit
 
 	// Apply request size limit middleware (32MB)
 	p.serviceGroup.Use(middleware.RequestSizeLimitMiddleware(middleware.MaxRequestSize))
-
-	if enableMonitor {
-		p.serviceGroup.Use(monitor.TrackMetrics())
-	}
 
 	return p
 }

--- a/api/inference/internal/proxy/rejection.go
+++ b/api/inference/internal/proxy/rejection.go
@@ -88,8 +88,18 @@ func newRejectionAggregator(logger log.Logger, interval time.Duration) *rejectio
 // addresses out of the logs per CLAUDE.md while avoiding the distinct-user
 // undercount that truncating-as-key would cause when two wallets share the
 // 6+4-char prefix. An empty user is recorded against the reason total only.
-func (a *rejectionAggregator) record(reason, user string) {
+//
+// ctx may be nil (tests, non-gin callers); when set, the reason is stamped under
+// monitor.CtxKeyRejectionReason so TrackMetrics' single emit site can label the
+// unified failure counter (broker_request_failures_total) with this code. Doing
+// it here means every rejection — context-classified or recorded inline (rate
+// limit, concurrency, …) — surfaces its code without each call site repeating
+// the Set.
+func (a *rejectionAggregator) record(ctx *gin.Context, reason, user string) {
 	monitor.RecordRejection(reason)
+	if ctx != nil {
+		ctx.Set(monitor.CtxKeyRejectionReason, reason)
+	}
 	if a == nil {
 		return
 	}

--- a/api/inference/internal/proxy/rejection_test.go
+++ b/api/inference/internal/proxy/rejection_test.go
@@ -46,9 +46,9 @@ func TestRejectionAggregator_FlushSummarizesPerReason(t *testing.T) {
 
 	// 5 rejections for one user, 2 reasons.
 	for i := 0; i < 5; i++ {
-		a.record(monitor.RejectionInsufficientBal, "0x4870000000000000000000000000000000a4E9")
+		a.record(nil, monitor.RejectionInsufficientBal, "0x4870000000000000000000000000000000a4E9")
 	}
-	a.record(monitor.RejectionRateLimit, "0x1111000000000000000000000000000000002222")
+	a.record(nil, monitor.RejectionRateLimit, "0x1111000000000000000000000000000000002222")
 
 	a.flush()
 
@@ -79,7 +79,7 @@ func TestRejectionAggregator_BoundsTrackedUsers(t *testing.T) {
 	// not grow without bound; the excess is folded into the overflow tally.
 	total := maxRejectionUsersPerReason + 50
 	for i := 0; i < total; i++ {
-		a.record(monitor.RejectionRateLimit, addrForIndex(i))
+		a.record(nil, monitor.RejectionRateLimit, addrForIndex(i))
 	}
 
 	b := a.buckets[monitor.RejectionRateLimit]
@@ -129,7 +129,7 @@ func TestRejectionAggregator_NilReceiverRecordDoesNotPanic(t *testing.T) {
 	// A Proxy built outside New() (e.g. the test helper) has a nil aggregator.
 	// record must still fire the metric without panicking.
 	var a *rejectionAggregator
-	a.record(monitor.RejectionRateLimit, "0x4870000000000000000000000000000000a4E9")
+	a.record(nil, monitor.RejectionRateLimit, "0x4870000000000000000000000000000000a4E9")
 }
 
 func TestRejectionAggregator_StopIsIdempotent(t *testing.T) {
@@ -143,8 +143,8 @@ func TestRejectionAggregator_DistinctTruncationCollisionsCountedSeparately(t *te
 	a := newTestAggregator(logger)
 	// Two addresses that share the 6+4 truncation prefix but differ in the
 	// middle must be counted as two distinct users, not merged.
-	a.record(monitor.RejectionRateLimit, "0x4870aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa4E9")
-	a.record(monitor.RejectionRateLimit, "0x4870bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb4E9")
+	a.record(nil, monitor.RejectionRateLimit, "0x4870aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa4E9")
+	a.record(nil, monitor.RejectionRateLimit, "0x4870bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb4E9")
 	b := a.buckets[monitor.RejectionRateLimit]
 	if got := len(b.users); got != 2 {
 		t.Fatalf("expected 2 distinct users despite shared truncation prefix, got %d", got)

--- a/api/inference/monitor/server.go
+++ b/api/inference/monitor/server.go
@@ -70,7 +70,16 @@ var (
 	// that ends in failure (HTTP status >= 400 — whether the broker rejected it
 	// before forwarding or the upstream provider returned a non-2xx we proxied
 	// back) increments it exactly once, labeled so a single query answers
-	// "whose fault, which model, what code":
+	// "whose fault, which model, what code". Coverage is every failure that
+	// flows through a synchronous request handler under TrackMetrics; the known
+	// gaps are: (1) a handler that panics without writing a status (the engine
+	// runs without gin.Recovery(), so a panic-induced 500 surfaces as a
+	// process-level crash/log, not here); (2) cross-origin requests rejected by
+	// cors with 403 (cors is registered before TrackMetrics so preflight isn't
+	// counted as traffic); and (3) failures inside the async background worker
+	// (see ctrl/async.go), which runs off the request lifecycle on
+	// context.Background() — its upstream non-2xx is recorded to the job's DB
+	// status, not to this counter.
 	//
 	//   - source: "broker" (admission/billing/auth/TEE/internal) vs "upstream"
 	//     (the provider returned the non-2xx that was proxied back).

--- a/api/inference/monitor/server.go
+++ b/api/inference/monitor/server.go
@@ -65,7 +65,43 @@ var (
 	// label here (that would be unbounded); operators get top-N offenders from
 	// the periodic aggregated rejection log instead.
 	RequestRejectedTotal *prometheus.CounterVec
+
+	// FailureCount is the unified failure-attribution counter. Every request
+	// that ends in failure (HTTP status >= 400 — whether the broker rejected it
+	// before forwarding or the upstream provider returned a non-2xx we proxied
+	// back) increments it exactly once, labeled so a single query answers
+	// "whose fault, which model, what code":
+	//
+	//   - source: "broker" (admission/billing/auth/TEE/internal) vs "upstream"
+	//     (the provider returned the non-2xx that was proxied back).
+	//   - code:   the bounded classification — a Rejection* reason for broker
+	//     rejections; empty for broker/upstream errors that carry no classified
+	//     reason (the status label then carries the granularity).
+	//   - model:  the bounded metric model (see CtxKeyMetricModel); "" when the
+	//     request failed before model resolution (e.g. an early rate-limit gate).
+	//   - status: HTTP status text.
+	//
+	// It supersedes broker_requests_errors_total (which has no source/model and
+	// drops client-caused 4xx via ignoreError) and complements
+	// broker_requests_rejected_total (broker-only, no status/model); both remain
+	// for dashboard back-compat. The provider_address const label is on every
+	// series, so provider attribution needs no extra label here.
+	FailureCount *prometheus.CounterVec
 )
+
+// Failure source label values for FailureCount. Bounded to two values so the
+// "broker vs upstream" cut never grows cardinality.
+const (
+	FailureSourceBroker   = "broker"
+	FailureSourceUpstream = "upstream"
+)
+
+// CtxKeyFailureSource lets a handler override the failure source TrackMetrics
+// attributes to a >=400 response. Unset means FailureSourceBroker (the default
+// for any broker-side failure); the upstream proxy error path sets it to
+// FailureSourceUpstream so a provider's non-2xx is never misattributed to the
+// broker.
+const CtxKeyFailureSource = "failureSource"
 
 // Rejection reason label values for RequestRejectedTotal. These are the only
 // strings ever passed to RecordRejection, keeping the metric's cardinality
@@ -282,12 +318,22 @@ func PrometheusInit(serverName, providerAddress string) {
 		[]string{"reason"},
 	)
 
+	FailureCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name:        "broker_request_failures_total",
+			Help:        "Total failed requests (HTTP status >= 400), labeled by source (broker|upstream), code (Rejection* reason or empty), model, and status. Unified failure-attribution counter; see FailureCount doc.",
+			ConstLabels: constLabels,
+		},
+		[]string{"source", "code", "model", "status"},
+	)
+
 	prometheus.MustRegister(WhitelistRequestsTotal)
 	prometheus.MustRegister(WhitelistInputTokensTotal)
 	prometheus.MustRegister(WhitelistOutputTokensTotal)
 	prometheus.MustRegister(WhitelistAudioSecondsTotal)
 	prometheus.MustRegister(VideoBillingSkippedTotal)
 	prometheus.MustRegister(RequestRejectedTotal)
+	prometheus.MustRegister(FailureCount)
 }
 
 // StartDAUUpdater starts a background goroutine that periodically queries the database
@@ -399,6 +445,30 @@ func modelFromGinContext(c *gin.Context) string {
 	return ""
 }
 
+// failureSourceFromGinContext returns the failure source a handler stamped under
+// CtxKeyFailureSource, defaulting to FailureSourceBroker. A broker-side failure
+// never needs to set the key; only the upstream proxy path opts into "upstream".
+func failureSourceFromGinContext(c *gin.Context) string {
+	if v, exists := c.Get(CtxKeyFailureSource); exists {
+		if s, ok := v.(string); ok && s != "" {
+			return s
+		}
+	}
+	return FailureSourceBroker
+}
+
+// failureCodeFromGinContext returns the bounded classification stamped under
+// CtxKeyRejectionReason (one of the Rejection* constants), or "" when the
+// failure carried no classified reason — the status label then distinguishes it.
+func failureCodeFromGinContext(c *gin.Context) string {
+	if v, exists := c.Get(CtxKeyRejectionReason); exists {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
 // TrackMetrics is a Gin middleware that tracks request metrics.
 func TrackMetrics() gin.HandlerFunc {
 	return func(c *gin.Context) {
@@ -418,9 +488,18 @@ func TrackMetrics() gin.HandlerFunc {
 		// so it carries whatever the request path resolved ("" for non-inference
 		// paths and unresolved requests).
 		status := c.Writer.Status()
-		RequestCount.WithLabelValues(path, http.StatusText(status), modelFromGinContext(c)).Inc()
+		statusText := http.StatusText(status)
+		model := modelFromGinContext(c)
+		RequestCount.WithLabelValues(path, statusText, model).Inc()
 		if !ignoreError && status >= 400 {
-			ErrorCount.WithLabelValues(path, http.StatusText(status)).Inc()
+			ErrorCount.WithLabelValues(path, statusText).Inc()
+		}
+		// Unified failure attribution: count EVERY >=400 (including client-caused
+		// rejections that ErrorCount drops via ignoreError) exactly once, split by
+		// source/code/model so "broker vs upstream, which model, what reason" is a
+		// single query. Source defaults to broker; the upstream proxy path opts in.
+		if status >= 400 {
+			RecordFailure(failureSourceFromGinContext(c), failureCodeFromGinContext(c), model, statusText)
 		}
 	}
 }
@@ -477,6 +556,17 @@ func RecordRejection(reason string) {
 		return
 	}
 	RequestRejectedTotal.WithLabelValues(reason).Inc()
+}
+
+// RecordFailure increments the unified failure counter. source must be a
+// FailureSource* constant and code a Rejection* constant or "" so the metric
+// stays bounded. Safe to call before PrometheusInit (no-op when monitoring is
+// disabled). Normally called only from TrackMetrics' single emit site.
+func RecordFailure(source, code, model, status string) {
+	if FailureCount == nil {
+		return
+	}
+	FailureCount.WithLabelValues(source, code, model, status).Inc()
 }
 
 // RecordWhitelistRequest increments the whitelist request counter for the given


### PR DESCRIPTION
## Why

When a request fails, our Prometheus metrics couldn't answer the basic operational question: **whose fault was it, on which model, and for what reason?**

- `broker_requests_errors_total` carries only `path` + `status` — no model, no source, and it **drops client-caused 4xx via `ignoreError`**, so upstream 4xx and broker rejections were effectively invisible.
- `broker_requests_rejected_total` is broker-only, keyed by `reason` alone — no model, no status, and it doesn't cover upstream provider errors at all.
- Upstream provider errors (`handleServiceError`) incremented **no dedicated metric** and couldn't be told apart from broker-side 5xx.

So "this spike of failures — is it the provider's fault or ours, and which model?" had no single answer.

## What

Adds one unified failure-attribution counter:

```
broker_request_failures_total{source, code, model, status}
  (+ provider_address const label on every series)
```

| Dimension | Meaning |
|---|---|
| `source` | `broker` (admission/billing/auth/TEE/internal) vs `upstream` (provider returned the proxied non-2xx) |
| `code` | bounded `Rejection*` reason for classified rejections; empty when unclassified (status carries granularity) |
| `model` | bounded metric model (folds to `*` on wildcard deployments) |
| `status` | HTTP status text |

### Design

- **Single emit site** in `TrackMetrics` middleware — `status` and `model` are final there, the most accurate point.
- **Source propagation**: `handleServiceError` stamps `CtxKeyFailureSource=upstream`; anything else defaults to `broker`, so a provider non-2xx is never misattributed to the broker.
- **Code propagation**: `rejectionAggregator.record` now takes the gin context and stamps `CtxKeyRejectionReason`, so inline-recorded rejections (rate/tpm/ipm/concurrency/model_mismatch) surface their code at the single emit site without each call site repeating the `Set`.
- **Not gated by `ignoreError`** — the whole point is to count the client-caused 4xx and broker rejections that the existing error counter hides.
- **Back-compat**: `broker_requests_errors_total` and `broker_requests_rejected_total` are unchanged.

### Known limitation
Requests rejected before model resolution (e.g. the earliest rate-limit gate) get `model=""` — an inherent ordering effect, documented in the metric's comment.

## Test
- `go build ./...` ✅
- `go test ./inference/monitor/... ./inference/internal/proxy/... ./inference/internal/ctrl/...` ✅
- `gofmt -l` clean, `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)