### PR TITLE
Add serving_domain field to expose upstream provider hostnames

### DIFF
--- a/api/inference/internal/handler/models.go
+++ b/api/inference/internal/handler/models.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"math/big"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -38,7 +39,17 @@ type ModelObject struct {
 	ExpirationDate      string                    `json:"expiration_date,omitempty"`
 	ProviderType        string                    `json:"provider_type,omitempty"`
 	ProviderIdentity    string                    `json:"provider_identity,omitempty"`
-	RateLimits          *ModelRateLimits          `json:"rate_limits,omitempty"`
+	// ServingDomain is the upstream hostname (FQDN, e.g. "api.openai.com") that
+	// the broker actually connects to for a centralized provider. It is the host
+	// component of service.targetUrl — scheme, port, and path stripped — so it
+	// matches the TLS SNI / certificate SAN seen on the upstream connection.
+	//
+	// This is a discovery/display hint surfaced from unsigned broker config; it is
+	// NOT a verifiable claim on its own. Verification of where a request was routed
+	// relies on the TEE-signed routing proof, not this field. Empty for
+	// decentralized providers. Consumers prepend "https://" if they need a URL.
+	ServingDomain string           `json:"serving_domain,omitempty"`
+	RateLimits    *ModelRateLimits `json:"rate_limits,omitempty"`
 }
 
 // ModelRateLimits exposes per-user rate limit configuration so clients/SDKs
