### PR TITLE
Add provider display metadata (name and country) to service config and API

### DIFF
--- a/api/inference/config/config.go
+++ b/api/inference/config/config.go
@@ -18,6 +18,11 @@ import (
 // This prevents issues with the colon-delimited routing proof text format.
 var validProviderIdentity = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
 
+// validProviderCountry matches a two-letter ISO 3166-1 alpha-2 country code.
+// Format-only check (not validated against the full code list) — the value is a
+// display hint, so enforcing two ASCII letters is enough to keep it well-formed.
+var validProviderCountry = regexp.MustCompile(`^[A-Z]{2}$`)
+
 // validCanonicalID matches a bare lowercase canonical model identifier
 // (e.g. "glm-5.1", "deepseek-v3", "whisper-large-v3"). Disallows slashes
 // so namespaced names like "zai-org/GLM-5-FP8" cannot be set as canonical
@@ -211,6 +216,16 @@ type Service struct {
 	// ProviderIdentity identifies the centralized provider (e.g., "openai", "anthropic").
 	// Only used when ProviderType is "centralized".
 	ProviderIdentity string `yaml:"providerIdentity"`
+	// ProviderName is an optional human-readable display name for the provider
+	// (e.g., "OpenAI", "Aliyun (CN)"). Surfaced as provider_name in /v1/models for
+	// presentation only. Unlike ProviderIdentity (a lowercase machine key), this is
+	// freeform and may carry brand casing. Applies to any provider type.
+	ProviderName string `yaml:"providerName"`
+	// ProviderCountry is an optional ISO 3166-1 alpha-2 country code (e.g., "US",
+	// "CN") identifying the provider's jurisdiction, surfaced as provider_country
+	// in /v1/models. Normalized to uppercase. Display/discovery hint only — it is
+	// self-asserted by the broker and not verifiable. Applies to any provider type.
+	ProviderCountry string `yaml:"providerCountry"`
 
 	// PriceDenomination selects how input/output prices are expressed:
 	//   "NATIVE" (default): InputPrice/OutputPrice are wei amounts, written to chain as-is.
@@ -928,6 +943,15 @@ func loadConfig(cfg *Config) error {
 		// resp.TLS which is only populated for HTTPS connections.
 		if cfg.Service.TargetURL != "" && !strings.HasPrefix(strings.ToLower(cfg.Service.TargetURL), "https://") {
 			return fmt.Errorf("invalid config: service.targetUrl must use HTTPS for centralized providers (routing proof requires TLS), got '%s'", cfg.Service.TargetURL)
+		}
+	}
+
+	// Provider display metadata (applies to any provider type). Both are optional.
+	cfg.Service.ProviderName = strings.TrimSpace(cfg.Service.ProviderName)
+	if cfg.Service.ProviderCountry != "" {
+		cfg.Service.ProviderCountry = strings.ToUpper(strings.TrimSpace(cfg.Service.ProviderCountry))
+		if !validProviderCountry.MatchString(cfg.Service.ProviderCountry) {
+			return fmt.Errorf("invalid config: service.providerCountry must be a two-letter ISO 3166-1 alpha-2 code (e.g., 'US', 'CN'), got '%s'", cfg.Service.ProviderCountry)
 		}
 	}
 

--- a/api/inference/config/config_test.go
+++ b/api/inference/config/config_test.go
@@ -711,6 +711,70 @@ service:
 	}
 }
 
