### PR TITLE
feat(inference): broker-wide global RPM/TPM caps mirroring upstream quota

### DIFF
--- a/api/common/middleware/global_ratelimit.go
+++ b/api/common/middleware/global_ratelimit.go
@@ -35,6 +35,11 @@ const CtxKeyGlobalTPMLimiter = "globalTPMLimiter"
 // read-only Tokens()>0 check and the actual token count is deducted after the
 // response via ConsumeTokens. Either dimension is optional; a nil sub-limiter
 // means that dimension is disabled and always admits.
+//
+// A nil *GlobalRateLimiter is a valid "fully disabled" value: every method is
+// nil-receiver-safe by design (the proxy holds a nil field when neither
+// dimension is configured), so the g == nil guards are load-bearing — do not
+// strip them as redundant.
 type GlobalRateLimiter struct {
 	rpm      *rate.Limiter // nil when global RPM disabled
 	tpm      *rate.Limiter // nil when global TPM disabled
@@ -135,8 +140,8 @@ func (g *GlobalRateLimiter) tpmResetSeconds() float64 {
 }
 
 // CheckGlobalRPM enforces the broker-wide RPM cap for every request. On
-// rejection it writes a 503 (see writeGlobalCapacity503) and returns false;
-// returns true when admitted or when global RPM is disabled.
+// rejection it writes a 503 and aborts the context (response already written)
+// and returns false; returns true when admitted or when global RPM is disabled.
 func CheckGlobalRPM(g *GlobalRateLimiter, c *gin.Context) bool {
 	if g == nil || g.rpm == nil {
 		return true
@@ -150,12 +155,22 @@ func CheckGlobalRPM(g *GlobalRateLimiter, c *gin.Context) bool {
 	return true
 }
 
+// IsTokenService reports whether a service type is billed in tokens and is thus
+// subject to the TPM caps (per-user and global). Centralizing the set keeps the
+// admission gate (CheckGlobalTPM / CheckPerUserTPMLimit) and the proxy's
+// post-consume wiring from silently diverging — a divergence would admit a
+// request against the TPM cap without ever stashing the limiter to debit it.
+func IsTokenService(serviceType string) bool {
+	return serviceType == "chatbot" || serviceType == "speech-to-text"
+}
+
 // CheckGlobalTPM enforces the broker-wide TPM cap for token-based services
-// (chatbot, speech-to-text), mirroring the per-user TPM scope. On rejection it
-// writes a 503 and returns false; returns true when admitted, when global TPM is
-// disabled, or for non-token services.
+// (see IsTokenService), mirroring the per-user TPM scope. On rejection it writes
+// a 503 and aborts the context (response already written) and returns false;
+// returns true when admitted, when global TPM is disabled, or for non-token
+// services.
 func CheckGlobalTPM(g *GlobalRateLimiter, c *gin.Context, serviceType string) bool {
-	if g == nil || g.tpm == nil || (serviceType != "chatbot" && serviceType != "speech-to-text") {
+	if g == nil || g.tpm == nil || !IsTokenService(serviceType) {
 		return true
 	}
 	if !g.AllowTokens() {
@@ -170,6 +185,13 @@ func CheckGlobalTPM(g *GlobalRateLimiter, c *gin.Context, serviceType string) bo
 // ConsumeGlobalTokens deducts tokens from the global TPM bucket stashed in ctx,
 // if present. Safe no-op when the limiter is absent (global TPM disabled or a
 // non-token service). Mirrors the per-user post-consume call sites.
+//
+// CONTRACT: every token-billed response — for BOTH whitelisted and
+// non-whitelisted callers — must balance its admission with exactly one
+// ConsumeGlobalTokens call, or the global TPM cap silently stops depleting and
+// the broker overruns the upstream quota it exists to protect. When adding a
+// new token-billed service or response path, debit here right where you call
+// monitor.RecordTokens.
 func ConsumeGlobalTokens(ctx *gin.Context, tokens int) {
 	if tokens <= 0 {
 		return

--- a/api/common/middleware/global_ratelimit.go
+++ b/api/common/middleware/global_ratelimit.go
@@ -1,0 +1,199 @@
+package middleware
+
+import (
+	"fmt"
+	"math"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"golang.org/x/time/rate"
+)
+
+// CtxKeyGlobalTPMLimiter is the gin context key under which the proxy stashes
+// the GlobalRateLimiter for token-based services, so handlers can post-consume
+// the actual token count after the response completes. Mirrors the per-user
+// "tpmLimiter" key but is set for ALL users (including whitelisted ones).
+const CtxKeyGlobalTPMLimiter = "globalTPMLimiter"
+
+// GlobalRateLimiter enforces broker-wide (all users, including whitelisted)
+// requests-per-minute and tokens-per-minute caps using a single shared bucket
+// per dimension.
+//
+// Unlike the per-user limiters, the cap is shared across the whole broker, so it
+// mirrors a hard quota the broker itself is subject to — typically the RPM/TPM
+// limit a third-party upstream API (e.g. an Alibaba account reached over
+// TEE-TLS) imposes on the broker's account/key. Sizing these to the upstream
+// quota lets the broker self-throttle (returning 503 so the router fails over to
+// another provider) instead of overrunning the upstream and being throttled or
+// banned. Self-hosted GPU providers leave this disabled and rely on the
+// concurrency limiter, which is the right axis for GPU capacity.
+//
+// RPM uses an admission-consume model (each admitted request spends one token).
+// TPM uses the same post-consume model as PerUserTPMLimiter: admission is a
+// read-only Tokens()>0 check and the actual token count is deducted after the
+// response via ConsumeTokens. Either dimension is optional; a nil sub-limiter
+// means that dimension is disabled and always admits.
+type GlobalRateLimiter struct {
+	rpm      *rate.Limiter // nil when global RPM disabled
+	tpm      *rate.Limiter // nil when global TPM disabled
+	rpmLimit int           // original RPM value, for display
+	tpmLimit int           // original TPM value, for display
+	tpmBurst int           // TPM burst size, for chunked ConsumeTokens
+}
+
+// NewGlobalRateLimiter builds a broker-wide limiter. A non-positive rpm/tpm
+// disables that dimension. Bursts are floored to 1 when enabled so ConsumeTokens
+// never loops forever and Allow has a usable bucket.
+func NewGlobalRateLimiter(rpm, rpmBurst, tpm, tpmBurst int) *GlobalRateLimiter {
+	g := &GlobalRateLimiter{rpmLimit: rpm, tpmLimit: tpm}
+	if rpm > 0 {
+		if rpmBurst <= 0 {
+			rpmBurst = 1
+		}
+		g.rpm = rate.NewLimiter(rate.Limit(float64(rpm)/60.0), rpmBurst)
+	}
+	if tpm > 0 {
+		if tpmBurst <= 0 {
+			tpmBurst = 1
+		}
+		g.tpm = rate.NewLimiter(rate.Limit(float64(tpm)/60.0), tpmBurst)
+		g.tpmBurst = tpmBurst
+	}
+	return g
+}
+
+// Enabled reports whether at least one global dimension is active. Safe on a nil
+// receiver so the proxy can leave the field nil when neither dimension is set.
+func (g *GlobalRateLimiter) Enabled() bool {
+	return g != nil && (g.rpm != nil || g.tpm != nil)
+}
+
+// AllowRequest consumes one request token from the global RPM bucket. Returns
+// false when the broker-wide RPM cap is exhausted; always true when RPM is
+// disabled.
+func (g *GlobalRateLimiter) AllowRequest() bool {
+	if g == nil || g.rpm == nil {
+		return true
+	}
+	return g.rpm.Allow()
+}
+
+// AllowTokens reports whether the global TPM bucket has any budget left. This is
+// a read-only check (post-consume model); the actual deduction happens in
+// ConsumeTokens after the response. Always true when TPM is disabled.
+func (g *GlobalRateLimiter) AllowTokens() bool {
+	if g == nil || g.tpm == nil {
+		return true
+	}
+	return g.tpm.Tokens() > 0
+}
+
+// ConsumeTokens deducts the actual token count from the global TPM bucket after
+// a response completes. Tokens are consumed in burst-sized chunks because
+// rate.Limiter.ReserveN silently no-ops when n > burst. No-op when TPM disabled.
+func (g *GlobalRateLimiter) ConsumeTokens(tokens int) {
+	if g == nil || g.tpm == nil || tokens <= 0 {
+		return
+	}
+	now := time.Now()
+	remaining := tokens
+	for remaining > 0 {
+		n := remaining
+		if n > g.tpmBurst {
+			n = g.tpmBurst
+		}
+		g.tpm.ReserveN(now, n)
+		remaining -= n
+	}
+}
+
+// rpmResetSeconds returns roughly how long until one request token is available
+// again, for a Retry-After hint. Returns 0 when RPM is disabled or has budget.
+func (g *GlobalRateLimiter) rpmResetSeconds() float64 {
+	if g == nil || g.rpm == nil {
+		return 0
+	}
+	if tokens := g.rpm.Tokens(); tokens < 1 {
+		return (1 - tokens) / float64(g.rpm.Limit())
+	}
+	return 0
+}
+
+// tpmResetSeconds returns roughly how long until the TPM bucket returns to a
+// positive balance, for a Retry-After hint. Returns 0 when TPM is disabled or
+// has budget.
+func (g *GlobalRateLimiter) tpmResetSeconds() float64 {
+	if g == nil || g.tpm == nil {
+		return 0
+	}
+	if tokens := g.tpm.Tokens(); tokens < 0 {
+		return math.Abs(tokens) / float64(g.tpm.Limit())
+	}
+	return 0
+}
+
+// CheckGlobalRPM enforces the broker-wide RPM cap for every request. On
+// rejection it writes a 503 (see writeGlobalCapacity503) and returns false;
+// returns true when admitted or when global RPM is disabled.
+func CheckGlobalRPM(g *GlobalRateLimiter, c *gin.Context) bool {
+	if g == nil || g.rpm == nil {
+		return true
+	}
+	if !g.AllowRequest() {
+		writeGlobalCapacity503(c,
+			fmt.Sprintf("Server is at capacity (global limit: %d requests/min). Please try again later.", g.rpmLimit),
+			g.rpmResetSeconds())
+		return false
+	}
+	return true
+}
+
+// CheckGlobalTPM enforces the broker-wide TPM cap for token-based services
+// (chatbot, speech-to-text), mirroring the per-user TPM scope. On rejection it
+// writes a 503 and returns false; returns true when admitted, when global TPM is
+// disabled, or for non-token services.
+func CheckGlobalTPM(g *GlobalRateLimiter, c *gin.Context, serviceType string) bool {
+	if g == nil || g.tpm == nil || (serviceType != "chatbot" && serviceType != "speech-to-text") {
+		return true
+	}
+	if !g.AllowTokens() {
+		writeGlobalCapacity503(c,
+			fmt.Sprintf("Server is at capacity (global limit: %d tokens/min). Please try again later.", g.tpmLimit),
+			g.tpmResetSeconds())
+		return false
+	}
+	return true
+}
+
+// ConsumeGlobalTokens deducts tokens from the global TPM bucket stashed in ctx,
+// if present. Safe no-op when the limiter is absent (global TPM disabled or a
+// non-token service). Mirrors the per-user post-consume call sites.
+func ConsumeGlobalTokens(ctx *gin.Context, tokens int) {
+	if tokens <= 0 {
+		return
+	}
+	if v, exists := ctx.Get(CtxKeyGlobalTPMLimiter); exists {
+		if g, ok := v.(*GlobalRateLimiter); ok {
+			g.ConsumeTokens(tokens)
+		}
+	}
+}
+
+// writeGlobalCapacity503 writes the capacity-shedding response shared by the
+// global RPM/TPM gates. It returns 503 (not 429) deliberately: a 503 is a
+// capacity signal the router treats as retryable in every mode, so it fails over
+// to another provider — matching the global concurrency limiter. The
+// ignoreError flag keeps this expected shedding out of the broker error count
+// while the failure counter still records it as a broker-source 503.
+func writeGlobalCapacity503(c *gin.Context, message string, retryAfterSecs float64) {
+	c.Set("ignoreError", true)
+	if retryAfterSecs > 0 {
+		c.Header("Retry-After", strconv.Itoa(int(math.Ceil(retryAfterSecs))))
+	}
+	c.JSON(http.StatusServiceUnavailable, gin.H{
+		"error": message,
+	})
+	c.Abort()
+}

--- a/api/common/middleware/global_ratelimit_test.go
+++ b/api/common/middleware/global_ratelimit_test.go
@@ -1,0 +1,131 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func init() { gin.SetMode(gin.TestMode) }
+
+// newGinCtx returns a gin.Context backed by a fresh ResponseRecorder for
+// asserting status/headers written by the Check* helpers.
+func newGinCtx() (*gin.Context, *httptest.ResponseRecorder) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/proxy/chat/completions", nil)
+	return c, w
+}
+
+// TestGlobalRateLimiterDisabled verifies a nil/zero limiter admits everything so
+// providers that don't set the global caps are unaffected.
+func TestGlobalRateLimiterDisabled(t *testing.T) {
+	var g *GlobalRateLimiter // nil receiver
+	if g.Enabled() {
+		t.Fatal("nil limiter should not be Enabled")
+	}
+	c, _ := newGinCtx()
+	if !CheckGlobalRPM(g, c) || !CheckGlobalTPM(g, c, "chatbot") {
+		t.Fatal("nil limiter must admit all requests")
+	}
+
+	off := NewGlobalRateLimiter(0, 0, 0, 0)
+	if off.Enabled() {
+		t.Fatal("0/0 limiter should not be Enabled")
+	}
+}
+
+// TestGlobalRPMAdmission verifies the broker-wide RPM bucket admits up to the
+// burst then sheds with a 503 (capacity signal, not 429) plus a Retry-After.
+func TestGlobalRPMAdmission(t *testing.T) {
+	// 60 RPM => 1 token/sec; burst 2 => first 2 requests pass, 3rd is shed.
+	g := NewGlobalRateLimiter(60, 2, 0, 0)
+	if !g.Enabled() {
+		t.Fatal("limiter with RPM>0 should be Enabled")
+	}
+
+	for i := 0; i < 2; i++ {
+		c, _ := newGinCtx()
+		if !CheckGlobalRPM(g, c) {
+			t.Fatalf("request %d within burst should be admitted", i+1)
+		}
+	}
+
+	c, w := newGinCtx()
+	if CheckGlobalRPM(g, c) {
+		t.Fatal("request beyond burst should be shed")
+	}
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("shed request status = %d, want 503", w.Code)
+	}
+	if w.Header().Get("Retry-After") == "" {
+		t.Fatal("shed request should carry a Retry-After header")
+	}
+	if !c.IsAborted() {
+		t.Fatal("shed request context should be aborted")
+	}
+	if v, ok := c.Get("ignoreError"); !ok || v != true {
+		t.Fatal("capacity shedding must set ignoreError so it isn't counted as a service error")
+	}
+}
+
+// TestGlobalTPMPostConsume verifies the post-consume model: admission is
+// read-only until ConsumeTokens drives the shared bucket non-positive, after
+// which token-based services are shed with a 503 while non-token services pass.
+func TestGlobalTPMPostConsume(t *testing.T) {
+	// 600 TPM => 10 tokens/sec; burst 100.
+	g := NewGlobalRateLimiter(0, 0, 600, 100)
+
+	c, _ := newGinCtx()
+	if !CheckGlobalTPM(g, c, "chatbot") {
+		t.Fatal("fresh TPM bucket should admit")
+	}
+
+	// Deplete well past the burst; the bucket goes negative.
+	g.ConsumeTokens(500)
+
+	c, w := newGinCtx()
+	if CheckGlobalTPM(g, c, "chatbot") {
+		t.Fatal("exhausted TPM bucket should shed token-based service")
+	}
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("shed TPM request status = %d, want 503", w.Code)
+	}
+
+	// Non-token services (e.g. image) are not subject to the TPM cap.
+	c2, _ := newGinCtx()
+	if !CheckGlobalTPM(g, c2, "text-to-image") {
+		t.Fatal("TPM cap must not apply to non-token services")
+	}
+}
+
+// TestGlobalTPMBurstChunking verifies a single consume larger than the burst is
+// fully accounted for (ReserveN no-ops when n > burst, so it must be chunked).
+func TestGlobalTPMBurstChunking(t *testing.T) {
+	g := NewGlobalRateLimiter(0, 0, 600, 50)
+	// Consume 10x the burst in one call; must still drive the bucket negative.
+	g.ConsumeTokens(500)
+	if g.AllowTokens() {
+		t.Fatal("consuming 500 tokens against burst 50 should exhaust the bucket")
+	}
+}
+
+// TestConsumeGlobalTokensFromContext verifies the context helper deducts only
+// when a limiter is stashed, and is a safe no-op otherwise.
+func TestConsumeGlobalTokensFromContext(t *testing.T) {
+	g := NewGlobalRateLimiter(0, 0, 600, 100)
+
+	c, _ := newGinCtx()
+	ConsumeGlobalTokens(c, 50) // no limiter in context -> no-op, must not panic
+	if !g.AllowTokens() {
+		t.Fatal("limiter not in context must be untouched")
+	}
+
+	c.Set(CtxKeyGlobalTPMLimiter, g)
+	ConsumeGlobalTokens(c, 500)
+	if g.AllowTokens() {
+		t.Fatal("ConsumeGlobalTokens should deplete the stashed limiter")
+	}
+}

--- a/api/common/middleware/per_user_tpm_ratelimit.go
+++ b/api/common/middleware/per_user_tpm_ratelimit.go
@@ -183,7 +183,7 @@ func (rl *PerUserTPMLimiter) EffectiveTPM(userID string) int {
 // Returns true if allowed, false if rate limited (response already written).
 // Non-token-based services always return true (TPM doesn't apply).
 func CheckPerUserTPMLimit(limiter *PerUserTPMLimiter, c *gin.Context, userAddress string, serviceType string) bool {
-	if limiter == nil || (serviceType != "chatbot" && serviceType != "speech-to-text") {
+	if limiter == nil || !IsTokenService(serviceType) {
 		return true
 	}
 

--- a/api/config-example-all.yaml
+++ b/api/config-example-all.yaml
@@ -40,3 +40,55 @@ zkProver:
   # requestLength defines the number of requests prover broker packs into one
   # chunk as the minimum unit for settlement.
   requestLength: 40
+
+# Concurrency and rate limiting for backend protection. All values shown are the
+# built-in defaults — the whole block is optional; omit it to keep the defaults.
+concurrencyLimit:
+  # ---- Global caps (apply to ALL users, including whitelisted ones) ----
+
+  # Max total in-flight requests to the backend. Size this to your GPU/serving
+  # capacity. Exhaustion returns HTTP 503 (the router treats it as a capacity
+  # signal and fails over to another provider).
+  maxGlobalConcurrent: 20
+
+  # Broker-wide requests-per-minute / tokens-per-minute caps. 0 disables them.
+  # Leave OFF for self-hosted GPU providers (concurrency is the right axis there).
+  # Turn ON when this broker fronts a rate-limited third-party upstream API
+  # (e.g. an Alibaba account reached over TEE-TLS): set these to mirror the
+  # RPM/TPM quota the upstream grants your account so the broker self-throttles
+  # (returns 503 -> router fails over) instead of overrunning the upstream and
+  # getting throttled/banned. TPM applies to chatbot/speech-to-text only.
+  # Bursts default to limit/6 (~10s) when 0; global TPM burst is floored to the
+  # model's context_length.
+  maxGlobalRPM: 0
+  maxGlobalRPMBurst: 0
+  maxGlobalTPM: 0
+  maxGlobalTPMBurst: 0
+
+  # ---- Per-user caps (keyed by wallet address; whitelisted users are exempt) ----
+
+  # Max concurrent requests per user. Exhaustion returns HTTP 429.
+  maxPerUserConcurrent: 5
+
+  # Per-user requests/tokens/images per minute. 0 disables a dimension.
+  # RPM applies to all services; TPM to chatbot/speech-to-text; IPM to
+  # text-to-image/image-editing. Exhaustion returns HTTP 429.
+  perUserRPM: 30
+  perUserBurst: 5
+  perUserTPM: 0
+  perUserTPMBurst: 0
+  perUserIPM: 0
+  perUserIPMBurst: 0
+
+  # Optional per-address overrides for heavy partners. A zero field inherits the
+  # corresponding default above; an override only takes effect for a dimension
+  # that is globally enabled. Overrides never raise maxGlobalConcurrent.
+  # perUserOverrides:
+  #   - userAddress: "0xabc...123"
+  #     maxConcurrent: 10
+  #     rpm: 120
+  #     burst: 20
+  #     tpm: 0
+  #     tpmBurst: 0
+  #     ipm: 0
+  #     ipmBurst: 0

--- a/api/inference/config/config.go
+++ b/api/inference/config/config.go
@@ -549,6 +549,10 @@ type Config struct {
 // Per-user limit prevents a single user from monopolizing all slots.
 type ConcurrencyLimitConfig struct {
 	MaxGlobalConcurrent  int `yaml:"maxGlobalConcurrent"`  // Max total concurrent requests to backend (default: 20)
+	MaxGlobalRPM         int `yaml:"maxGlobalRPM"`         // Broker-wide requests/min cap mirroring the upstream account quota (default: 0 = disabled, applies to ALL users incl. whitelisted)
+	MaxGlobalRPMBurst    int `yaml:"maxGlobalRPMBurst"`    // Burst for global RPM (default: 0 → MaxGlobalRPM/6)
+	MaxGlobalTPM         int `yaml:"maxGlobalTPM"`         // Broker-wide tokens/min cap mirroring the upstream account quota (default: 0 = disabled, chatbot/speech-to-text)
+	MaxGlobalTPMBurst    int `yaml:"maxGlobalTPMBurst"`    // Burst for global TPM (default: 0 → MaxGlobalTPM/6, floored to context_length)
 	MaxPerUserConcurrent int `yaml:"maxPerUserConcurrent"` // Max concurrent requests per user (default: 5, whitelisted users are exempt)
 	PerUserRPM           int `yaml:"perUserRPM"`           // Max requests per minute per user (default: 30, 0 = disabled)
 	PerUserBurst         int `yaml:"perUserBurst"`         // Max burst size for per-user rate limit (default: 5)
@@ -1201,6 +1205,10 @@ func GetConfig() *Config {
 			},
 			ConcurrencyLimit: ConcurrencyLimitConfig{
 				MaxGlobalConcurrent:  20,
+				MaxGlobalRPM:         0, // disabled by default
+				MaxGlobalRPMBurst:    0,
+				MaxGlobalTPM:         0, // disabled by default
+				MaxGlobalTPMBurst:    0,
 				MaxPerUserConcurrent: 5,
 				PerUserRPM:           30,
 				PerUserBurst:         5,

--- a/api/inference/internal/ctrl/chatbot.go
+++ b/api/inference/internal/ctrl/chatbot.go
@@ -449,6 +449,7 @@ func (c *Ctrl) processSingleResponse(ctx context.Context, decodedBody []byte, ou
 			monitor.RecordTokens("chatbot", metricModel, int64(chunk.Usage.PromptTokens), int64(chunk.Usage.CompletionTokens))
 			monitor.RecordWhitelistTokens("chatbot", metricModel, int64(chunk.Usage.PromptTokens), int64(chunk.Usage.CompletionTokens))
 			monitor.RecordTPSFromContext(ctx, "chatbot", metricModel, int64(chunk.Usage.CompletionTokens))
+			c.consumeGlobalChatTokens(ctx, chunk.Usage)
 		}
 		return nil
 	}
@@ -687,6 +688,21 @@ func (c *Ctrl) updateAccountWithOutput(ctx context.Context, output string, outpu
 	return nil
 }
 
+// consumeGlobalChatTokens debits the broker-wide TPM bucket for a chatbot
+// response. It is the whitelisted-path counterpart to the inline
+// ConsumeGlobalTokens calls in updateAccountWithUsage/updateAccountWithOutput:
+// whitelisted traffic skips per-user billing but still consumes real upstream
+// tokens, so it must count against the global quota. Always pair a token-billed
+// chatbot response with one of these calls — see CtxKeyGlobalTPMLimiter.
+func (c *Ctrl) consumeGlobalChatTokens(ctx context.Context, usage *Usage) {
+	if usage == nil {
+		return
+	}
+	if ginCtx, ok := ctx.(*gin.Context); ok {
+		middleware.ConsumeGlobalTokens(ginCtx, usage.PromptTokens+usage.CompletionTokens)
+	}
+}
+
 func isStreamDone(line []byte) bool {
 	return bytes.Equal(line, []byte("data: [DONE]"))
 }
@@ -806,6 +822,7 @@ func (c *Ctrl) finalizeChatStream(ctx context.Context, output string, usage *Usa
 			monitor.RecordTokens("chatbot", metricModel, int64(usage.PromptTokens), int64(usage.CompletionTokens))
 			monitor.RecordWhitelistTokens("chatbot", metricModel, int64(usage.PromptTokens), int64(usage.CompletionTokens))
 			monitor.RecordTPSFromContext(ctx, "chatbot", metricModel, int64(usage.CompletionTokens))
+			c.consumeGlobalChatTokens(ctx, usage)
 		}
 		return nil
 	}

--- a/api/inference/internal/ctrl/chatbot.go
+++ b/api/inference/internal/ctrl/chatbot.go
@@ -630,6 +630,9 @@ func (c *Ctrl) updateAccountWithUsage(ctx context.Context, usage *Usage, outputP
 				limiter.ConsumeTokens(userStr, totalTokens)
 			}
 		}
+		// Deduct the same tokens from the broker-wide TPM bucket (applies to all
+		// users, including whitelisted ones, so it mirrors the upstream quota).
+		middleware.ConsumeGlobalTokens(ginCtx, totalTokens)
 	}
 
 	return nil
@@ -671,12 +674,14 @@ func (c *Ctrl) updateAccountWithOutput(ctx context.Context, output string, outpu
 	if ginCtx, ok := ctx.(*gin.Context); ok {
 		userAddr, _ := ginCtx.Get("userAddress")
 		userStr, userOk := userAddr.(string)
+		estimatedTotal := int(outputCount + request.InputCount)
 		if tpmLimiter, exists := ginCtx.Get("tpmLimiter"); exists && userOk {
 			if limiter, ok := tpmLimiter.(*middleware.PerUserTPMLimiter); ok {
-				estimatedTotal := int(outputCount + request.InputCount)
 				limiter.ConsumeTokens(userStr, estimatedTotal)
 			}
 		}
+		// Mirror the deduction into the broker-wide TPM bucket (fallback path).
+		middleware.ConsumeGlobalTokens(ginCtx, estimatedTotal)
 	}
 
 	return nil

--- a/api/inference/internal/ctrl/chatbot.go
+++ b/api/inference/internal/ctrl/chatbot.go
@@ -449,8 +449,8 @@ func (c *Ctrl) processSingleResponse(ctx context.Context, decodedBody []byte, ou
 			monitor.RecordTokens("chatbot", metricModel, int64(chunk.Usage.PromptTokens), int64(chunk.Usage.CompletionTokens))
 			monitor.RecordWhitelistTokens("chatbot", metricModel, int64(chunk.Usage.PromptTokens), int64(chunk.Usage.CompletionTokens))
 			monitor.RecordTPSFromContext(ctx, "chatbot", metricModel, int64(chunk.Usage.CompletionTokens))
-			c.consumeGlobalChatTokens(ctx, chunk.Usage)
 		}
+		c.consumeGlobalChatTokens(ctx, chunk.Usage, *output)
 		return nil
 	}
 
@@ -694,13 +694,20 @@ func (c *Ctrl) updateAccountWithOutput(ctx context.Context, output string, outpu
 // whitelisted traffic skips per-user billing but still consumes real upstream
 // tokens, so it must count against the global quota. Always pair a token-billed
 // chatbot response with one of these calls — see CtxKeyGlobalTPMLimiter.
-func (c *Ctrl) consumeGlobalChatTokens(ctx context.Context, usage *Usage) {
-	if usage == nil {
+//
+// When usage is nil (provider omitted it), it falls back to a word-count
+// estimate of the output, mirroring updateAccountWithOutput, so the global quota
+// still accounts for whitelisted traffic from providers that don't report usage.
+func (c *Ctrl) consumeGlobalChatTokens(ctx context.Context, usage *Usage, output string) {
+	ginCtx, ok := ctx.(*gin.Context)
+	if !ok {
 		return
 	}
-	if ginCtx, ok := ctx.(*gin.Context); ok {
+	if usage != nil {
 		middleware.ConsumeGlobalTokens(ginCtx, usage.PromptTokens+usage.CompletionTokens)
+		return
 	}
+	middleware.ConsumeGlobalTokens(ginCtx, len(strings.Fields(output)))
 }
 
 func isStreamDone(line []byte) bool {
@@ -822,8 +829,8 @@ func (c *Ctrl) finalizeChatStream(ctx context.Context, output string, usage *Usa
 			monitor.RecordTokens("chatbot", metricModel, int64(usage.PromptTokens), int64(usage.CompletionTokens))
 			monitor.RecordWhitelistTokens("chatbot", metricModel, int64(usage.PromptTokens), int64(usage.CompletionTokens))
 			monitor.RecordTPSFromContext(ctx, "chatbot", metricModel, int64(usage.CompletionTokens))
-			c.consumeGlobalChatTokens(ctx, usage)
 		}
+		c.consumeGlobalChatTokens(ctx, usage, output)
 		return nil
 	}
 	if usage != nil {

--- a/api/inference/internal/ctrl/chatbot_litellm.go
+++ b/api/inference/internal/ctrl/chatbot_litellm.go
@@ -147,7 +147,7 @@ func (c *Ctrl) processLiteLLMSingleResponse(ctx context.Context, decodedBody []b
 			monitor.RecordTokens("chatbot", metricModel, int64((*usage).PromptTokens), int64((*usage).CompletionTokens))
 			monitor.RecordWhitelistTokens("chatbot", metricModel, int64((*usage).PromptTokens), int64((*usage).CompletionTokens))
 			monitor.RecordTPSFromContext(ctx, "chatbot", metricModel, int64((*usage).CompletionTokens))
-			c.consumeGlobalChatTokens(ctx, *usage)
+			c.consumeGlobalChatTokens(ctx, *usage, *output)
 			return nil
 		}
 
@@ -158,8 +158,10 @@ func (c *Ctrl) processLiteLLMSingleResponse(ctx context.Context, decodedBody []b
 		return c.updateAccountWithUsage(ctx, *usage, prices.OutputPrice, requestHash, prices.InputPrice, prices.Tiers, prices.CacheTokenBilling)
 	}
 
-	// Skip billing for whitelisted users
+	// Skip billing for whitelisted users (no usage reported → word-count estimate
+	// still counts against the global TPM quota).
 	if isWhitelisted {
+		c.consumeGlobalChatTokens(ctx, nil, *output)
 		return nil
 	}
 

--- a/api/inference/internal/ctrl/chatbot_litellm.go
+++ b/api/inference/internal/ctrl/chatbot_litellm.go
@@ -147,6 +147,7 @@ func (c *Ctrl) processLiteLLMSingleResponse(ctx context.Context, decodedBody []b
 			monitor.RecordTokens("chatbot", metricModel, int64((*usage).PromptTokens), int64((*usage).CompletionTokens))
 			monitor.RecordWhitelistTokens("chatbot", metricModel, int64((*usage).PromptTokens), int64((*usage).CompletionTokens))
 			monitor.RecordTPSFromContext(ctx, "chatbot", metricModel, int64((*usage).CompletionTokens))
+			c.consumeGlobalChatTokens(ctx, *usage)
 			return nil
 		}
 

--- a/api/inference/internal/ctrl/speech_to_text.go
+++ b/api/inference/internal/ctrl/speech_to_text.go
@@ -336,6 +336,7 @@ func (c *Ctrl) handleNonStreamingSpeechToText(ctx *gin.Context, resp *http.Respo
 	// Skip billing for whitelisted users, but record whitelist traffic metrics
 	if reqModel.IsWhitelisted {
 		recordWhitelistUsageMetrics(transcriptionResp.Usage, c.metricModel(ctx))
+		c.consumeGlobalSpeechToTextUnits(ctx, transcriptionResp.Usage)
 		return nil
 	}
 
@@ -463,6 +464,7 @@ func (c *Ctrl) handleStreamingSpeechToText(ctx *gin.Context, resp *http.Response
 	// Skip billing for whitelisted users, but record whitelist traffic metrics
 	if reqModel.IsWhitelisted {
 		recordWhitelistUsageMetrics(usage, c.metricModel(ctx))
+		c.consumeGlobalSpeechToTextUnits(ctx, usage)
 		return nil
 	}
 
@@ -698,6 +700,22 @@ func (c *Ctrl) consumeSpeechToTextLimiter(ctx context.Context, units int) {
 		return
 	}
 	limiter.ConsumeTokens(userStr, units)
+}
+
+// consumeGlobalSpeechToTextUnits debits the broker-wide TPM bucket for a
+// speech-to-text response on the whitelisted path (which skips per-user billing
+// and so never reaches consumeSpeechToTextLimiter, where the non-whitelisted
+// global deduction lives). Units mirror the per-user limiter: audio seconds in
+// duration mode, otherwise input+output tokens.
+func (c *Ctrl) consumeGlobalSpeechToTextUnits(ctx context.Context, u *SpeechToTextUsage) {
+	seconds, in, out := classifyUsageForMetrics(u)
+	units := int(in + out)
+	if seconds > 0 {
+		units = int(seconds)
+	}
+	if ginCtx, ok := ctx.(*gin.Context); ok {
+		middleware.ConsumeGlobalTokens(ginCtx, units)
+	}
 }
 
 // classifyUsageForMetrics splits a usage object into the values destined for

--- a/api/inference/internal/ctrl/speech_to_text.go
+++ b/api/inference/internal/ctrl/speech_to_text.go
@@ -675,6 +675,12 @@ func (c *Ctrl) consumeSpeechToTextLimiter(ctx context.Context, units int) {
 		c.logger.Debugf("consumeSpeechToTextLimiter: ctx is not *gin.Context (units=%d), limiter skipped", units)
 		return
 	}
+	// Deduct from the broker-wide TPM bucket first, before the per-user early
+	// returns below: the global limiter is wired for all users (including
+	// whitelisted ones) and is independent of the per-user "tpmLimiter"/
+	// userAddress keys. No-op when global TPM is disabled.
+	middleware.ConsumeGlobalTokens(ginCtx, units)
+
 	userAddr, _ := ginCtx.Get("userAddress")
 	userStr, userOk := userAddr.(string)
 	if !userOk {

--- a/api/inference/internal/proxy/proxy.go
+++ b/api/inference/internal/proxy/proxy.go
@@ -38,6 +38,7 @@ type Proxy struct {
 	serviceGroup              *gin.RouterGroup
 	rateLimiter               *middleware.RateLimiter
 	concurrencyLimiter        *middleware.ConcurrencyLimiter
+	globalLimiter             *middleware.GlobalRateLimiter
 	perUserConcurrencyLimiter *middleware.PerUserConcurrencyLimiter
 	perUserRateLimiter        *middleware.PerUserRateLimiter
 	perUserTPMLimiter         *middleware.PerUserTPMLimiter
@@ -90,6 +91,38 @@ func New(ctrl *ctrl.Ctrl, engine *gin.Engine, allowOrigins []string, enableMonit
 		// Configure concurrency limiter to match backend GPU capacity
 		concurrencyLimiter:        middleware.NewConcurrencyLimiter(concurrencyConfig.MaxGlobalConcurrent),
 		perUserConcurrencyLimiter: middleware.NewPerUserConcurrencyLimiter(concurrencyConfig.MaxPerUserConcurrent, concOverrides),
+	}
+
+	// Initialize the broker-wide RPM/TPM limiter if configured. This mirrors a
+	// hard quota the broker's own upstream account is subject to (e.g. a
+	// third-party API key reached over TEE-TLS), so it applies to ALL users
+	// including whitelisted ones. Self-hosted GPU providers leave it off (0) and
+	// rely on the concurrency limiter instead.
+	if concurrencyConfig.MaxGlobalRPM > 0 || concurrencyConfig.MaxGlobalTPM > 0 {
+		rpmBurst := concurrencyConfig.MaxGlobalRPMBurst
+		if rpmBurst <= 0 && concurrencyConfig.MaxGlobalRPM > 0 {
+			rpmBurst = concurrencyConfig.MaxGlobalRPM / 6 // ~10 seconds worth of requests
+			if rpmBurst <= 0 {
+				rpmBurst = 1
+			}
+		}
+		tpmBurst := concurrencyConfig.MaxGlobalTPMBurst
+		if tpmBurst <= 0 && concurrencyConfig.MaxGlobalTPM > 0 {
+			tpmBurst = concurrencyConfig.MaxGlobalTPM / 6 // ~10 seconds worth of tokens
+			if tpmBurst <= 0 {
+				tpmBurst = 1
+			}
+		}
+		// Floor the global TPM burst to context_length so a single max-context
+		// request can't drive the shared bucket deeply negative and lock out
+		// every user, mirroring the per-user TPM burst rule above.
+		if concurrencyConfig.MaxGlobalTPM > 0 && contextLength > tpmBurst {
+			tpmBurst = contextLength
+		}
+		p.globalLimiter = middleware.NewGlobalRateLimiter(
+			concurrencyConfig.MaxGlobalRPM, rpmBurst, concurrencyConfig.MaxGlobalTPM, tpmBurst)
+		logger.Infof("Global rate limit: RPM=%d (burst=%d), TPM=%d (burst=%d)",
+			concurrencyConfig.MaxGlobalRPM, rpmBurst, concurrencyConfig.MaxGlobalTPM, tpmBurst)
 	}
 
 	// Initialize per-user rate limiter if configured
@@ -524,6 +557,29 @@ func (p *Proxy) proxyHTTPRequest(ctx *gin.Context) {
 
 	// Check if user is whitelisted (checked early to skip per-user concurrency limit)
 	isWhitelisted := p.ctrl.IsWhitelistedUser(userAddress)
+
+	// Global RPM/TPM caps apply to ALL users — including whitelisted internal
+	// services and the router — because they mirror a hard quota the broker's own
+	// upstream account is subject to: every request counts against it regardless
+	// of who sent it. Checked before the per-user limits since it guards the
+	// shared upstream quota. Exhaustion returns 503 (a capacity signal) so the
+	// router fails over to another provider, consistent with the global
+	// concurrency limiter.
+	if p.globalLimiter.Enabled() {
+		if !middleware.CheckGlobalRPM(p.globalLimiter, ctx) {
+			p.rejections.record(ctx, monitor.RejectionGlobalRPM, userAddress)
+			return
+		}
+		if !middleware.CheckGlobalTPM(p.globalLimiter, ctx, svcType) {
+			p.rejections.record(ctx, monitor.RejectionGlobalTPM, userAddress)
+			return
+		}
+		// Stash for post-response token consumption (token-based services only),
+		// regardless of whitelist status so global TPM accounts for all traffic.
+		if svcType == "chatbot" || svcType == "speech-to-text" {
+			ctx.Set(middleware.CtxKeyGlobalTPMLimiter, p.globalLimiter)
+		}
+	}
 
 	// Apply per-user rate limit and concurrency limit for non-whitelisted users.
 	// Whitelisted users (internal services, monitoring) are exempt to avoid

--- a/api/inference/internal/proxy/proxy.go
+++ b/api/inference/internal/proxy/proxy.go
@@ -576,7 +576,9 @@ func (p *Proxy) proxyHTTPRequest(ctx *gin.Context) {
 		}
 		// Stash for post-response token consumption (token-based services only),
 		// regardless of whitelist status so global TPM accounts for all traffic.
-		if svcType == "chatbot" || svcType == "speech-to-text" {
+		// Uses the same IsTokenService predicate as CheckGlobalTPM so the
+		// admission gate and the post-consume wiring can never diverge.
+		if middleware.IsTokenService(svcType) {
 			ctx.Set(middleware.CtxKeyGlobalTPMLimiter, p.globalLimiter)
 		}
 	}

--- a/api/inference/monitor/server.go
+++ b/api/inference/monitor/server.go
@@ -146,7 +146,8 @@ const CtxKeyFailureSource = "failureSource"
 
 // Rejection reason label values for RequestRejectedTotal. These are the only
 // strings ever passed to RecordRejection, keeping the metric's cardinality
-// bounded. Group: admission gates (rate/tpm/ipm/concurrency/model_mismatch),
+// bounded. Group: admission gates (rate/tpm/ipm/concurrency/global_rpm/
+// global_tpm/model_mismatch),
 // billing gates (insufficient_balance/not_acknowledged/account_not_exist), and
 // the upstream_error catch-all for validation failures whose specific cause
 // isn't classified. Every constant here has a live emit site — a reason is not
@@ -157,6 +158,8 @@ const (
 	RejectionTPMLimit        = "tpm_limit"
 	RejectionIPMLimit        = "ipm_limit"
 	RejectionConcurrency     = "concurrency"
+	RejectionGlobalRPM       = "global_rpm"
+	RejectionGlobalTPM       = "global_tpm"
 	RejectionModelMismatch   = "model_mismatch"
 	RejectionInsufficientBal = "insufficient_balance"
 	RejectionNotAcknowledged = "not_acknowledged"


### PR DESCRIPTION
## What

Adds optional **broker-wide** requests-per-minute (`maxGlobalRPM`) and tokens-per-minute (`maxGlobalTPM`) caps, default `0` (off). This is **Phase B** of the provider-fallback robustness plan in 0gfoundation/0g-router#493.

## Why

The broker's existing global cap is **concurrency** only — the right axis when the provider is self-hosted GPU. But when a broker fronts a **rate-limited third-party upstream API** (e.g. an Alibaba account reached over TEE-TLS), the binding constraint is the upstream's **RPM/TPM quota on our account**, which concurrency can't enforce. Without this, the broker overruns the upstream and gets throttled/banned.

These caps let the broker **self-throttle to the upstream quota** and shed with **503** — a capacity signal the router treats as retryable in every mode, so it **fails over to another provider** instead of surfacing the error to the user (consistent with the existing global concurrency limiter).

## Design

- **Scope:** single shared bucket, applies to **all users including whitelisted** (the router), because every request counts against the shared upstream quota. Checked *before* per-user limits, *outside* the whitelist gate.
- **RPM:** admission-consume (one token per request).
- **TPM:** same post-consume model as `PerUserTPMLimiter` — read-only `Tokens()>0` admission, actual token count deducted after the response (chunked by burst). Applies to chatbot/speech-to-text only. Burst floored to `context_length`.
- **Rejection:** `503` + `Retry-After`, `ignoreError` set (kept out of error count, recorded as broker-source failure with reason `global_rpm` / `global_tpm`).
- **Off by default:** self-hosted GPU providers are unaffected and keep using concurrency.

## Changes

| File | Change |
|---|---|
| `common/middleware/global_ratelimit.go` | New `GlobalRateLimiter` + `CheckGlobalRPM/TPM` + `ConsumeGlobalTokens` (+ unit tests) |
| `inference/config/config.go` | `MaxGlobalRPM/Burst`, `MaxGlobalTPM/Burst` on `ConcurrencyLimitConfig` |
| `inference/internal/proxy/proxy.go` | Wire limiter; admit before per-user; stash for post-consume |
| `inference/internal/ctrl/chatbot.go`, `speech_to_text.go` | Deduct actual tokens from the global bucket |
| `inference/monitor/server.go` | `global_rpm` / `global_tpm` rejection reasons |
| `config-example-all.yaml` | Document the full `concurrencyLimit` block (was undocumented) |

## Three-layer limit model after this PR

| Limit | Axis | For | On exhaustion |
|---|---|---|---|
| global concurrency | in-flight ≈ GPU capacity | self-hosted GPU | 503 |
| **global RPM/TPM (new)** | per-minute ≈ upstream account quota | upstream-fronting providers | 503 |
| per-user RPM/TPM/IPM | single-user abuse | direct users (router exempt) | 429 |

## Test

- New unit tests: RPM burst→503+Retry-After, TPM post-consume→503, burst chunking, disabled no-op, context helper.
- `go build ./...`, `go test ./...`, `gofmt` all clean. (Pre-existing `make lint` toolchain errors in untouched test files are unrelated.)

## Scope note

Router-side phases (Phase 0 #427 fix, Phase A windowed health bookkeeping) are tracked in 0gfoundation/0g-router#493 and handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