@@ -128,6 +139,12 @@ func (h *Handler) GetModels(ctx *gin.Context) {
 	if cfg.HasMultiModelPricing() {
 		models := make([]ModelObject, 0, len(cfg.ModelPricing))
 		teeVerifier := parseTeeVerifier(svc.AdditionalInfo)
+		// Serving domain is provider-level (one targetUrl for all models); compute
+		// once. Only meaningful for centralized providers.
+		var servingDomain string
+		if cfg.IsCentralized() {
+			servingDomain = parseServingDomain(cfg.TargetURL)
+		}
 		var created int64
 		if svc.CreatedAt != nil {
 			created = svc.CreatedAt.Unix()
@@ -204,6 +221,7 @@ func (h *Handler) GetModels(ctx *gin.Context) {
 				Pricing:          &ModelPricing{CacheTokenBilling: modelCacheBilling},
 				ProviderType:     cfg.ProviderType,
 				ProviderIdentity: cfg.ProviderIdentity,
+				ServingDomain:    servingDomain,
 				RateLimits:       sharedLimits,
 			}
 
@@ -411,6 +429,7 @@ func (h *Handler) GetModels(ctx *gin.Context) {
 	if cfg.IsCentralized() {
 		obj.ProviderType = cfg.ProviderType
 		obj.ProviderIdentity = cfg.ProviderIdentity
+		obj.ServingDomain = parseServingDomain(cfg.TargetURL)
 	}
 
 	// USD-denominated providers: surface per-token USD pricing (derived from
@@ -452,6 +471,21 @@ func (h *Handler) GetModels(ctx *gin.Context) {
 		Data:      []ModelObject{obj},
 		PriceFeed: priceFeedOut,
 	})
+}
+
+// parseServingDomain extracts the bare hostname (FQDN) from a target URL,
+// stripping scheme, port, and path. Returns "" if the URL is empty or cannot be
+// parsed into a host. The result is meant to match the TLS SNI / certificate SAN
+// of the upstream the broker connects to (e.g. "api.openai.com").
+func parseServingDomain(targetURL string) string {
+	if targetURL == "" {
+		return ""
+	}
+	u, err := url.Parse(targetURL)
+	if err != nil {
+		return ""
+	}
+	return u.Hostname()
 }
 
 // parseTeeVerifier extracts the TEEVerifier field from the additionalInfo JSON string.

--- a/api/inference/internal/handler/models_test.go
+++ b/api/inference/internal/handler/models_test.go
@@ -413,6 +413,7 @@ func TestGetModels_CentralizedProviderInfo(t *testing.T) {
 			OwnedBy:          "0G Foundation",
 			ProviderType:     "centralized",
 			ProviderIdentity: "openai",
+			TargetURL:        "https://api.openai.com/v1",
 		},
 	}
 
@@ -435,6 +436,10 @@ func TestGetModels_CentralizedProviderInfo(t *testing.T) {
 	if m.ProviderIdentity != "openai" {
 		t.Errorf("expected provider_identity=openai, got %q", m.ProviderIdentity)
 	}
+	// serving_domain is the bare FQDN from targetUrl — scheme, port, and path stripped.
+	if m.ServingDomain != "api.openai.com" {
+		t.Errorf("expected serving_domain=api.openai.com, got %q", m.ServingDomain)
+	}
 }
 
 func TestGetModels_DecentralizedOmitsProviderFields(t *testing.T) {
@@ -447,6 +452,8 @@ func TestGetModels_DecentralizedOmitsProviderFields(t *testing.T) {
 		},
 		serviceConfig: config.Service{
 			ProviderType: "decentralized",
+			// A decentralized targetUrl is internal and must NOT leak as serving_domain.
+			TargetURL: "https://backend:8000",
 		},
 	}
 
@@ -469,6 +476,9 @@ func TestGetModels_DecentralizedOmitsProviderFields(t *testing.T) {
 	if m.ProviderIdentity != "" {
 		t.Errorf("expected empty provider_identity for decentralized, got %q", m.ProviderIdentity)
 	}
+	if m.ServingDomain != "" {
+		t.Errorf("expected empty serving_domain for decentralized, got %q", m.ServingDomain)
+	}
 
 	// Also verify the fields are omitted from JSON output
 	raw := w.Body.Bytes()
@@ -484,6 +494,9 @@ func TestGetModels_DecentralizedOmitsProviderFields(t *testing.T) {
 	if _, exists := modelMap["provider_identity"]; exists {
 		t.Error("provider_identity should be omitted from JSON for decentralized providers")
 	}
+	if _, exists := modelMap["serving_domain"]; exists {
+		t.Error("serving_domain should be omitted from JSON for decentralized providers")
+	}
 }
 
 func TestGetModels_USDPricingAndFeedState(t *testing.T) {
@@ -494,14 +507,14 @@ func TestGetModels_USDPricingAndFeedState(t *testing.T) {
 	updatedAt := time.Now().Add(-5 * time.Second)
 	mock := &mockModelsCtrl{
 		service: model.Service{
-			ModelType:      "test-model",
-			Type:           "chatbot",
-			InputPrice:     "166660000000000",
-			OutputPrice:    "500000000000000",
+			ModelType:                      "test-model",
+			Type:                           "chatbot",
+			InputPrice:                     "166660000000000",
+			OutputPrice:                    "500000000000000",
 			InputPriceUSDPerMillionTokens:  "0.50",
 			OutputPriceUSDPerMillionTokens: "1.50",
 		},
-		serviceConfig: config.Service{},
+		serviceConfig:  config.Service{},
 		priceFeedIsUSD: true,
 		priceFeedSnapshot: pricefeed.Snapshot{
 			InputPriceWei:  big.NewInt(166660000000000),
@@ -606,14 +619,14 @@ func TestGetModels_USDModeCachePopulatedButStale(t *testing.T) {
 	rate, _ := new(big.Rat).SetString("0.003")
 	mock := &mockModelsCtrl{
 		service: model.Service{
-			ModelType:      "test-model",
-			Type:           "chatbot",
-			InputPrice:     "1",
-			OutputPrice:    "1",
+			ModelType:                      "test-model",
+			Type:                           "chatbot",
+			InputPrice:                     "1",
+			OutputPrice:                    "1",
 			InputPriceUSDPerMillionTokens:  "0.50",
 			OutputPriceUSDPerMillionTokens: "1.50",
 		},
-		serviceConfig: config.Service{},
+		serviceConfig:  config.Service{},
 		priceFeedIsUSD: true,
 		priceFeedSnapshot: pricefeed.Snapshot{
 			InputPriceWei:  big.NewInt(1),
@@ -645,10 +658,10 @@ func TestGetModels_USDModeUnpopulatedCacheOmitsPriceFeed(t *testing.T) {
 	// omitted since there's no meaningful rate to report.
 	mock := &mockModelsCtrl{
 		service: model.Service{
-			ModelType:      "test-model",
-			Type:           "chatbot",
-			InputPrice:     "1",
-			OutputPrice:    "1",
+			ModelType:                      "test-model",
+			Type:                           "chatbot",
+			InputPrice:                     "1",
+			OutputPrice:                    "1",
 			InputPriceUSDPerMillionTokens:  "0.50",
 			OutputPriceUSDPerMillionTokens: "1.50",
 		},
@@ -682,6 +695,7 @@ func TestGetModels_MultiModel_PerModelInfoAndFallback(t *testing.T) {
 	svcCfg := config.Service{
 		ProviderType:     "centralized",
 		ProviderIdentity: "openai",
+		TargetURL:        "https://api.openai.com/v1",
 		ModelType:        "gpt-4o",
 		Type:             "chatbot",
 		OwnedBy:          "0G Foundation",
@@ -764,6 +778,14 @@ func TestGetModels_MultiModel_PerModelInfoAndFallback(t *testing.T) {
 	if mini.Architecture == nil || mini.Architecture.Modality != "text->text" {
 		t.Errorf("gpt-4o-mini architecture = %+v, want service-level text->text", mini.Architecture)
 	}
+
+	// serving_domain is provider-level: every model carries the same FQDN.
+	if full.ServingDomain != "api.openai.com" {
+		t.Errorf("gpt-4o serving_domain = %q, want api.openai.com", full.ServingDomain)
+	}
+	if mini.ServingDomain != "api.openai.com" {
+		t.Errorf("gpt-4o-mini serving_domain = %q, want api.openai.com", mini.ServingDomain)
+	}
 }
 
 func TestParseTeeVerifier(t *testing.T) {
@@ -785,6 +807,31 @@ func TestParseTeeVerifier(t *testing.T) {
 			got := parseTeeVerifier(tt.additionalInfo)
 			if got != tt.want {
 				t.Errorf("parseTeeVerifier(%q) = %q, want %q", tt.additionalInfo, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseServingDomain(t *testing.T) {
+	tests := []struct {
+		name      string
+		targetURL string
+		want      string
+	}{
+		{"https with path", "https://api.openai.com/v1", "api.openai.com"},
+		{"https bare host", "https://api.openai.com", "api.openai.com"},
+		{"strips port", "https://api.openai.com:443/v1", "api.openai.com"},
+		{"gateway host preserved", "https://openrouter.ai/api/v1", "openrouter.ai"},
+		{"subdomain preserved", "https://gateway.example.com/v1", "gateway.example.com"},
+		{"empty", "", ""},
+		{"not a url", "://nonsense", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseServingDomain(tt.targetURL)
+			if got != tt.want {
+				t.Errorf("parseServingDomain(%q) = %q, want %q", tt.targetURL, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
Adds a new `serving_domain` field to the `ModelObject` response that exposes the upstream hostname (FQDN) that the broker connects to for centralized providers. This field is extracted from the provider's `targetUrl` configuration and is omitted for decentralized providers.

## Key Changes
- **New `ServingDomain` field** in `ModelObject` struct with detailed documentation explaining it is a discovery/display hint from unsigned broker config, not a verifiable claim
- **`parseServingDomain()` helper function** that extracts the bare hostname from a target URL by stripping scheme, port, and path using `net/url.Parse()` and `url.Hostname()`
- **Provider-level computation** for multi-model services: `serving_domain` is computed once per service configuration and applied to all models
- **Centralized-only exposure**: Field is populated only when `cfg.IsCentralized()` is true; empty for decentralized providers
- **Comprehensive test coverage**:
  - `TestGetModels_CentralizedProviderInfo`: Validates `serving_domain` is set for centralized providers
  - `TestGetModels_DecentralizedOmitsProviderFields`: Ensures `serving_domain` is empty and omitted from JSON for decentralized providers
  - `TestGetModels_MultiModel_PerModelInfoAndFallback`: Verifies all models in a multi-model service share the same `serving_domain`
  - `TestParseServingDomain`: Unit tests for the parsing function covering HTTPS URLs with/without paths, port stripping, subdomain preservation, and edge cases (empty string, malformed URLs)
- **Code formatting alignment** in test setup structs for consistency

## Implementation Details
- The `serving_domain` value matches the TLS SNI / certificate SAN seen on the upstream connection, enabling clients to understand which hostname the broker actually connects to
- Consumers can prepend "https://" if they need a full URL
- The field is marked `omitempty` in JSON serialization, so it does not appear in responses for decentralized providers
- Parsing gracefully handles empty URLs and malformed input by returning an empty string

https://claude.ai/code/session_01LQiNFHZeaLT8YA9CiCo7nD