+func TestLoadConfig_ProviderNameAndCountry(t *testing.T) {
+	configPath := writeTestConfig(t, `
+service:
+  servingUrl: "http://example.com"
+  targetUrl: "https://api.openai.com"
+  inputPrice: "1000"
+  outputPrice: "2000"
+  type: "chatbot"
+  model: "gpt-4"
+  verifiability: "TeeML"
+  providerType: "centralized"
+  providerIdentity: "alibaba"
+  providerName: "Aliyun (CN)"
+  providerCountry: "cn"
+  additionalSecret:
+    Authorization: "Bearer sk-test"
+`)
+	t.Setenv("CONFIG_FILE", configPath)
+
+	cfg := &Config{}
+	if err := loadConfig(cfg); err != nil {
+		t.Fatalf("loadConfig failed: %v", err)
+	}
+
+	// providerName is freeform and preserved as-is (brand casing kept).
+	if cfg.Service.ProviderName != "Aliyun (CN)" {
+		t.Errorf("expected providerName 'Aliyun (CN)', got %q", cfg.Service.ProviderName)
+	}
+	// providerCountry is normalized to uppercase.
+	if cfg.Service.ProviderCountry != "CN" {
+		t.Errorf("expected providerCountry 'CN' (uppercased), got %q", cfg.Service.ProviderCountry)
+	}
+	// providerIdentity stays lowercase regardless of the display name.
+	if cfg.Service.ProviderIdentity != "alibaba" {
+		t.Errorf("expected providerIdentity 'alibaba', got %q", cfg.Service.ProviderIdentity)
+	}
+}
+
+func TestLoadConfig_InvalidProviderCountry(t *testing.T) {
+	configPath := writeTestConfig(t, `
+service:
+  servingUrl: "http://example.com"
+  targetUrl: "https://api.openai.com"
+  inputPrice: "1000"
+  outputPrice: "2000"
+  type: "chatbot"
+  model: "gpt-4"
+  verifiability: "TeeML"
+  providerType: "centralized"
+  providerIdentity: "openai"
+  providerCountry: "USA"
+`)
+	t.Setenv("CONFIG_FILE", configPath)
+
+	cfg := &Config{}
+	err := loadConfig(cfg)
+	if err == nil {
+		t.Fatal("expected error for invalid providerCountry")
+	}
+	if !strings.Contains(err.Error(), "providerCountry must be a two-letter") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
 func TestLoadConfig_CentralizedMissingIdentity(t *testing.T) {
 	configPath := writeTestConfig(t, `
 service:

--- a/api/inference/internal/handler/models.go
+++ b/api/inference/internal/handler/models.go
@@ -39,6 +39,14 @@ type ModelObject struct {
 	ExpirationDate      string                    `json:"expiration_date,omitempty"`
 	ProviderType        string                    `json:"provider_type,omitempty"`
 	ProviderIdentity    string                    `json:"provider_identity,omitempty"`
+	// ProviderName is an optional human-readable display name (e.g. "OpenAI",
+	// "Aliyun (CN)"). Freeform presentation companion to ProviderIdentity (the
+	// lowercase machine key); use this for UI labels, not for lookups.
+	ProviderName string `json:"provider_name,omitempty"`
+	// ProviderCountry is the provider's ISO 3166-1 alpha-2 jurisdiction code
+	// (e.g. "US", "CN"). Display/discovery hint only — self-asserted by the broker
+	// and not verifiable.
+	ProviderCountry string `json:"provider_country,omitempty"`
 	// ServingDomain is the upstream hostname (FQDN, e.g. "api.openai.com") that
 	// the broker actually connects to for a centralized provider. It is the host
 	// component of service.targetUrl — scheme, port, and path stripped — so it
@@ -227,6 +235,8 @@ func (h *Handler) GetModels(ctx *gin.Context) {
 				Pricing:          &ModelPricing{CacheTokenBilling: modelCacheBilling},
 				ProviderType:     cfg.ProviderType,
 				ProviderIdentity: cfg.ProviderIdentity,
+				ProviderName:     cfg.ProviderName,
+				ProviderCountry:  cfg.ProviderCountry,
 				ServingDomain:    servingDomain,
 				RateLimits:       sharedLimits,
 			}
@@ -447,6 +457,10 @@ func (h *Handler) GetModels(ctx *gin.Context) {
 		obj.ProviderIdentity = cfg.ProviderIdentity
 		obj.ServingDomain = parseServingDomain(cfg.TargetURL)
 	}
+
+	// Provider display metadata is provider-type-agnostic; surface whenever set.
+	obj.ProviderName = cfg.ProviderName
+	obj.ProviderCountry = cfg.ProviderCountry
 
 	// USD-denominated providers: surface per-token USD pricing (derived from
 	// the configured per-1M-tokens value) plus the live rate-feed state.

--- a/api/inference/internal/handler/models_test.go
+++ b/api/inference/internal/handler/models_test.go
@@ -477,6 +477,8 @@ func TestGetModels_CentralizedProviderInfo(t *testing.T) {
 			OwnedBy:          "0G Foundation",
 			ProviderType:     "centralized",
 			ProviderIdentity: "openai",
+			ProviderName:     "OpenAI",
+			ProviderCountry:  "US",
 			TargetURL:        "https://api.openai.com/v1",
 		},
 	}
@@ -500,9 +502,59 @@ func TestGetModels_CentralizedProviderInfo(t *testing.T) {
 	if m.ProviderIdentity != "openai" {
 		t.Errorf("expected provider_identity=openai, got %q", m.ProviderIdentity)
 	}
+	if m.ProviderName != "OpenAI" {
+		t.Errorf("expected provider_name=OpenAI, got %q", m.ProviderName)
+	}
+	if m.ProviderCountry != "US" {
+		t.Errorf("expected provider_country=US, got %q", m.ProviderCountry)
+	}
 	// serving_domain is the bare FQDN from targetUrl — scheme, port, and path stripped.
 	if m.ServingDomain != "api.openai.com" {
 		t.Errorf("expected serving_domain=api.openai.com, got %q", m.ServingDomain)
+	}
+}
+
+// TestGetModels_ProviderNameCountryDecentralized pins that provider_name and
+// provider_country are provider-type-agnostic display metadata: they surface for
+// a decentralized provider too (unlike serving_domain / provider_identity, which
+// are centralized-only).
+func TestGetModels_ProviderNameCountryDecentralized(t *testing.T) {
+	mock := &mockModelsCtrl{
+		service: model.Service{
+			ModelType:   "llama-3.1-8b",
+			Type:        "chatbot",
+			InputPrice:  "100",
+			OutputPrice: "200",
+		},
+		serviceConfig: config.Service{
+			ProviderType:    "decentralized",
+			ProviderName:    "Community GPU",
+			ProviderCountry: "SG",
+		},
+	}
+
+	h := newModelsTestHandler(mock)
+	w := performRequest(h.GetModels, "GET", "/v1/models", "", nil)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	var resp ModelListResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+
+	m := resp.Data[0]
+	if m.ProviderName != "Community GPU" {
+		t.Errorf("expected provider_name=Community GPU for decentralized, got %q", m.ProviderName)
+	}
+	if m.ProviderCountry != "SG" {
+		t.Errorf("expected provider_country=SG for decentralized, got %q", m.ProviderCountry)
+	}
+	// Centralized-only fields stay empty.
+	if m.ProviderIdentity != "" {
+		t.Errorf("expected empty provider_identity for decentralized, got %q", m.ProviderIdentity)
 	}
 }
 
@@ -560,6 +612,13 @@ func TestGetModels_DecentralizedOmitsProviderFields(t *testing.T) {
 	}
 	if _, exists := modelMap["serving_domain"]; exists {
 		t.Error("serving_domain should be omitted from JSON for decentralized providers")
+	}
+	// provider_name / provider_country were not configured here, so they must be omitted too.
+	if _, exists := modelMap["provider_name"]; exists {
+		t.Error("provider_name should be omitted from JSON when unset")
+	}
+	if _, exists := modelMap["provider_country"]; exists {
+		t.Error("provider_country should be omitted from JSON when unset")
 	}
 }
 


### PR DESCRIPTION
## Summary
Adds optional `providerName` and `providerCountry` fields to service configuration and exposes them in the `/v1/models` API response. These are provider-type-agnostic display metadata intended for UI presentation and discovery, complementing the existing `providerIdentity` (centralized-only machine key).

## Key Changes

- **Config Schema** (`config.go`):
  - Added `ProviderName` field: freeform human-readable display name (e.g., "OpenAI", "Aliyun (CN)"), preserves brand casing
  - Added `ProviderCountry` field: ISO 3166-1 alpha-2 country code (e.g., "US", "CN"), normalized to uppercase
  - Added validation: `providerCountry` must be exactly two uppercase ASCII letters if provided
  - Both fields are optional and apply to any provider type (centralized or decentralized)

- **API Response** (`models.go`):
  - Added `ProviderName` and `ProviderCountry` fields to `ModelObject` struct
  - Both fields are populated from service config and surfaced in JSON responses with `omitempty` tags
  - Fields are provider-type-agnostic (unlike `ProviderIdentity` and `ServingDomain`, which are centralized-only)

- **Tests** (`config_test.go`, `models_test.go`):
  - Added `TestLoadConfig_ProviderNameAndCountry`: validates that `providerName` is preserved as-is while `providerCountry` is normalized to uppercase
  - Added `TestLoadConfig_InvalidProviderCountry`: validates rejection of non-ISO-3166-1 country codes (e.g., "USA")
  - Added `TestGetModels_CentralizedProviderInfo`: updated to verify `provider_name` and `provider_country` in centralized provider responses
  - Added `TestGetModels_ProviderNameCountryDecentralized`: pins that display metadata surfaces for decentralized providers too
  - Updated `TestGetModels_DecentralizedOmitsProviderFields`: verifies unset fields are omitted from JSON

## Implementation Details

- `providerCountry` validation uses regex `^[A-Z]{2}$` — format-only check (not validated against full ISO code list) to keep validation lightweight while ensuring well-formed values
- Both fields are trimmed of whitespace during config load
- `providerCountry` is case-normalized to uppercase for consistency
- Fields use `omitempty` JSON tags so they are excluded from responses when unset, maintaining backward compatibility

https://claude.ai/code/session_01LQiNFHZeaLT8YA9CiCo7nD