### PR TITLE
feat(inference): per-wallet daily usage stats for Router pull

### DIFF
--- a/api/inference/cmd/server/main.go
+++ b/api/inference/cmd/server/main.go
@@ -250,6 +250,54 @@ func Main() {
 		logger.Info("LoRA serving enabled: manager and event watcher started")
 	}
 
+	// The /v1/admin/usage/daily read endpoint is authorized via the billing
+	// whitelist (IsWhitelistedUser). With the whitelist disabled that gate
+	// rejects everyone, so an operator who enables the feature without a
+	// whitelist gets a route that 403s every caller — including the Router it
+	// was turned on for. Warn loudly rather than fail silently.
+	if config.UserUsageStats.Enabled && !config.Whitelist.Enabled {
+		logger.Warn("userUsageStats is enabled but whitelist is disabled: GET /v1/admin/usage/daily will reject all callers (it is whitelist-gated). Configure whitelist.userAddresses with the Router's address.")
+	}
+
+	// Per-wallet usage retention pruner. user_daily_stat is never deleted at
+	// settlement (unlike request) and grows as wallets × models × days, so
+	// trim rows older than the configured retention. The Router keeps its own
+	// permanent copy, so the broker only needs the pull window. Pure DB
+	// deletes on its own cancellable context, cancelled in the shutdown block
+	// below (mirroring the price-processor / LoRA workers — the root ctx is
+	// never cancelled).
+	var pruneCancel context.CancelFunc
+	if config.UserUsageStats.Enabled && config.UserUsageStats.RetentionDays > 0 {
+		retentionDays := config.UserUsageStats.RetentionDays
+		interval := config.UserUsageStats.PruneInterval
+		var pruneCtx context.Context
+		pruneCtx, pruneCancel = context.WithCancel(ctx)
+		go func() {
+			prune := func() {
+				removed, err := db.PruneUserDailyStat(retentionDays)
+				if err != nil {
+					logger.Errorf("user_daily_stat prune failed: %v", err)
+					return
+				}
+				if removed > 0 {
+					logger.Infof("user_daily_stat prune: removed %d rows older than %d days", removed, retentionDays)
+				}
+			}
+			prune() // run once at startup
+			ticker := time.NewTicker(interval)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-pruneCtx.Done():
+					return
+				case <-ticker.C:
+					prune()
+				}
+			}
+		}()
+		logger.Infof("user_daily_stat retention pruner started: %d-day retention, every %s", retentionDays, interval)
+	}
+
 	proxy := proxy.New(ctrl, engine, config.AllowOrigins, config.Monitor.Enable, config.ConcurrencyLimit, logger)
 	if err := proxy.Start(); err != nil {
 		panic(err)
@@ -306,6 +354,11 @@ func Main() {
 
 	// Shutdown monitor background goroutines
 	monitorCancel()
+
+	// Stop the per-wallet usage retention pruner
+	if pruneCancel != nil {
+		pruneCancel()
+	}
 
 	// Shutdown LoRA event watcher and manager
 	if loraCancel != nil {

--- a/api/inference/config/config.go
+++ b/api/inference/config/config.go
@@ -390,6 +390,26 @@ type WhitelistConfig struct {
 	UserAddresses []string `yaml:"userAddresses"` // List of whitelisted user addresses (case-insensitive)
 }
 
+// UserUsageStatsConfig gates the per-wallet daily usage feature: the
+// user_daily_stat table written inside settlement and the read-only
+// GET /v1/admin/usage/daily endpoint the Router pulls from. Defaults to
+// disabled so the settlement hot-path is unchanged and the route is not
+// registered (404) until an operator opts in. See
+// docs/wallet-direct-usage-design.md (router repo) for the full contract.
+type UserUsageStatsConfig struct {
+	// Enabled turns on both the settlement-time per-wallet upsert and the
+	// read endpoint. When false the broker behaves exactly as before.
+	Enabled bool `yaml:"enabled"`
+	// RetentionDays bounds the unbounded-growth of user_daily_stat: rows with
+	// date older than now-RetentionDays are pruned by a background worker.
+	// The Router keeps its own permanent copy, so the broker only needs to
+	// retain enough history to cover the Router's pull window. 0 disables
+	// pruning (keep forever). Defaults to 90 when Enabled and left unset.
+	RetentionDays int `yaml:"retentionDays"`
+	// PruneInterval is how often the pruner runs. Defaults to 24h.
+	PruneInterval time.Duration `yaml:"pruneInterval"`
+}
+
 // LoRAConfig configures LoRA adapter serving for fine-tuned models.
 // When enabled, the inference broker can serve fine-tuned LoRA adapters
 // via ServerlessLLM, with per-user access control and automatic adapter
@@ -499,6 +519,7 @@ type Config struct {
 	Async               AsyncConfig             `yaml:"async"`
 	ProviderHttp        ProviderHttpConfig      `yaml:"providerHttp"`
 	ConcurrencyLimit    ConcurrencyLimitConfig  `yaml:"concurrencyLimit"`
+	UserUsageStats      UserUsageStatsConfig    `yaml:"userUsageStats"`
 	// AllowTokenBilledSpeechToText opens the billing path for token-billed
 	// speech-to-text models (gpt-4o-transcribe, gpt-4o-mini-transcribe).
 	// Defaults to false.
@@ -1046,6 +1067,17 @@ func loadConfig(cfg *Config) error {
 	// ceiling — see model_pricing.go.
 	if err := validateModelPricing(cfg); err != nil {
 		return err
+	}
+
+	// Per-wallet usage stats defaults. Only meaningful when the feature is
+	// enabled; leaving them unset gives a 90-day retention pruned daily.
+	if cfg.UserUsageStats.Enabled {
+		if cfg.UserUsageStats.RetentionDays == 0 {
+			cfg.UserUsageStats.RetentionDays = 90
+		}
+		if cfg.UserUsageStats.PruneInterval == 0 {
+			cfg.UserUsageStats.PruneInterval = 24 * time.Hour
+		}
 	}
 
 	return nil

--- a/api/inference/internal/ctrl/ctrl.go
+++ b/api/inference/internal/ctrl/ctrl.go
@@ -105,6 +105,10 @@ type Ctrl struct {
 	// Whitelist for users that bypass billing
 	whitelistUsers map[string]struct{}
 
+	// userUsageStats gates the per-wallet daily usage feature (settlement-time
+	// upsert into user_daily_stat + the /v1/admin/usage/daily read endpoint).
+	userUsageStats config.UserUsageStatsConfig
+
 	// Async processing
 	asyncMu         sync.RWMutex // protects asyncEnabled + asyncJobQueue against send-on-closed-channel during shutdown
 	asyncJobQueue   chan asyncJobParams
@@ -211,6 +215,7 @@ func New(
 		tieredPricing:        cfg.TieredPricing,
 		priceFeed:            cfg.PriceFeed,
 		concurrencyLimit:     cfg.ConcurrencyLimit,
+		userUsageStats:       cfg.UserUsageStats,
 		allowTokenBilledSTT:  cfg.AllowTokenBilledSpeechToText,
 		priceCache:           priceCache,
 		svcCache:             svcCache,

--- a/api/inference/internal/ctrl/settlement_tee.go
+++ b/api/inference/internal/ctrl/settlement_tee.go
@@ -15,6 +15,7 @@ import (
 	constant "github.com/0glabs/0g-serving-broker/inference/const"
 	"github.com/0glabs/0g-serving-broker/inference/contract"
 	providercontract "github.com/0glabs/0g-serving-broker/inference/internal/contract"
+	"github.com/0glabs/0g-serving-broker/inference/internal/db"
 	"github.com/0glabs/0g-serving-broker/inference/model"
 )
 
@@ -789,7 +790,11 @@ func (c *Ctrl) deleteRequests(requests []*model.Request) error {
 	// at settlement time therefore shares c.Service.Type, so a function-wide
 	// skip is safe. If we ever multiplex services in one broker, this needs
 	// to partition `requests` by per-row service type instead — track in #530.
-	if err := c.db.AccumulateAndDeleteRequests(requests, c.Service.Type); err != nil {
+	if err := c.db.AccumulateAndDeleteRequests(requests, db.AccumulateOptions{
+		ServiceType:     c.Service.Type,
+		RecordPerWallet: c.userUsageStats.Enabled,
+		FallbackModel:   c.Service.ModelType,
+	}); err != nil {
 		c.logger.Errorf("CRITICAL: failed to accumulate stats and delete settled requests: %v", err)
 		return err
 	}

--- a/api/inference/internal/ctrl/usage_stats.go
+++ b/api/inference/internal/ctrl/usage_stats.go
@@ -1,0 +1,15 @@
+package ctrl
+
+import "github.com/0glabs/0g-serving-broker/inference/model"
+
+// UserUsageStatsEnabled reports whether the per-wallet daily usage feature is
+// on. The read endpoint and its route registration gate on this.
+func (c *Ctrl) UserUsageStatsEnabled() bool {
+	return c.userUsageStats.Enabled
+}
+
+// ListUserDailyStat returns the per-wallet usage rows for a UTC date plus the
+// total row count for that date (for pagination).
+func (c *Ctrl) ListUserDailyStat(date string, limit, offset int) ([]model.UserDailyStat, int64, error) {
+	return c.db.ListUserDailyStat(date, limit, offset)
+}

--- a/api/inference/internal/db/daily_stat.go
+++ b/api/inference/internal/db/daily_stat.go
@@ -122,8 +122,14 @@ func (d *DB) AccumulateAndDeleteRequests(requests []*model.Request, opts Accumul
 		// even if settlement straddles UTC midnight. Reading it from the DB
 		// (rather than the app clock) keeps it consistent with the existing
 		// UTC_DATE() semantics and avoids app/DB clock skew.
+		//
+		// DATE_FORMAT (not bare UTC_DATE()) is deliberate: with the driver's
+		// parseTime=True a DATE-typed result is decoded to time.Time and, when
+		// scanned into a string, re-serialized as RFC3339 ("...T00:00:00Z"),
+		// which MySQL rejects as a DATE literal in strict mode. Formatting to a
+		// plain string server-side returns "YYYY-MM-DD" verbatim.
 		var date string
-		if err := tx.Raw("SELECT UTC_DATE()").Scan(&date).Error; err != nil {
+		if err := tx.Raw("SELECT DATE_FORMAT(UTC_DATE(), '%Y-%m-%d')").Scan(&date).Error; err != nil {
 			return fmt.Errorf("failed to resolve settlement date: %w", err)
 		}
 

--- a/api/inference/internal/db/daily_stat.go
+++ b/api/inference/internal/db/daily_stat.go
@@ -2,25 +2,61 @@ package db
 
 import (
 	"fmt"
+	"strings"
 
 	constant "github.com/0glabs/0g-serving-broker/inference/const"
 	"github.com/0glabs/0g-serving-broker/inference/model"
 	"gorm.io/gorm"
 )
 
+// unknownModelLabel labels a per-wallet usage row whose request carried no
+// model id and for which no fallback was configured, so the model primary-key
+// component is never blank.
+const unknownModelLabel = "unknown"
+
+// AccumulateOptions configures the optional per-wallet recording in
+// AccumulateAndDeleteRequests. Using a struct with named fields (rather than
+// positional string/bool/string parameters) makes the two string fields
+// impossible to transpose silently — a transposition of ServiceType and
+// FallbackModel would otherwise flip the STT token-skip and corrupt analytics
+// with no compile error.
+type AccumulateOptions struct {
+	// ServiceType is the broker's configured service type ("chatbot",
+	// "speech-to-text", etc.). For "speech-to-text", input_count/output_count
+	// carry seconds (whisper) rather than tokens, so the token-named columns
+	// are skipped to stay unit-coherent.
+	ServiceType string
+	// RecordPerWallet enables the per-wallet, per-model upsert into
+	// user_daily_stat (in the same transaction, before request deletion).
+	RecordPerWallet bool
+	// FallbackModel labels per-wallet rows whose request ModelName is empty
+	// (rows predating the model_name column). When it is itself empty, such
+	// rows fall back to the unknownModelLabel sentinel.
+	FallbackModel string
+}
+
 // AccumulateAndDeleteRequests atomically accumulates request stats into daily_stat
 // and deletes the requests in a single transaction. This prevents double-counting
 // that would occur if accumulation succeeds but deletion fails.
 //
-// serviceType is the broker's configured service type ("chatbot",
-// "speech-to-text", etc.). For "speech-to-text", input_count/output_count
-// carry seconds (whisper) rather than tokens, so we skip the token-named
-// columns in daily_stat to keep AllTimeInputTokens / AllTimeOutputTokens
-// unit-coherent. total_requests is still bumped because the requests really
-// did happen. The whisper traffic loses long-term per-second analytics
-// history until issue #530 lands a per-unit column on daily_stat — that's
-// the accepted trade-off for the deployment window.
-func (d *DB) AccumulateAndDeleteRequests(requests []*model.Request, serviceType string) error {
+// For opts.ServiceType == "speech-to-text", input_count/output_count carry
+// seconds (whisper) rather than tokens, so we skip the token-named columns in
+// daily_stat to keep AllTimeInputTokens / AllTimeOutputTokens unit-coherent.
+// total_requests is still bumped because the requests really did happen. The
+// whisper traffic loses long-term per-second analytics history until issue
+// #530 lands a per-unit column on daily_stat — that's the accepted trade-off
+// for the deployment window.
+//
+// When opts.RecordPerWallet is true, the per-wallet, per-model breakdown is
+// also upserted into user_daily_stat in the SAME transaction, before the
+// request rows are deleted — otherwise the breakdown would be lost at
+// settlement (the request rows are the only per-wallet source; see
+// docs/wallet-direct-usage-design.md §4.1 in the router repo). The STT token
+// skip applies identically here. To bound how long the settlement transaction
+// is held open (and how many statements could fail and roll back an
+// already-on-chain settlement), all per-wallet rows go in a single multi-row
+// upsert rather than one statement per (user, model) pair.
+func (d *DB) AccumulateAndDeleteRequests(requests []*model.Request, opts AccumulateOptions) error {
 	if len(requests) == 0 {
 		return nil
 	}
@@ -32,7 +68,23 @@ func (d *DB) AccumulateAndDeleteRequests(requests []*model.Request, serviceType 
 	// speech-to-text writes seconds into input_count for whisper rows. Token
 	// accumulation would silently corrupt daily_stat.input_tokens, so skip
 	// it until #530 lands a dedicated audio_seconds column.
-	skipTokenAccumulation := serviceType == constant.ServiceTypeSpeechToText
+	skipTokenAccumulation := opts.ServiceType == constant.ServiceTypeSpeechToText
+
+	// Per-wallet aggregation grouped by (user_address, model). Keyed off the
+	// same request batch so it shares the STT skip and never double-counts.
+	type userModelKey struct {
+		user  string
+		model string
+	}
+	type userModelAgg struct {
+		requestCount int64
+		inputTokens  int64
+		outputTokens int64
+	}
+	var perWallet map[userModelKey]*userModelAgg
+	if opts.RecordPerWallet {
+		perWallet = make(map[userModelKey]*userModelAgg)
+	}
 
 	for _, req := range requests {
 		totalRequests++
@@ -41,19 +93,73 @@ func (d *DB) AccumulateAndDeleteRequests(requests []*model.Request, serviceType 
 			outputTokens += req.OutputCount
 		}
 		hashes = append(hashes, req.RequestHash)
+
+		if opts.RecordPerWallet {
+			modelName := req.ModelName
+			if modelName == "" {
+				modelName = opts.FallbackModel
+			}
+			if modelName == "" {
+				modelName = unknownModelLabel
+			}
+			key := userModelKey{user: req.UserAddress, model: modelName}
+			agg := perWallet[key]
+			if agg == nil {
+				agg = &userModelAgg{}
+				perWallet[key] = agg
+			}
+			agg.requestCount++
+			if !skipTokenAccumulation {
+				agg.inputTokens += req.InputCount
+				agg.outputTokens += req.OutputCount
+			}
+		}
 	}
 
 	return d.db.Transaction(func(tx *gorm.DB) error {
+		// Resolve the UTC calendar day once for the whole transaction so the
+		// daily_stat row and every user_daily_stat row land on the same date
+		// even if settlement straddles UTC midnight. Reading it from the DB
+		// (rather than the app clock) keeps it consistent with the existing
+		// UTC_DATE() semantics and avoids app/DB clock skew.
+		var date string
+		if err := tx.Raw("SELECT UTC_DATE()").Scan(&date).Error; err != nil {
+			return fmt.Errorf("failed to resolve settlement date: %w", err)
+		}
+
 		if err := tx.Exec(
 			`INSERT INTO daily_stat (date, total_requests, input_tokens, output_tokens)
-			 VALUES (UTC_DATE(), ?, ?, ?) AS new_vals
+			 VALUES (?, ?, ?, ?) AS new_vals
 			 ON DUPLICATE KEY UPDATE
 			   total_requests = daily_stat.total_requests + new_vals.total_requests,
 			   input_tokens = daily_stat.input_tokens + new_vals.input_tokens,
 			   output_tokens = daily_stat.output_tokens + new_vals.output_tokens`,
-			totalRequests, inputTokens, outputTokens,
+			date, totalRequests, inputTokens, outputTokens,
 		).Error; err != nil {
 			return fmt.Errorf("failed to accumulate daily stats: %w", err)
+		}
+
+		if len(perWallet) > 0 {
+			var b strings.Builder
+			b.WriteString("INSERT INTO user_daily_stat (date, user_address, model, request_count, input_tokens, output_tokens) VALUES ")
+			args := make([]any, 0, len(perWallet)*6)
+			i := 0
+			for key, agg := range perWallet {
+				if i > 0 {
+					b.WriteByte(',')
+				}
+				b.WriteString("(?, ?, ?, ?, ?, ?)")
+				args = append(args, date, key.user, key.model, agg.requestCount, agg.inputTokens, agg.outputTokens)
+				i++
+			}
+			b.WriteString(` AS new_vals
+			 ON DUPLICATE KEY UPDATE
+			   request_count = user_daily_stat.request_count + new_vals.request_count,
+			   input_tokens  = user_daily_stat.input_tokens  + new_vals.input_tokens,
+			   output_tokens = user_daily_stat.output_tokens + new_vals.output_tokens`)
+			if err := tx.Exec(b.String(), args...).Error; err != nil {
+				return fmt.Errorf("failed to accumulate user daily stats: %w", err)
+			}
 		}
 
 		if err := tx.Where("request_hash IN ?", hashes).Delete(&model.Request{}).Error; err != nil {
@@ -62,6 +168,48 @@ func (d *DB) AccumulateAndDeleteRequests(requests []*model.Request, serviceType 
 
 		return nil
 	})
+}
+
+// ListUserDailyStat returns the per-wallet usage rows for a single UTC date,
+// ordered by (user_address, model) — the stable order the date-leading primary
+// key serves without a filesort. It also returns the total row count for that
+// date so the caller can paginate. limit/offset bound the returned slice;
+// callers should pass a sane limit (the handler caps it).
+func (d *DB) ListUserDailyStat(date string, limit, offset int) ([]model.UserDailyStat, int64, error) {
+	var total int64
+	if err := d.db.Model(&model.UserDailyStat{}).Where("date = ?", date).Count(&total).Error; err != nil {
+		return nil, 0, fmt.Errorf("failed to count user daily stats: %w", err)
+	}
+
+	var rows []model.UserDailyStat
+	if err := d.db.Where("date = ?", date).
+		Order("user_address, model").
+		Limit(limit).
+		Offset(offset).
+		Find(&rows).Error; err != nil {
+		return nil, 0, fmt.Errorf("failed to list user daily stats: %w", err)
+	}
+	return rows, total, nil
+}
+
+// PruneUserDailyStat deletes user_daily_stat rows older than the given number
+// of retention days (relative to the current UTC date). It returns the number
+// of rows removed. A non-positive retentionDays is a no-op — callers gate on
+// the configured retention before invoking. This bounds the otherwise
+// unbounded growth of the per-wallet table (the Router keeps its own permanent
+// copy). See config.UserUsageStatsConfig.
+func (d *DB) PruneUserDailyStat(retentionDays int) (int64, error) {
+	if retentionDays <= 0 {
+		return 0, nil
+	}
+	res := d.db.Exec(
+		"DELETE FROM user_daily_stat WHERE date < DATE_SUB(UTC_DATE(), INTERVAL ? DAY)",
+		retentionDays,
+	)
+	if res.Error != nil {
+		return 0, fmt.Errorf("failed to prune user daily stats: %w", res.Error)
+	}
+	return res.RowsAffected, nil
 }
 
 // TotalStats holds the all-time cumulative statistics.

--- a/api/inference/internal/db/migrate.go
+++ b/api/inference/internal/db/migrate.go
@@ -272,6 +272,24 @@ func (d *DB) Migrate() error {
 				return tx.AutoMigrate(&Request{})
 			},
 		},
+		{
+			ID: "create-user-daily-stat",
+			Migrate: func(tx *gorm.DB) error {
+				// Per-wallet daily usage for direct consumers. PK column order
+				// (date, user_address, model) matches the only read pattern
+				// (WHERE date=? ORDER BY user_address, model). See
+				// model.UserDailyStat.
+				type UserDailyStat struct {
+					Date         string `gorm:"type:date;primaryKey"`
+					UserAddress  string `gorm:"type:varchar(255);primaryKey"`
+					Model        string `gorm:"type:varchar(255);primaryKey"`
+					RequestCount int64  `gorm:"type:bigint;not null;default:0"`
+					InputTokens  int64  `gorm:"type:bigint;not null;default:0"`
+					OutputTokens int64  `gorm:"type:bigint;not null;default:0"`
+				}
+				return tx.AutoMigrate(&UserDailyStat{})
+			},
+		},
 	})
 
 	return errors.Wrap(m.Migrate(), "migrate database")

--- a/api/inference/internal/db/user_daily_stat_test.go
+++ b/api/inference/internal/db/user_daily_stat_test.go
@@ -1,0 +1,221 @@
+//go:build integration
+
+package db
+
+import (
+	"testing"
+
+	constant "github.com/0glabs/0g-serving-broker/inference/const"
+	"github.com/0glabs/0g-serving-broker/inference/model"
+)
+
+// migrateUsageTables auto-migrates the tables the per-wallet usage path
+// touches onto the shared test DB.
+func migrateUsageTables(t *testing.T, d *DB) {
+	t.Helper()
+	if err := d.db.AutoMigrate(&model.Request{}, &model.UserDailyStat{}, &model.DailyStat{}); err != nil {
+		t.Fatalf("auto-migrate usage tables: %v", err)
+	}
+}
+
+func seedRequest(t *testing.T, d *DB, user, modelName, hash string, in, out int64) {
+	t.Helper()
+	req := model.Request{
+		UserAddress: user,
+		Nonce:       hash,
+		RequestHash: hash,
+		ServiceName: "chatbot",
+		ModelName:   modelName,
+		InputCount:  in,
+		OutputCount: out,
+	}
+	if err := d.db.Create(&req).Error; err != nil {
+		t.Fatalf("seed request %s: %v", hash, err)
+	}
+}
+
+func fetchUserDailyStat(t *testing.T, d *DB) map[string]model.UserDailyStat {
+	t.Helper()
+	var rows []model.UserDailyStat
+	if err := d.db.Find(&rows).Error; err != nil {
+		t.Fatalf("fetch user_daily_stat: %v", err)
+	}
+	out := make(map[string]model.UserDailyStat, len(rows))
+	for _, r := range rows {
+		out[r.UserAddress+"|"+r.Model] = r
+	}
+	return out
+}
+
+// TestAccumulatePerWallet verifies the per-wallet upsert aggregates by
+// (user, model), deletes the requests, and accumulates across two calls.
+func TestAccumulatePerWallet(t *testing.T) {
+	d := setupTestDB(t)
+	migrateUsageTables(t, d)
+
+	// First settlement batch: two users, alice on two models.
+	batch1 := []*model.Request{
+		{UserAddress: "0xAlice", ModelName: "deepseek-r1", RequestHash: "h1", InputCount: 10, OutputCount: 20},
+		{UserAddress: "0xAlice", ModelName: "deepseek-r1", RequestHash: "h2", InputCount: 5, OutputCount: 7},
+		{UserAddress: "0xAlice", ModelName: "qwen3-max", RequestHash: "h3", InputCount: 1, OutputCount: 2},
+		{UserAddress: "0xBob", ModelName: "deepseek-r1", RequestHash: "h4", InputCount: 100, OutputCount: 200},
+	}
+	for _, r := range batch1 {
+		seedRequest(t, d, r.UserAddress, r.ModelName, r.RequestHash, r.InputCount, r.OutputCount)
+	}
+	if err := d.AccumulateAndDeleteRequests(batch1, AccumulateOptions{ServiceType: constant.ServiceTypeChatbot, RecordPerWallet: true, FallbackModel: "fallback-model"}); err != nil {
+		t.Fatalf("accumulate batch1: %v", err)
+	}
+
+	stats := fetchUserDailyStat(t, d)
+	if got := stats["0xAlice|deepseek-r1"]; got.RequestCount != 2 || got.InputTokens != 15 || got.OutputTokens != 27 {
+		t.Errorf("alice/deepseek-r1 = %+v, want req=2 in=15 out=27", got)
+	}
+	if got := stats["0xAlice|qwen3-max"]; got.RequestCount != 1 || got.InputTokens != 1 {
+		t.Errorf("alice/qwen3-max = %+v, want req=1 in=1", got)
+	}
+	if got := stats["0xBob|deepseek-r1"]; got.RequestCount != 1 || got.InputTokens != 100 {
+		t.Errorf("bob/deepseek-r1 = %+v, want req=1 in=100", got)
+	}
+
+	// Requests must be deleted.
+	var remaining int64
+	d.db.Model(&model.Request{}).Count(&remaining)
+	if remaining != 0 {
+		t.Errorf("requests remaining after settlement = %d, want 0", remaining)
+	}
+
+	// Second batch on the same day must accumulate onto the existing rows.
+	batch2 := []*model.Request{
+		{UserAddress: "0xAlice", ModelName: "deepseek-r1", RequestHash: "h5", InputCount: 3, OutputCount: 4},
+	}
+	seedRequest(t, d, "0xAlice", "deepseek-r1", "h5", 3, 4)
+	if err := d.AccumulateAndDeleteRequests(batch2, AccumulateOptions{ServiceType: constant.ServiceTypeChatbot, RecordPerWallet: true, FallbackModel: "fallback-model"}); err != nil {
+		t.Fatalf("accumulate batch2: %v", err)
+	}
+	stats = fetchUserDailyStat(t, d)
+	if got := stats["0xAlice|deepseek-r1"]; got.RequestCount != 3 || got.InputTokens != 18 || got.OutputTokens != 31 {
+		t.Errorf("after batch2 alice/deepseek-r1 = %+v, want req=3 in=18 out=31", got)
+	}
+}
+
+// TestAccumulatePerWalletEmptyModelFallback verifies an empty ModelName falls
+// back to the provided model id.
+func TestAccumulatePerWalletEmptyModelFallback(t *testing.T) {
+	d := setupTestDB(t)
+	migrateUsageTables(t, d)
+
+	batch := []*model.Request{{UserAddress: "0xAlice", ModelName: "", RequestHash: "e1", InputCount: 9, OutputCount: 1}}
+	seedRequest(t, d, "0xAlice", "", "e1", 9, 1)
+	if err := d.AccumulateAndDeleteRequests(batch, AccumulateOptions{ServiceType: constant.ServiceTypeChatbot, RecordPerWallet: true, FallbackModel: "single-model"}); err != nil {
+		t.Fatalf("accumulate: %v", err)
+	}
+	stats := fetchUserDailyStat(t, d)
+	if got := stats["0xAlice|single-model"]; got.RequestCount != 1 || got.InputTokens != 9 {
+		t.Errorf("fallback model row = %+v, want req=1 in=9 under 'single-model'", got)
+	}
+}
+
+// TestAccumulatePerWalletSTTSkipsTokens verifies speech-to-text records
+// request_count but writes 0 to the token columns (input_count carries
+// seconds for whisper, not tokens).
+func TestAccumulatePerWalletSTTSkipsTokens(t *testing.T) {
+	d := setupTestDB(t)
+	migrateUsageTables(t, d)
+
+	batch := []*model.Request{
+		{UserAddress: "0xAlice", ModelName: "whisper-large-v3", RequestHash: "s1", InputCount: 120, OutputCount: 0},
+		{UserAddress: "0xAlice", ModelName: "whisper-large-v3", RequestHash: "s2", InputCount: 90, OutputCount: 0},
+	}
+	for _, r := range batch {
+		seedRequest(t, d, r.UserAddress, r.ModelName, r.RequestHash, r.InputCount, r.OutputCount)
+	}
+	if err := d.AccumulateAndDeleteRequests(batch, AccumulateOptions{ServiceType: constant.ServiceTypeSpeechToText, RecordPerWallet: true, FallbackModel: "whisper-large-v3"}); err != nil {
+		t.Fatalf("accumulate stt: %v", err)
+	}
+	stats := fetchUserDailyStat(t, d)
+	got := stats["0xAlice|whisper-large-v3"]
+	if got.RequestCount != 2 {
+		t.Errorf("stt request_count = %d, want 2", got.RequestCount)
+	}
+	if got.InputTokens != 0 || got.OutputTokens != 0 {
+		t.Errorf("stt tokens = (%d,%d), want (0,0) — seconds must not be recorded as tokens", got.InputTokens, got.OutputTokens)
+	}
+}
+
+// TestAccumulatePerWalletDisabled verifies that with recordPerWallet=false no
+// user_daily_stat rows are written (requests are still deleted).
+func TestAccumulatePerWalletDisabled(t *testing.T) {
+	d := setupTestDB(t)
+	migrateUsageTables(t, d)
+
+	batch := []*model.Request{{UserAddress: "0xAlice", ModelName: "deepseek-r1", RequestHash: "d1", InputCount: 10, OutputCount: 20}}
+	seedRequest(t, d, "0xAlice", "deepseek-r1", "d1", 10, 20)
+	if err := d.AccumulateAndDeleteRequests(batch, AccumulateOptions{ServiceType: constant.ServiceTypeChatbot, RecordPerWallet: false, FallbackModel: "fallback"}); err != nil {
+		t.Fatalf("accumulate: %v", err)
+	}
+	var count int64
+	d.db.Model(&model.UserDailyStat{}).Count(&count)
+	if count != 0 {
+		t.Errorf("user_daily_stat rows with feature disabled = %d, want 0", count)
+	}
+}
+
+// TestListAndPruneUserDailyStat verifies ordering, total, pagination, and TTL.
+func TestListAndPruneUserDailyStat(t *testing.T) {
+	d := setupTestDB(t)
+	migrateUsageTables(t, d)
+
+	// Seed three rows for one date directly, out of order.
+	rows := []model.UserDailyStat{
+		{Date: "2026-06-22", UserAddress: "0xBob", Model: "m1", RequestCount: 1, InputTokens: 1},
+		{Date: "2026-06-22", UserAddress: "0xAlice", Model: "m2", RequestCount: 1, InputTokens: 1},
+		{Date: "2026-06-22", UserAddress: "0xAlice", Model: "m1", RequestCount: 1, InputTokens: 1},
+		// A stale row far in the past for the prune test.
+		{Date: "2020-01-01", UserAddress: "0xAlice", Model: "m1", RequestCount: 1, InputTokens: 1},
+	}
+	if err := d.db.Create(&rows).Error; err != nil {
+		t.Fatalf("seed rows: %v", err)
+	}
+
+	page, total, err := d.ListUserDailyStat("2026-06-22", 2, 0)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if total != 3 {
+		t.Errorf("total = %d, want 3", total)
+	}
+	// Ordered by (user_address, model): alice/m1, alice/m2, then bob/m1.
+	if len(page) != 2 || page[0].UserAddress != "0xAlice" || page[0].Model != "m1" || page[1].Model != "m2" {
+		t.Errorf("page1 = %+v, want [alice/m1, alice/m2]", page)
+	}
+	page2, _, err := d.ListUserDailyStat("2026-06-22", 2, 2)
+	if err != nil {
+		t.Fatalf("list page2: %v", err)
+	}
+	if len(page2) != 1 || page2[0].UserAddress != "0xBob" {
+		t.Errorf("page2 = %+v, want [bob/m1]", page2)
+	}
+
+	// Prune with retention=0 must be a no-op (the documented "keep forever"
+	// contract), then a 365-day retention must drop the ancient 2020 row while
+	// leaving the recent rows untouched — an assertion that holds regardless of
+	// the test clock.
+	if removed, err := d.PruneUserDailyStat(0); err != nil || removed != 0 {
+		t.Errorf("prune(0) = (%d, %v), want (0, nil)", removed, err)
+	}
+	// 2020-01-01 is comfortably older than 365 days from any plausible test
+	// clock, while the 2026 rows are not (this test's data date).
+	removed, err := d.PruneUserDailyStat(365)
+	if err != nil {
+		t.Fatalf("prune(365): %v", err)
+	}
+	if removed < 1 {
+		t.Errorf("prune(365) removed = %d, want >= 1 (the 2020 row)", removed)
+	}
+	var remaining int64
+	d.db.Model(&model.UserDailyStat{}).Where("date = ?", "2020-01-01").Count(&remaining)
+	if remaining != 0 {
+		t.Errorf("ancient rows remaining = %d, want 0", remaining)
+	}
+}

--- a/api/inference/internal/handler/handler.go
+++ b/api/inference/internal/handler/handler.go
@@ -109,6 +109,13 @@ func (h *Handler) Register(r *gin.Engine) {
 	group.GET("/logs", corsMiddleware(), h.ListLogs)                        // List all log files
 	group.GET("/logs/:component/:filename", corsMiddleware(), h.GetLogFile) // Download specific log file
 
+	// Per-wallet daily usage for the Router to pull direct (non-whitelisted)
+	// consumption. Only registered when the feature is enabled, so it returns
+	// 404 by default. Whitelist-gated inside the handler.
+	if h.ctrl.UserUsageStatsEnabled() {
+		group.GET("/admin/usage/daily", corsMiddleware(), middleware.RateLimitMiddleware(h.rateLimiter), h.GetUserDailyUsage)
+	}
+
 	// Async job endpoints (OpenAI-style paths)
 	asyncGroup := group.Group("/async")
 	asyncGroup.Use(corsMiddleware())

--- a/api/inference/internal/handler/usage_stats.go
+++ b/api/inference/internal/handler/usage_stats.go
@@ -1,0 +1,130 @@
+package handler
+
+import (
+	"net/http"
+	"regexp"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/0glabs/0g-serving-broker/common/errors"
+)
+
+// usageDailyDateRe enforces a strict YYYY-MM-DD calendar-date shape on the
+// required date parameter (the value is interpolated into a MySQL DATE
+// comparison via a bound parameter, but validating the shape rejects garbage
+// early with a clear 400).
+var usageDailyDateRe = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$`)
+
+const (
+	usageDailyDefaultLimit = 1000
+	usageDailyMaxLimit     = 5000
+)
+
+// userDailyStatItem is one per-wallet, per-model row in the response.
+type userDailyStatItem struct {
+	UserAddress  string `json:"user_address"`
+	Model        string `json:"model"`
+	RequestCount int64  `json:"request_count"`
+	InputTokens  int64  `json:"input_tokens"`
+	OutputTokens int64  `json:"output_tokens"`
+}
+
+// GetUserDailyUsage returns per-wallet, per-model token usage for a single UTC
+// date, for the direct (non-whitelisted) consumers of this provider's broker.
+// The Router pulls this daily and materializes it into its own table.
+//
+// Auth reuses the existing whitelist gate: the caller must present a valid
+// session token AND be whitelisted. See docs/wallet-direct-usage-design.md
+// (router repo) §4.5 — this couples "bypass billing" with "read all wallets'
+// usage"; acceptable for the internal/self-operated Router, revisit if any
+// non-Router address is ever whitelisted for billing reasons.
+//
+//	@Description  Get per-wallet daily token usage for a UTC date (whitelist-gated)
+//	@ID           getUserDailyUsage
+//	@Tags         usage
+//	@Produce      json
+//	@Param        date    query  string  true   "UTC calendar date (YYYY-MM-DD)"
+//	@Param        limit   query  int     false  "Page size (default 1000, max 5000)"
+//	@Param        offset  query  int     false  "Page offset (default 0)"
+//	@Router       /admin/usage/daily [get]
+//	@Success      200  {object}  map[string]interface{}
+func (h *Handler) GetUserDailyUsage(ctx *gin.Context) {
+	// 1. Authenticate the session (proves possession of the private key).
+	authedUser, err := h.ctrl.ValidateSession(ctx)
+	if err != nil {
+		ctx.Set("ignoreError", true)
+		handleBrokerError(ctx, err, "validate session")
+		return
+	}
+
+	// 2. Authorize: only whitelisted addresses may read all wallets' usage.
+	if !h.ctrl.IsWhitelistedUser(authedUser) {
+		ctx.JSON(http.StatusForbidden, gin.H{
+			"error": "not authorized to read usage statistics",
+		})
+		return
+	}
+
+	date := ctx.Query("date")
+	if !usageDailyDateRe.MatchString(date) {
+		ctx.JSON(http.StatusBadRequest, gin.H{
+			"error": "date is required and must be in YYYY-MM-DD format",
+		})
+		return
+	}
+
+	limit := usageDailyDefaultLimit
+	if raw := ctx.Query("limit"); raw != "" {
+		v, err := strconv.Atoi(raw)
+		if err != nil || v <= 0 {
+			ctx.JSON(http.StatusBadRequest, gin.H{"error": "limit must be a positive integer"})
+			return
+		}
+		if v > usageDailyMaxLimit {
+			v = usageDailyMaxLimit
+		}
+		limit = v
+	}
+
+	offset := 0
+	if raw := ctx.Query("offset"); raw != "" {
+		v, err := strconv.Atoi(raw)
+		if err != nil || v < 0 {
+			ctx.JSON(http.StatusBadRequest, gin.H{"error": "offset must be a non-negative integer"})
+			return
+		}
+		offset = v
+	}
+
+	rows, total, err := h.ctrl.ListUserDailyStat(date, limit, offset)
+	if err != nil {
+		// A DB failure here is a broker fault, not a client error: wrap as 500
+		// so it is classified, logged, and sanitized (rather than defaulting to
+		// 400 with a raw DB string, which the Router could mistake for a
+		// permanent client error and skip retrying).
+		handleBrokerError(ctx, errors.Internal(err), "list user daily usage")
+		return
+	}
+
+	data := make([]userDailyStatItem, 0, len(rows))
+	for _, r := range rows {
+		data = append(data, userDailyStatItem{
+			UserAddress:  r.UserAddress,
+			Model:        r.Model,
+			RequestCount: r.RequestCount,
+			InputTokens:  r.InputTokens,
+			OutputTokens: r.OutputTokens,
+		})
+	}
+
+	ctx.JSON(http.StatusOK, gin.H{
+		"object":           "list",
+		"provider_address": h.ctrl.ProviderAddress(),
+		"date":             date,
+		"total":            total,
+		"limit":            limit,
+		"offset":           offset,
+		"data":             data,
+	})
+}

--- a/api/inference/model/user_daily_stat.go
+++ b/api/inference/model/user_daily_stat.go
@@ -1,0 +1,31 @@
+package model
+
+// UserDailyStat stores per-wallet, per-model daily token usage for direct
+// (non-whitelisted) consumers. Unlike DailyStat (one global row per day), this
+// table keeps the user_address and model dimensions so the Router can pull
+// per-wallet direct usage that never passed through it.
+//
+// It is written inside the settlement transaction, before the request rows are
+// deleted (see db.AccumulateAndDeleteRequests), so the per-wallet breakdown
+// survives settlement. Whitelisted traffic never creates a request row, so it
+// is naturally excluded — this table contains only direct consumers.
+//
+// The primary key column order (date, user_address, model) is deliberate: the
+// only read pattern is "WHERE date = ? ORDER BY user_address, model" (the
+// /v1/admin/usage/daily endpoint), which the date-leading key serves with a
+// range scan in already-sorted order. The table is never deleted at
+// settlement (unlike request) and grows as wallets × models × days, so a
+// retention pruner trims old rows (see config.UserUsageStatsConfig).
+//
+// For speech-to-text the token columns are intentionally left at 0: whisper's
+// input_count carries seconds, not tokens, so accumulating it here would
+// mislabel seconds as tokens — the same skip DailyStat applies. request_count
+// is still recorded. See db.AccumulateAndDeleteRequests and #530.
+type UserDailyStat struct {
+	Date         string `gorm:"type:date;primaryKey" json:"date"`
+	UserAddress  string `gorm:"type:varchar(255);primaryKey" json:"userAddress"`
+	Model        string `gorm:"type:varchar(255);primaryKey" json:"model"`
+	RequestCount int64  `gorm:"type:bigint;not null;default:0" json:"requestCount"`
+	InputTokens  int64  `gorm:"type:bigint;not null;default:0" json:"inputTokens"`
+	OutputTokens int64  `gorm:"type:bigint;not null;default:0" json:"outputTokens"`
+}


### PR DESCRIPTION
## What

Adds a **per-wallet, per-model daily usage** breakdown that the Router can pull from each broker to account for **direct (non-Router) consumption** — traffic where a user settles on-chain with the provider directly and the Router never sees a request. The existing `daily_stat` is global (no wallet dimension) and the `request` rows are deleted at settlement, so this data had nowhere to live.

Wire contract (single source of truth): `docs/wallet-direct-usage-design.md` in the `0g-router` repo.

## How

- **`user_daily_stat` table** — PK `(date, user_address, model)` (date-leading to serve the only read pattern `WHERE date=? ORDER BY user_address, model` without a filesort). Upserted **inside the settlement transaction, before request rows are deleted**, so the per-wallet breakdown survives settlement. Reuses the existing speech-to-text seconds-vs-tokens skip so whisper seconds are never recorded as tokens.
- **`GET /v1/admin/usage/daily`** — read endpoint, `ValidateSession` + `IsWhitelistedUser` gated, paginated (`date`/`limit`/`offset`), echoes `provider_address`.
- **TTL pruner** — background goroutine bounds the table's unbounded growth (the Router keeps the permanent copy); runs on a cancellable context tied to shutdown.
- **Feature flag `userUsageStats.Enabled` (default off)** — when disabled the settlement hot-path is unchanged and the route is not registered (404).

## Channel invariant (why no double-counting)

Whitelisted traffic (the Router's own proxied requests) returns **before** `CreateRequest` in both the sync and async paths, so it never enters the `request` table → never enters `user_daily_stat`. The table therefore contains only direct consumers, with zero overlap with the Router's own ledger. No subtraction needed.

## Testing

- `go build ./...`, `go vet ./inference/...` clean.
- New integration tests (testcontainers MySQL): per-wallet aggregation, cross-batch accumulation, empty-model fallback, **STT token-skip**, feature-disabled no-write, list ordering/pagination, and TTL prune.
- Reviewed via 4 rounds of deep-review (general/security/error-handling/API-footgun); all CRITICAL/HIGH/MEDIUM findings from rounds 1–2 fixed, two final rounds clean.

## Reviewer notes / open decisions

- **Hot-path change**: the per-wallet upsert runs inside the settlement transaction. It's flag-gated and default-off — recommend enabling on a canary provider first.
- **Residual MEDIUM (design decision)**: on *wildcard* providers, `model` is the raw client string and becomes a durable PK component (row-inflation risk, bounded by the pruner; only paid/settled requests aggregate). Not fixed here because design-doc §6 mandates the broker report the *raw* model id and let the Router map to canonical — flagging for the Router owner to decide.
- `make lint` is red in CI-independent local runs due to a golangci-lint/Go-toolchain typecheck incompatibility affecting untouched packages too; `go build`/`go vet` are the authoritative signal here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)