### PR TITLE
Add reasoning parameter translation for thinking-enabled models

### DIFF
--- a/api/inference/internal/ctrl/proxy.go
+++ b/api/inference/internal/ctrl/proxy.go
@@ -77,6 +77,18 @@ func (c *Ctrl) PrepareHTTPRequest(ctx *gin.Context, targetURL string, reqBody []
 			// Set resolvedModel for unified billing
 			ctx.Set(CtxKeyResolvedModel, c.Service.ModelType)
 		}
+
+		// Reasoning translation: re-express the client's portable reasoning_effort
+		// as the upstream-native thinking control the target model advertises (e.g.
+		// chat_template_kwargs.enable_thinking). No-op unless the model advertises a
+		// native reasoning param. Runs after model handling so the multi-model body
+		// still carries the user's requested model for supportedParameters lookup.
+		// See docs/design/reasoning-translation.md.
+		modifiedBody, err = c.TranslateReasoning(reqBody)
+		if err != nil {
+			return nil, errors.Wrap(err, "translate reasoning")
+		}
+		reqBody = modifiedBody
 	}
 
 	// Multi-model speech-to-text / video-generation: resolve the requested model

--- a/api/inference/internal/ctrl/reasoning.go
+++ b/api/inference/internal/ctrl/reasoning.go
@@ -1,0 +1,177 @@
+package ctrl
+
+// This file implements reasoning-parameter translation: re-expressing a client's
+// portable OpenAI `reasoning_effort` as the upstream-native "thinking" control
+// the target model understands (e.g. Qwen3/vLLM's chat_template_kwargs.
+// enable_thinking). The translation target is picked from the model's advertised
+// supportedParameters; the per-dialect mechanics live in the switch in
+// applyNativeReasoning. See docs/design/reasoning-translation.md.
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/0glabs/0g-serving-broker/common/errors"
+	"github.com/0glabs/0g-serving-broker/inference/config"
+)
+
+// reasoningEffortKey is the portable OpenAI field the broker translates FROM. It
+// is never a translation target — only an input.
+const reasoningEffortKey = "reasoning_effort"
+
+// isNativeReasoningParam reports whether a supportedParameters entry names an
+// upstream-native thinking control the broker can translate to. This set is the
+// counterpart of the switch in applyNativeReasoning: every name here must have a
+// case there, and vice versa.
+func isNativeReasoningParam(name string) bool {
+	switch name {
+	case "enable_thinking":
+		return true
+	default:
+		return false
+	}
+}
+
+// reasoningIntent is the binary thinking on/off decision derived from the
+// client's reasoning_effort. Unset means the client expressed no preference, so
+// the broker emits nothing and the upstream default stands.
+type reasoningIntent int
+
+const (
+	reasoningUnset reasoningIntent = iota
+	reasoningOff
+	reasoningOn
+)
+
+// normalizeReasoningEffort maps an OpenAI reasoning_effort value to a binary
+// intent. Any non-empty effort other than "none"/"minimal" turns thinking on;
+// "none"/"minimal" turn it off; absent leaves it unset.
+func normalizeReasoningEffort(effort string) reasoningIntent {
+	switch strings.ToLower(strings.TrimSpace(effort)) {
+	case "":
+		return reasoningUnset
+	case "none", "minimal":
+		return reasoningOff
+	default:
+		return reasoningOn
+	}
+}
+
+// resolveModelInfo returns the effective ModelInfo for a model: a per-model
+// pricing entry's own ModelInfo wins, otherwise the service-level ModelInfo.
+// Mirrors the resolution used by ModelExpiration and the /v1/models handler.
+func (c *Ctrl) resolveModelInfo(model string) *config.ModelInfo {
+	mi := c.Service.ModelInfo
+	if c.Service.HasMultiModelPricing() {
+		if mp := c.Service.GetModelPricing(model); mp != nil && mp.ModelInfo != nil {
+			mi = mp.ModelInfo
+		}
+	}
+	return mi
+}
+
+// nativeReasoningParam returns the upstream-native thinking control the given
+// model advertises in supportedParameters (e.g. "enable_thinking"), or "" if it
+// advertises none the broker can translate to.
+func (c *Ctrl) nativeReasoningParam(model string) string {
+	mi := c.resolveModelInfo(model)
+	if mi == nil {
+		return ""
+	}
+	for _, p := range mi.SupportedParameters {
+		if isNativeReasoningParam(p) {
+			return p
+		}
+	}
+	return ""
+}
+
+// nativeReasoningParamSet reports whether the client already set the native
+// parameter in its wire location. When true the broker leaves it untouched
+// (explicit native parameter wins over a derived reasoning_effort).
+func nativeReasoningParamSet(bodyMap map[string]interface{}, nativeParam string) bool {
+	switch nativeParam {
+	case "enable_thinking":
+		kw, ok := bodyMap["chat_template_kwargs"].(map[string]interface{})
+		if !ok {
+			return false
+		}
+		_, present := kw["enable_thinking"]
+		return present
+	default:
+		_, present := bodyMap[nativeParam]
+		return present
+	}
+}
+
+// applyNativeReasoning writes the native thinking control for `on` into bodyMap,
+// in the wire location the upstream dialect expects. Each case owns its own value
+// shape (bool here) — there is no shared value/type data. A name handled here
+// must also be recognized by isNativeReasoningParam.
+func applyNativeReasoning(bodyMap map[string]interface{}, nativeParam string, on bool) {
+	switch nativeParam {
+	case "enable_thinking":
+		// Qwen3 on vLLM/SGLang: bool nested under chat_template_kwargs.
+		kw, ok := bodyMap["chat_template_kwargs"].(map[string]interface{})
+		if !ok {
+			kw = map[string]interface{}{}
+			bodyMap["chat_template_kwargs"] = kw
+		}
+		kw["enable_thinking"] = on
+	}
+}
+
+// TranslateReasoning rewrites a chatbot request body so the client's portable
+// reasoning_effort is expressed as the upstream-native thinking control the
+// target model advertises (e.g. chat_template_kwargs.enable_thinking). The model
+// is read from the body itself, so the call needs no extra plumbing.
+//
+// It returns the body unchanged when:
+//   - the body is empty or not a JSON object (mirrors EnsureStreamOptions);
+//   - the resolved model advertises no native reasoning parameter;
+//   - the client already set that native parameter (explicit native wins);
+//   - the client sent no reasoning_effort (intent Unset) — upstream default stands.
+//
+// When translation occurs, reasoning_effort is removed from the outgoing body:
+// it has been consumed and re-expressed natively, and a Qwen/vLLM upstream that
+// needs enable_thinking may reject the unknown OpenAI field.
+func (c *Ctrl) TranslateReasoning(body []byte) ([]byte, error) {
+	if len(body) == 0 {
+		return body, nil
+	}
+
+	var bodyMap map[string]interface{}
+	if err := json.Unmarshal(body, &bodyMap); err != nil {
+		// Non-JSON request: leave as-is, consistent with the other body rewriters.
+		return body, nil
+	}
+
+	model, _ := bodyMap["model"].(string)
+	nativeParam := c.nativeReasoningParam(model)
+	if nativeParam == "" {
+		return body, nil
+	}
+
+	// Explicit native parameter wins: the client addressed the upstream directly,
+	// so forward it untouched and do not derive from reasoning_effort.
+	if nativeReasoningParamSet(bodyMap, nativeParam) {
+		return body, nil
+	}
+
+	effort, _ := bodyMap[reasoningEffortKey].(string)
+	intent := normalizeReasoningEffort(effort)
+	if intent == reasoningUnset {
+		return body, nil
+	}
+
+	applyNativeReasoning(bodyMap, nativeParam, intent == reasoningOn)
+	// reasoning_effort has been re-expressed natively; drop it so a vLLM-style
+	// upstream that only understands the native control doesn't reject it.
+	delete(bodyMap, reasoningEffortKey)
+
+	modified, err := json.Marshal(bodyMap)
+	if err != nil {
+		return body, errors.Wrap(err, "failed to marshal reasoning-translated body")
+	}
+	return modified, nil
+}

--- a/api/inference/internal/ctrl/reasoning.go
+++ b/api/inference/internal/ctrl/reasoning.go
@@ -23,14 +23,26 @@ const reasoningEffortKey = "reasoning_effort"
 // upstream-native thinking control the broker can translate to. This set is the
 // counterpart of the switch in applyNativeReasoning: every name here must have a
 // case there, and vice versa.
+//
+// Note the advertised name is the wire parameter the model accepts, which is not
+// always the toggle key itself: a Qwen3/GLM model advertises the container
+// "chat_template_kwargs" and the thinking toggle lives in its nested
+// "enable_thinking" key (see applyNativeReasoning).
 func isNativeReasoningParam(name string) bool {
 	switch name {
-	case "enable_thinking":
+	case nativeParamChatTemplateKwargs:
 		return true
 	default:
 		return false
 	}
 }
+
+// nativeParamChatTemplateKwargs is the container parameter Qwen3/GLM models on
+// vLLM/SGLang advertise; the thinking toggle is its nested enable_thinking bool.
+const (
+	nativeParamChatTemplateKwargs = "chat_template_kwargs"
+	enableThinkingKey             = "enable_thinking"
+)
 
 // reasoningIntent is the binary thinking on/off decision derived from the
 // client's reasoning_effort. Unset means the client expressed no preference, so
@@ -91,12 +103,12 @@ func (c *Ctrl) nativeReasoningParam(model string) string {
 // (explicit native parameter wins over a derived reasoning_effort).
 func nativeReasoningParamSet(bodyMap map[string]interface{}, nativeParam string) bool {
 	switch nativeParam {
-	case "enable_thinking":
-		kw, ok := bodyMap["chat_template_kwargs"].(map[string]interface{})
+	case nativeParamChatTemplateKwargs:
+		kw, ok := bodyMap[nativeParamChatTemplateKwargs].(map[string]interface{})
 		if !ok {
 			return false
 		}
-		_, present := kw["enable_thinking"]
+		_, present := kw[enableThinkingKey]
 		return present
 	default:
 		_, present := bodyMap[nativeParam]
@@ -105,20 +117,25 @@ func nativeReasoningParamSet(bodyMap map[string]interface{}, nativeParam string)
 }
 
 // applyNativeReasoning writes the native thinking control for `on` into bodyMap,
-// in the wire location the upstream dialect expects. Each case owns its own value
-// shape (bool here) — there is no shared value/type data. A name handled here
-// must also be recognized by isNativeReasoningParam.
-func applyNativeReasoning(bodyMap map[string]interface{}, nativeParam string, on bool) {
+// in the wire location the upstream dialect expects, and reports whether it wrote
+// anything. Each case owns its own value shape (bool here) — there is no shared
+// value/type data. A name handled here must also be recognized by
+// isNativeReasoningParam; the bool return guards TranslateReasoning against
+// dropping reasoning_effort when a recognized-but-unhandled name writes nothing.
+func applyNativeReasoning(bodyMap map[string]interface{}, nativeParam string, on bool) bool {
 	switch nativeParam {
-	case "enable_thinking":
-		// Qwen3 on vLLM/SGLang: bool nested under chat_template_kwargs.
-		kw, ok := bodyMap["chat_template_kwargs"].(map[string]interface{})
+	case nativeParamChatTemplateKwargs:
+		// Qwen3/GLM on vLLM/SGLang: bool nested under chat_template_kwargs.
+		// Preserve any other kwargs the client already set.
+		kw, ok := bodyMap[nativeParamChatTemplateKwargs].(map[string]interface{})
 		if !ok {
 			kw = map[string]interface{}{}
-			bodyMap["chat_template_kwargs"] = kw
+			bodyMap[nativeParamChatTemplateKwargs] = kw
 		}
-		kw["enable_thinking"] = on
+		kw[enableThinkingKey] = on
+		return true
 	}
+	return false
 }
 
 // TranslateReasoning rewrites a chatbot request body so the client's portable
@@ -164,7 +181,12 @@ func (c *Ctrl) TranslateReasoning(body []byte) ([]byte, error) {
 		return body, nil
 	}
 
-	applyNativeReasoning(bodyMap, nativeParam, intent == reasoningOn)
+	if !applyNativeReasoning(bodyMap, nativeParam, intent == reasoningOn) {
+		// Recognized but unhandled (should not happen while detection and the
+		// apply switch stay in sync): write nothing and leave the body untouched
+		// rather than stripping reasoning_effort without a replacement.
+		return body, nil
+	}
 	// reasoning_effort has been re-expressed natively; drop it so a vLLM-style
 	// upstream that only understands the native control doesn't reject it.
 	delete(bodyMap, reasoningEffortKey)

--- a/api/inference/internal/ctrl/reasoning.go
+++ b/api/inference/internal/ctrl/reasoning.go
@@ -25,23 +25,37 @@ const reasoningEffortKey = "reasoning_effort"
 // case there, and vice versa.
 //
 // Note the advertised name is the wire parameter the model accepts, which is not
-// always the toggle key itself: a Qwen3/GLM model advertises the container
-// "chat_template_kwargs" and the thinking toggle lives in its nested
+// always the toggle key itself: a Qwen3/GLM model on vLLM advertises the
+// container "chat_template_kwargs" and the thinking toggle lives in its nested
 // "enable_thinking" key (see applyNativeReasoning).
+//
+// "preserve_thinking" (advertised by DeepSeek/Qwen on DashScope) is deliberately
+// NOT recognized: it is not an on/off toggle but a multi-turn flag that keeps
+// prior turns' reasoning in context. The DashScope thinking toggle is a top-level
+// "enable_thinking" instead.
 func isNativeReasoningParam(name string) bool {
 	switch name {
-	case nativeParamChatTemplateKwargs:
+	case nativeParamChatTemplateKwargs, nativeParamEnableThinking, nativeParamThinking:
 		return true
 	default:
 		return false
 	}
 }
 
-// nativeParamChatTemplateKwargs is the container parameter Qwen3/GLM models on
-// vLLM/SGLang advertise; the thinking toggle is its nested enable_thinking bool.
+// Native thinking-control parameter names the broker can translate reasoning_effort into.
 const (
+	// nativeParamChatTemplateKwargs is the container Qwen3/GLM models on
+	// vLLM/SGLang advertise; the thinking toggle is its nested enable_thinking bool.
 	nativeParamChatTemplateKwargs = "chat_template_kwargs"
-	enableThinkingKey             = "enable_thinking"
+	// nativeParamEnableThinking is the top-level bool DashScope (Aliyun) accepts
+	// as an extra_body key — distinct from the vLLM nested form above.
+	nativeParamEnableThinking = "enable_thinking"
+	// nativeParamThinking is MiniMax's object control: {"type": "enabled"|"disabled"}.
+	nativeParamThinking = "thinking"
+
+	// enableThinkingKey is the toggle key (nested under chat_template_kwargs, or
+	// used top-level for DashScope).
+	enableThinkingKey = "enable_thinking"
 )
 
 // reasoningIntent is the binary thinking on/off decision derived from the
@@ -111,6 +125,7 @@ func nativeReasoningParamSet(bodyMap map[string]interface{}, nativeParam string)
 		_, present := kw[enableThinkingKey]
 		return present
 	default:
+		// Top-level params (enable_thinking, thinking): present iff the key exists.
 		_, present := bodyMap[nativeParam]
 		return present
 	}
@@ -118,8 +133,8 @@ func nativeReasoningParamSet(bodyMap map[string]interface{}, nativeParam string)
 
 // applyNativeReasoning writes the native thinking control for `on` into bodyMap,
 // in the wire location the upstream dialect expects, and reports whether it wrote
-// anything. Each case owns its own value shape (bool here) — there is no shared
-// value/type data. A name handled here must also be recognized by
+// anything. Each case owns its own value shape (bool, or MiniMax's object) — there
+// is no shared value/type data. A name handled here must also be recognized by
 // isNativeReasoningParam; the bool return guards TranslateReasoning against
 // dropping reasoning_effort when a recognized-but-unhandled name writes nothing.
 func applyNativeReasoning(bodyMap map[string]interface{}, nativeParam string, on bool) bool {
@@ -133,6 +148,18 @@ func applyNativeReasoning(bodyMap map[string]interface{}, nativeParam string, on
 			bodyMap[nativeParamChatTemplateKwargs] = kw
 		}
 		kw[enableThinkingKey] = on
+		return true
+	case nativeParamEnableThinking:
+		// DashScope (Aliyun): top-level bool.
+		bodyMap[nativeParamEnableThinking] = on
+		return true
+	case nativeParamThinking:
+		// MiniMax: object {"type": "enabled"|"disabled"}.
+		thinkingType := "disabled"
+		if on {
+			thinkingType = "enabled"
+		}
+		bodyMap[nativeParamThinking] = map[string]interface{}{"type": thinkingType}
 		return true
 	}
 	return false

--- a/api/inference/internal/ctrl/reasoning_test.go
+++ b/api/inference/internal/ctrl/reasoning_test.go
@@ -52,7 +52,7 @@ func TestNativeReasoningParam(t *testing.T) {
 		params []string
 		want   string
 	}{
-		{"detects enable_thinking", []string{"temperature", "reasoning_effort", "enable_thinking"}, "enable_thinking"},
+		{"detects chat_template_kwargs", []string{"temperature", "reasoning_effort", "chat_template_kwargs"}, "chat_template_kwargs"},
 		{"reasoning_effort is not a target", []string{"temperature", "reasoning_effort"}, ""},
 		{"no reasoning params", []string{"temperature", "top_p"}, ""},
 	}
@@ -87,7 +87,7 @@ func decodeEnableThinking(t *testing.T, body []byte) (bool, bool) {
 }
 
 func TestTranslateReasoning_EffortOn(t *testing.T) {
-	c := newTestCtrlForReasoning(t, "reasoning_effort", "enable_thinking")
+	c := newTestCtrlForReasoning(t, "reasoning_effort", "chat_template_kwargs")
 	body := []byte(`{"model":"qwen3","reasoning_effort":"high","messages":[]}`)
 
 	got, err := c.TranslateReasoning(body)
@@ -107,7 +107,7 @@ func TestTranslateReasoning_EffortOn(t *testing.T) {
 }
 
 func TestTranslateReasoning_EffortOff(t *testing.T) {
-	c := newTestCtrlForReasoning(t, "reasoning_effort", "enable_thinking")
+	c := newTestCtrlForReasoning(t, "reasoning_effort", "chat_template_kwargs")
 	body := []byte(`{"model":"qwen3","reasoning_effort":"none","messages":[]}`)
 
 	got, err := c.TranslateReasoning(body)
@@ -121,7 +121,7 @@ func TestTranslateReasoning_EffortOff(t *testing.T) {
 }
 
 func TestTranslateReasoning_Unset(t *testing.T) {
-	c := newTestCtrlForReasoning(t, "reasoning_effort", "enable_thinking")
+	c := newTestCtrlForReasoning(t, "reasoning_effort", "chat_template_kwargs")
 	body := []byte(`{"model":"qwen3","messages":[]}`)
 
 	got, err := c.TranslateReasoning(body)
@@ -134,7 +134,7 @@ func TestTranslateReasoning_Unset(t *testing.T) {
 }
 
 func TestTranslateReasoning_ExplicitNativeWins(t *testing.T) {
-	c := newTestCtrlForReasoning(t, "reasoning_effort", "enable_thinking")
+	c := newTestCtrlForReasoning(t, "reasoning_effort", "chat_template_kwargs")
 	// Client sets enable_thinking=false directly AND a high effort; the explicit
 	// native value must survive and reasoning_effort must not override it.
 	body := []byte(`{"model":"qwen3","reasoning_effort":"high","chat_template_kwargs":{"enable_thinking":false},"messages":[]}`)
@@ -176,7 +176,7 @@ func TestTranslateReasoning_NoNativeParamPassthrough(t *testing.T) {
 }
 
 func TestTranslateReasoning_PreservesExistingChatTemplateKwargs(t *testing.T) {
-	c := newTestCtrlForReasoning(t, "reasoning_effort", "enable_thinking")
+	c := newTestCtrlForReasoning(t, "reasoning_effort", "chat_template_kwargs")
 	body := []byte(`{"model":"qwen3","reasoning_effort":"low","chat_template_kwargs":{"foo":"bar"},"messages":[]}`)
 
 	got, err := c.TranslateReasoning(body)
@@ -197,7 +197,7 @@ func TestTranslateReasoning_PreservesExistingChatTemplateKwargs(t *testing.T) {
 }
 
 func TestTranslateReasoning_NonJSONUnchanged(t *testing.T) {
-	c := newTestCtrlForReasoning(t, "reasoning_effort", "enable_thinking")
+	c := newTestCtrlForReasoning(t, "reasoning_effort", "chat_template_kwargs")
 	body := []byte(`not json`)
 	got, err := c.TranslateReasoning(body)
 	if err != nil {

--- a/api/inference/internal/ctrl/reasoning_test.go
+++ b/api/inference/internal/ctrl/reasoning_test.go
@@ -196,6 +196,67 @@ func TestTranslateReasoning_PreservesExistingChatTemplateKwargs(t *testing.T) {
 	}
 }
 
+func TestNativeReasoningParam_PreserveThinkingNotAToggle(t *testing.T) {
+	// preserve_thinking is a multi-turn context flag, not an on/off toggle, so it
+	// must not be picked as a translation target.
+	c := newTestCtrlForReasoning(t, "temperature", "preserve_thinking")
+	if got := c.nativeReasoningParam("qwen3"); got != "" {
+		t.Errorf("nativeReasoningParam() = %q, want \"\" (preserve_thinking is not a toggle)", got)
+	}
+}
+
+func TestTranslateReasoning_TopLevelEnableThinking(t *testing.T) {
+	// DashScope dialect: top-level enable_thinking bool (not nested).
+	c := newTestCtrlForReasoning(t, "reasoning_effort", "enable_thinking")
+	body := []byte(`{"model":"qwen3","reasoning_effort":"high","messages":[]}`)
+
+	got, err := c.TranslateReasoning(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var out map[string]interface{}
+	if err := json.Unmarshal(got, &out); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if out["enable_thinking"] != true {
+		t.Errorf("top-level enable_thinking = %v, want true", out["enable_thinking"])
+	}
+	if _, ok := out["chat_template_kwargs"]; ok {
+		t.Errorf("top-level dialect must not create chat_template_kwargs")
+	}
+}
+
+func TestTranslateReasoning_MiniMaxThinkingObject(t *testing.T) {
+	c := newTestCtrlForReasoning(t, "reasoning_effort", "thinking", "reasoning_split")
+	tests := []struct {
+		effort   string
+		wantType string
+	}{
+		{"high", "enabled"},
+		{"none", "disabled"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.effort, func(t *testing.T) {
+			body := []byte(`{"model":"MiniMax-M3","reasoning_effort":"` + tt.effort + `","messages":[]}`)
+			got, err := c.TranslateReasoning(body)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			var out map[string]interface{}
+			if err := json.Unmarshal(got, &out); err != nil {
+				t.Fatalf("invalid json: %v", err)
+			}
+			th, ok := out["thinking"].(map[string]interface{})
+			if !ok {
+				t.Fatalf("thinking = %v, want object", out["thinking"])
+			}
+			if th["type"] != tt.wantType {
+				t.Errorf("thinking.type = %v, want %q", th["type"], tt.wantType)
+			}
+		})
+	}
+}
+
 func TestTranslateReasoning_NonJSONUnchanged(t *testing.T) {
 	c := newTestCtrlForReasoning(t, "reasoning_effort", "chat_template_kwargs")
 	body := []byte(`not json`)

--- a/api/inference/internal/ctrl/reasoning_test.go
+++ b/api/inference/internal/ctrl/reasoning_test.go
@@ -24,6 +24,40 @@ func newTestCtrlForReasoning(t *testing.T, supportedParams ...string) *Ctrl {
 	}
 }
 
+// newTestCtrlForReasoningMultiModel builds a multi-model chatbot Ctrl. serviceParams
+// (when non-nil) become the service-level ModelInfo.supportedParameters used as the
+// fallback; entries maps a model id to its per-model supportedParameters — a nil
+// slice means that entry has NO own ModelInfo, so resolution falls back to the
+// service-level ModelInfo. Use "*" as a model id to exercise the wildcard entry.
+func newTestCtrlForReasoningMultiModel(t *testing.T, serviceParams []string, entries map[string][]string) *Ctrl {
+	t.Helper()
+	svc := config.Service{
+		Type:      "chatbot",
+		ModelType: "default-model",
+	}
+	if serviceParams != nil {
+		svc.ModelInfo = &config.ModelInfo{SupportedParameters: serviceParams}
+	}
+	for model, params := range entries {
+		entry := config.ModelPricingEntry{Model: model}
+		if params != nil {
+			entry.ModelInfo = &config.ModelInfo{SupportedParameters: params}
+		}
+		svc.ModelPricing = append(svc.ModelPricing, entry)
+	}
+	if err := svc.BuildModelPricingMap(); err != nil {
+		t.Fatalf("BuildModelPricingMap: %v", err)
+	}
+	if !svc.HasMultiModelPricing() {
+		t.Fatalf("expected multi-model service, got single-model")
+	}
+	return &Ctrl{
+		Service:        svc,
+		logger:         testLogger(),
+		whitelistUsers: make(map[string]struct{}),
+	}
+}
+
 func TestNormalizeReasoningEffort(t *testing.T) {
 	tests := []struct {
 		effort string
@@ -254,6 +288,99 @@ func TestTranslateReasoning_MiniMaxThinkingObject(t *testing.T) {
 				t.Errorf("thinking.type = %v, want %q", th["type"], tt.wantType)
 			}
 		})
+	}
+}
+
+// TestTranslateReasoning_MultiModel_PerModelNativeParam verifies that in a
+// multi-model service each model's own supportedParameters drives translation, so
+// the SAME effort is re-expressed in different dialects depending on the requested
+// model. This is the behavior that depends on the body still carrying the user's
+// requested model (ValidateModelAllowlist preserves it) when TranslateReasoning runs.
+func TestTranslateReasoning_MultiModel_PerModelNativeParam(t *testing.T) {
+	c := newTestCtrlForReasoningMultiModel(t,
+		[]string{"temperature"}, // service-level fallback advertises no native param
+		map[string][]string{
+			"qwen-a":    {"reasoning_effort", "enable_thinking"}, // DashScope top-level bool
+			"minimax-b": {"reasoning_effort", "thinking"},        // MiniMax object
+		},
+	)
+
+	// qwen-a → top-level enable_thinking, no thinking object.
+	gotA, err := c.TranslateReasoning([]byte(`{"model":"qwen-a","reasoning_effort":"high","messages":[]}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var outA map[string]interface{}
+	if err := json.Unmarshal(gotA, &outA); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if outA["enable_thinking"] != true {
+		t.Errorf("qwen-a: enable_thinking = %v, want true", outA["enable_thinking"])
+	}
+	if _, ok := outA["thinking"]; ok {
+		t.Errorf("qwen-a: must not emit MiniMax thinking object")
+	}
+
+	// minimax-b → thinking object, no top-level enable_thinking.
+	gotB, err := c.TranslateReasoning([]byte(`{"model":"minimax-b","reasoning_effort":"high","messages":[]}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var outB map[string]interface{}
+	if err := json.Unmarshal(gotB, &outB); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	th, ok := outB["thinking"].(map[string]interface{})
+	if !ok || th["type"] != "enabled" {
+		t.Errorf("minimax-b: thinking = %v, want {type:enabled}", outB["thinking"])
+	}
+	if _, ok := outB["enable_thinking"]; ok {
+		t.Errorf("minimax-b: must not emit top-level enable_thinking")
+	}
+}
+
+// TestTranslateReasoning_MultiModel_FallbackToServiceModelInfo verifies that a
+// per-model entry without its own ModelInfo falls back to the service-level
+// ModelInfo for the native-param lookup.
+func TestTranslateReasoning_MultiModel_FallbackToServiceModelInfo(t *testing.T) {
+	c := newTestCtrlForReasoningMultiModel(t,
+		[]string{"reasoning_effort", "chat_template_kwargs"}, // service-level fallback
+		map[string][]string{
+			"qwen-a": nil, // no per-model ModelInfo → fall back to service-level
+		},
+	)
+
+	got, err := c.TranslateReasoning([]byte(`{"model":"qwen-a","reasoning_effort":"high","messages":[]}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	on, present := decodeEnableThinking(t, got)
+	if !present || !on {
+		t.Errorf("fallback: chat_template_kwargs.enable_thinking = (%v,%v), want (true,true)", on, present)
+	}
+}
+
+// TestTranslateReasoning_MultiModel_WildcardEntry verifies that a request for a
+// model not enumerated in modelPricing resolves through the wildcard ("*") entry,
+// whose ModelInfo drives the translation.
+func TestTranslateReasoning_MultiModel_WildcardEntry(t *testing.T) {
+	c := newTestCtrlForReasoningMultiModel(t,
+		[]string{"temperature"}, // service-level fallback advertises no native param
+		map[string][]string{
+			"*": {"reasoning_effort", "enable_thinking"},
+		},
+	)
+
+	got, err := c.TranslateReasoning([]byte(`{"model":"some-unlisted-model","reasoning_effort":"high","messages":[]}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var out map[string]interface{}
+	if err := json.Unmarshal(got, &out); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if out["enable_thinking"] != true {
+		t.Errorf("wildcard: enable_thinking = %v, want true", out["enable_thinking"])
 	}
 }
 

--- a/api/inference/internal/ctrl/reasoning_test.go
+++ b/api/inference/internal/ctrl/reasoning_test.go
@@ -1,0 +1,209 @@
+package ctrl
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/0glabs/0g-serving-broker/inference/config"
+)
+
+// newTestCtrlForReasoning builds a single-model chatbot Ctrl whose ModelInfo
+// advertises the given supportedParameters.
+func newTestCtrlForReasoning(t *testing.T, supportedParams ...string) *Ctrl {
+	t.Helper()
+	return &Ctrl{
+		Service: config.Service{
+			Type:      "chatbot",
+			ModelType: "qwen3",
+			ModelInfo: &config.ModelInfo{
+				SupportedParameters: supportedParams,
+			},
+		},
+		logger:         testLogger(),
+		whitelistUsers: make(map[string]struct{}),
+	}
+}
+
+func TestNormalizeReasoningEffort(t *testing.T) {
+	tests := []struct {
+		effort string
+		want   reasoningIntent
+	}{
+		{"", reasoningUnset},
+		{"none", reasoningOff},
+		{"minimal", reasoningOff},
+		{"NONE", reasoningOff},
+		{"  minimal  ", reasoningOff},
+		{"low", reasoningOn},
+		{"medium", reasoningOn},
+		{"high", reasoningOn},
+		{"High", reasoningOn},
+	}
+	for _, tt := range tests {
+		if got := normalizeReasoningEffort(tt.effort); got != tt.want {
+			t.Errorf("normalizeReasoningEffort(%q) = %v, want %v", tt.effort, got, tt.want)
+		}
+	}
+}
+
+func TestNativeReasoningParam(t *testing.T) {
+	tests := []struct {
+		name   string
+		params []string
+		want   string
+	}{
+		{"detects enable_thinking", []string{"temperature", "reasoning_effort", "enable_thinking"}, "enable_thinking"},
+		{"reasoning_effort is not a target", []string{"temperature", "reasoning_effort"}, ""},
+		{"no reasoning params", []string{"temperature", "top_p"}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newTestCtrlForReasoning(t, tt.params...)
+			if got := c.nativeReasoningParam("qwen3"); got != tt.want {
+				t.Errorf("nativeReasoningParam() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// decodeEnableThinking extracts chat_template_kwargs.enable_thinking, returning
+// (value, present).
+func decodeEnableThinking(t *testing.T, body []byte) (bool, bool) {
+	t.Helper()
+	var out map[string]interface{}
+	if err := json.Unmarshal(body, &out); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	kw, ok := out["chat_template_kwargs"].(map[string]interface{})
+	if !ok {
+		return false, false
+	}
+	v, present := kw["enable_thinking"]
+	if !present {
+		return false, false
+	}
+	b, _ := v.(bool)
+	return b, true
+}
+
+func TestTranslateReasoning_EffortOn(t *testing.T) {
+	c := newTestCtrlForReasoning(t, "reasoning_effort", "enable_thinking")
+	body := []byte(`{"model":"qwen3","reasoning_effort":"high","messages":[]}`)
+
+	got, err := c.TranslateReasoning(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	on, present := decodeEnableThinking(t, got)
+	if !present || !on {
+		t.Errorf("enable_thinking = (%v,%v), want (true,true)", on, present)
+	}
+	// reasoning_effort consumed and dropped.
+	var out map[string]interface{}
+	_ = json.Unmarshal(got, &out)
+	if _, ok := out[reasoningEffortKey]; ok {
+		t.Errorf("reasoning_effort should be removed from outgoing body")
+	}
+}
+
+func TestTranslateReasoning_EffortOff(t *testing.T) {
+	c := newTestCtrlForReasoning(t, "reasoning_effort", "enable_thinking")
+	body := []byte(`{"model":"qwen3","reasoning_effort":"none","messages":[]}`)
+
+	got, err := c.TranslateReasoning(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	on, present := decodeEnableThinking(t, got)
+	if !present || on {
+		t.Errorf("enable_thinking = (%v,%v), want (false,true)", on, present)
+	}
+}
+
+func TestTranslateReasoning_Unset(t *testing.T) {
+	c := newTestCtrlForReasoning(t, "reasoning_effort", "enable_thinking")
+	body := []byte(`{"model":"qwen3","messages":[]}`)
+
+	got, err := c.TranslateReasoning(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, present := decodeEnableThinking(t, got); present {
+		t.Errorf("enable_thinking should be absent when no reasoning_effort is sent")
+	}
+}
+
+func TestTranslateReasoning_ExplicitNativeWins(t *testing.T) {
+	c := newTestCtrlForReasoning(t, "reasoning_effort", "enable_thinking")
+	// Client sets enable_thinking=false directly AND a high effort; the explicit
+	// native value must survive and reasoning_effort must not override it.
+	body := []byte(`{"model":"qwen3","reasoning_effort":"high","chat_template_kwargs":{"enable_thinking":false},"messages":[]}`)
+
+	got, err := c.TranslateReasoning(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	on, present := decodeEnableThinking(t, got)
+	if !present || on {
+		t.Errorf("enable_thinking = (%v,%v), want (false,true) — explicit native must win", on, present)
+	}
+	// Body returned untouched, so reasoning_effort is preserved (not consumed).
+	var out map[string]interface{}
+	_ = json.Unmarshal(got, &out)
+	if out[reasoningEffortKey] != "high" {
+		t.Errorf("reasoning_effort should be preserved when native param wins")
+	}
+}
+
+func TestTranslateReasoning_NoNativeParamPassthrough(t *testing.T) {
+	// Model advertises only reasoning_effort (genuine OpenAI surface): no
+	// translation, body unchanged including reasoning_effort.
+	c := newTestCtrlForReasoning(t, "reasoning_effort")
+	body := []byte(`{"model":"qwen3","reasoning_effort":"high","messages":[]}`)
+
+	got, err := c.TranslateReasoning(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, present := decodeEnableThinking(t, got); present {
+		t.Errorf("enable_thinking must not be injected when model advertises no native param")
+	}
+	var out map[string]interface{}
+	_ = json.Unmarshal(got, &out)
+	if out[reasoningEffortKey] != "high" {
+		t.Errorf("reasoning_effort should pass through untouched")
+	}
+}
+
+func TestTranslateReasoning_PreservesExistingChatTemplateKwargs(t *testing.T) {
+	c := newTestCtrlForReasoning(t, "reasoning_effort", "enable_thinking")
+	body := []byte(`{"model":"qwen3","reasoning_effort":"low","chat_template_kwargs":{"foo":"bar"},"messages":[]}`)
+
+	got, err := c.TranslateReasoning(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var out map[string]interface{}
+	if err := json.Unmarshal(got, &out); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	kw, _ := out["chat_template_kwargs"].(map[string]interface{})
+	if kw["foo"] != "bar" {
+		t.Errorf("existing chat_template_kwargs entries must be preserved, got %v", kw)
+	}
+	if kw["enable_thinking"] != true {
+		t.Errorf("enable_thinking = %v, want true", kw["enable_thinking"])
+	}
+}
+
+func TestTranslateReasoning_NonJSONUnchanged(t *testing.T) {
+	c := newTestCtrlForReasoning(t, "reasoning_effort", "enable_thinking")
+	body := []byte(`not json`)
+	got, err := c.TranslateReasoning(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(got) != "not json" {
+		t.Errorf("non-JSON body should be returned unchanged, got %q", got)
+	}
+}

--- a/docs/design/reasoning-translation.md
+++ b/docs/design/reasoning-translation.md
@@ -1,0 +1,149 @@
+# Reasoning Parameter Translation Design
+
+This document describes how the broker translates a client's **reasoning intent**
+(the OpenAI-portable `reasoning_effort`) into whatever native thinking control the
+upstream model actually understands (`enable_thinking`, Anthropic `thinking`,
+OpenRouter `reasoning`, …), and why that translation is driven by an explicit
+per-model table rather than inferred from the advertised `supported_parameters`
+list.
+
+## The problem it solves
+
+Clients want one portable knob. Upstreams expose mutually incompatible ones:
+
+| Upstream / ecosystem | Native control | Value space | Wire placement |
+|----------------------|----------------|-------------|----------------|
+| OpenAI               | `reasoning_effort` | enum: `minimal`/`low`/`medium`/`high` | top-level |
+| Qwen3 on vLLM/SGLang | `enable_thinking`  | bool | **`chat_template_kwargs.enable_thinking`** |
+| Anthropic            | `thinking`         | object `{type, budget_tokens}` | top-level |
+| OpenRouter           | `reasoning`        | object `{effort \| max_tokens}` | top-level |
+
+A request arriving at the broker carries the portable form; the upstream behind a
+given model may need any of the others. The broker is the only place that knows
+which upstream a model maps to, so the translation belongs here.
+
+## Normalized intent
+
+The broker reduces every inbound reasoning signal to a single normalized intent
+before translation:
+
+```
+intent ∈ { On, Off, Unset }
+```
+
+`reasoning_effort` maps to intent with **threshold semantics**:
+
+```
+none, minimal   → Off      (explicitly disable thinking)
+low, medium, high (any other non-empty effort) → On
+absent / ""     → Unset    (do not emit any native control; upstream default stands)
+```
+
+The decision is deliberately coarse — **any effort level except `none`/`minimal`
+turns thinking on**. We do not attempt a faithful effort→budget gradient by default
+(see [Effort gradient](#effort-gradient-optional) for the optional extension). The
+common case is a binary "think or don't," and a bool is the lowest common
+denominator that every listed upstream can satisfy.
+
+`Unset` is distinct from `Off`: when the client says nothing, the broker emits
+**nothing**, leaving the model's own default in force. Only an explicit
+`none`/`minimal` forces an active disable.
+
+## Why not drive off `supported_parameters`
+
+`supported_parameters` (`config.go` `ModelInfo.SupportedParameters`,
+`api/inference/config/config.go:97`) is **static advertisement**, hand-authored by
+the operator and surfaced only on `/v1/models` (`models.go:258`, `models.go:375`).
+Nothing on the request path reads it. It must NOT become the translation driver,
+for three reasons:
+
+1. **A name is not a rule.** The entry is the string `"enable_thinking"` — it does
+   not encode the wire placement (top-level vs `chat_template_kwargs`), the value
+   type (bool vs enum vs int), or the upstream **default state**. The default state
+   is decisive: if a model defaults thinking *on*, honoring an `Off` intent requires
+   actively sending `enable_thinking: false`. Presence of the name alone cannot tell
+   you whether the disable path must act.
+
+2. **Different ecosystems.** `supported_parameters` is OpenRouter's vocabulary (it
+   lists `reasoning`, `include_reasoning`); `enable_thinking` is a Qwen3/vLLM chat
+   template kwarg. The backends that actually consume `enable_thinking` typically do
+   not publish a `supported_parameters` list at all. Advertising it there is the
+   operator hand-bridging two worlds — i.e. config-driven mapping, not detection.
+
+3. **Redundant once the rule exists.** A complete per-parameter rule (placement +
+   type + value + default) already answers "send what, where, when." A
+   list-membership check on top of it is dead weight.
+
+The advertised list and the translation rule therefore stay **separate concerns**:
+the list says what a client *may send*; the table says how the broker *rewrites it*.
+
+## Translation table (per model)
+
+Each model carries an optional reasoning translation rule. Conceptually:
+
+```yaml
+reasoningTranslation:
+  param: enable_thinking          # native parameter name
+  placement: chat_template_kwargs # top_level | chat_template_kwargs | nested
+  type: bool                      # bool | enum | int
+  defaultOn: false                # upstream default; drives whether Off must emit
+```
+
+Resolution per request:
+
+```
+intent = normalize(inbound reasoning signals)
+
+switch intent:
+  Unset → emit nothing
+  On    → emit (param := truthy value)   unless defaultOn already true → emit nothing
+  Off   → emit (param := falsy value)    only if defaultOn true; else emit nothing
+```
+
+The `defaultOn` short-circuits keep the outgoing body minimal: we never send a
+parameter whose value already matches the upstream default.
+
+Models without a `reasoningTranslation` block do not translate — an inbound
+`reasoning_effort` is passed through unchanged (relevant for genuine OpenAI-surface
+upstreams) or dropped per the existing parameter-forwarding policy.
+
+## `/v1/models` advertisement
+
+`supported_parameters` advertises **both** the portable `reasoning_effort` and the
+native `enable_thinking` for models that support thinking. Clients may send either.
+This is intentional: the portable knob is the recommended path, while exposing the
+native name lets advanced clients address the upstream directly.
+
+## Precedence when both are sent
+
+Because both names are advertised, a client may send `reasoning_effort` AND the
+native parameter (e.g. `enable_thinking`) in one request. Rule:
+
+> **An explicitly supplied native parameter wins.** The broker computes the
+> normalized intent from `reasoning_effort` only when the native parameter is
+> absent. If the native parameter is present, it is passed through untouched and
+> the effort value is not translated (to avoid emitting a conflicting duplicate).
+
+This keeps the advanced/explicit path authoritative and prevents the broker from
+writing two contradictory controls into one upstream body.
+
+## Effort gradient (optional)
+
+For upstreams whose native control is numeric (`thinking.budget_tokens`,
+`reasoning.max_tokens`), a future extension may map effort levels to budgets:
+
+```
+low → small budget, medium → mid, high → large
+```
+
+This is out of scope for the initial bool-only translation and is noted here so the
+table schema (`type: int`, plus a `budgets` map) can accommodate it without a
+redesign.
+
+## Open questions
+
+- Whether `none` vs `minimal` should ever differ (today both → `Off`). Some
+  upstreams distinguish "no reasoning" from "minimal reasoning"; the bool model
+  collapses them.
+- Whether to validate an inbound native parameter against the model's declared
+  `supported_parameters` and reject mismatches, or forward leniently.

--- a/docs/design/reasoning-translation.md
+++ b/docs/design/reasoning-translation.md
@@ -10,12 +10,26 @@ translation table.
 ## The problem it solves
 
 Clients want one portable knob. Different upstreams expose different ones for the
-same on/off concept:
+same on/off concept. The dialects actually seen in the model catalog:
 
-| Upstream / ecosystem | Native control     | Wire placement                  |
-|----------------------|--------------------|---------------------------------|
-| OpenAI               | `reasoning_effort` | top-level (no translation needed)|
-| Qwen3 on vLLM/SGLang | `enable_thinking`  | `chat_template_kwargs.enable_thinking` (bool) |
+| Upstream / ecosystem   | Advertised param       | Wire form the broker writes                       |
+|------------------------|------------------------|---------------------------------------------------|
+| OpenAI                 | `reasoning_effort`     | top-level (no translation needed)                 |
+| Qwen3 / GLM on vLLM    | `chat_template_kwargs` | `chat_template_kwargs.enable_thinking` = `bool`   |
+| DeepSeek / Qwen on DashScope | `enable_thinking`| top-level `enable_thinking` = `bool`              |
+| MiniMax                | `thinking`             | `thinking` = `{"type": "enabled"｜"disabled"}`    |
+
+Note the **advertised name is not always the toggle key**: a vLLM model advertises
+the container `chat_template_kwargs` and the toggle lives in its nested
+`enable_thinking`. DashScope uses a *top-level* `enable_thinking` (an `extra_body`
+key) — a different wire location from vLLM's nested one.
+
+**`preserve_thinking` is intentionally NOT a translation target.** DeepSeek/Qwen on
+DashScope advertise it, but it is a *multi-turn* flag that keeps prior turns'
+reasoning in context — not an on/off switch. The DashScope on/off toggle is the
+top-level `enable_thinking` above. Likewise MiniMax's `reasoning_split` only
+controls how reasoning is returned (separate field vs inline `<think>` tags), so
+it is not a target either.
 
 A request reaching the broker carries the portable `reasoning_effort`. The broker
 is the only component that knows which upstream a given model maps to, so the
@@ -60,18 +74,22 @@ that dialect expects:
 
 ```go
 switch nativeParam {
-case "enable_thinking":
-    // Qwen3/vLLM: bool nested under chat_template_kwargs
+case "chat_template_kwargs": // Qwen3/GLM on vLLM: nested bool
     bodyMap["chat_template_kwargs"]["enable_thinking"] = on
-// add a case per ecosystem as upstreams are onboarded
+case "enable_thinking":      // DashScope: top-level bool
+    bodyMap["enable_thinking"] = on
+case "thinking":             // MiniMax: object
+    bodyMap["thinking"] = map[string]any{"type": onOff(on)} // "enabled"｜"disabled"
 }
 ```
 
-The shape of each native control (bool here) lives inline in its `switch` arm — so
-there is no separate `type` / on-value / off-value data to store. A future
-object-shaped control (e.g. an Anthropic-style `{type: "enabled"}`) is simply
-another `case` that builds its own shape; the registry of names to recognize in
-step 1 stays in sync with the `switch` cases by construction (same vocabulary).
+The shape of each native control (bool, or MiniMax's object) lives inline in its
+`switch` arm — so there is no separate `type` / on-value / off-value data to store.
+A new object-shaped control is simply another `case` that builds its own shape; the
+set of names recognized in step 1 stays in sync with the `switch` cases by
+construction (same vocabulary). The apply step returns whether it wrote anything,
+so a recognized-but-unhandled name never causes `reasoning_effort` to be stripped
+without a replacement.
 
 ### Why not a per-model translation table
 

--- a/docs/design/reasoning-translation.md
+++ b/docs/design/reasoning-translation.md
@@ -1,149 +1,119 @@
 # Reasoning Parameter Translation Design
 
-This document describes how the broker translates a client's **reasoning intent**
-(the OpenAI-portable `reasoning_effort`) into whatever native thinking control the
-upstream model actually understands (`enable_thinking`, Anthropic `thinking`,
-OpenRouter `reasoning`, …), and why that translation is driven by an explicit
-per-model table rather than inferred from the advertised `supported_parameters`
-list.
+This document describes how the broker translates a client's **portable reasoning
+intent** — the OpenAI `reasoning_effort` field — into whatever native "thinking"
+control the target model's upstream actually understands (e.g. Qwen3/vLLM's
+`enable_thinking`). The translation is driven by the model's advertised
+`supportedParameters` plus a small in-code `switch`, not by a per-model
+translation table.
 
 ## The problem it solves
 
-Clients want one portable knob. Upstreams expose mutually incompatible ones:
+Clients want one portable knob. Different upstreams expose different ones for the
+same on/off concept:
 
-| Upstream / ecosystem | Native control | Value space | Wire placement |
-|----------------------|----------------|-------------|----------------|
-| OpenAI               | `reasoning_effort` | enum: `minimal`/`low`/`medium`/`high` | top-level |
-| Qwen3 on vLLM/SGLang | `enable_thinking`  | bool | **`chat_template_kwargs.enable_thinking`** |
-| Anthropic            | `thinking`         | object `{type, budget_tokens}` | top-level |
-| OpenRouter           | `reasoning`        | object `{effort \| max_tokens}` | top-level |
+| Upstream / ecosystem | Native control     | Wire placement                  |
+|----------------------|--------------------|---------------------------------|
+| OpenAI               | `reasoning_effort` | top-level (no translation needed)|
+| Qwen3 on vLLM/SGLang | `enable_thinking`  | `chat_template_kwargs.enable_thinking` (bool) |
 
-A request arriving at the broker carries the portable form; the upstream behind a
-given model may need any of the others. The broker is the only place that knows
-which upstream a model maps to, so the translation belongs here.
+A request reaching the broker carries the portable `reasoning_effort`. The broker
+is the only component that knows which upstream a given model maps to, so the
+translation belongs here.
 
-## Normalized intent
+## How it works
 
-The broker reduces every inbound reasoning signal to a single normalized intent
-before translation:
+The mechanism is two pieces — a startup-known set of native parameter names, and a
+request-time `switch` — exactly mirroring how the rest of the request pipeline
+rewrites bodies (`EnsureStreamOptions`, `EnforceConfiguredModel` in
+`internal/ctrl/proxy.go`).
 
-```
-intent ∈ { On, Off, Unset }
-```
+### 1. Which native parameter (driven by `supportedParameters`)
 
-`reasoning_effort` maps to intent with **threshold semantics**:
-
-```
-none, minimal   → Off      (explicitly disable thinking)
-low, medium, high (any other non-empty effort) → On
-absent / ""     → Unset    (do not emit any native control; upstream default stands)
-```
-
-The decision is deliberately coarse — **any effort level except `none`/`minimal`
-turns thinking on**. We do not attempt a faithful effort→budget gradient by default
-(see [Effort gradient](#effort-gradient-optional) for the optional extension). The
-common case is a binary "think or don't," and a bool is the lowest common
-denominator that every listed upstream can satisfy.
-
-`Unset` is distinct from `Off`: when the client says nothing, the broker emits
-**nothing**, leaving the model's own default in force. Only an explicit
-`none`/`minimal` forces an active disable.
-
-## Why not drive off `supported_parameters`
-
-`supported_parameters` (`config.go` `ModelInfo.SupportedParameters`,
-`api/inference/config/config.go:97`) is **static advertisement**, hand-authored by
-the operator and surfaced only on `/v1/models` (`models.go:258`, `models.go:375`).
-Nothing on the request path reads it. It must NOT become the translation driver,
-for three reasons:
-
-1. **A name is not a rule.** The entry is the string `"enable_thinking"` — it does
-   not encode the wire placement (top-level vs `chat_template_kwargs`), the value
-   type (bool vs enum vs int), or the upstream **default state**. The default state
-   is decisive: if a model defaults thinking *on*, honoring an `Off` intent requires
-   actively sending `enable_thinking: false`. Presence of the name alone cannot tell
-   you whether the disable path must act.
-
-2. **Different ecosystems.** `supported_parameters` is OpenRouter's vocabulary (it
-   lists `reasoning`, `include_reasoning`); `enable_thinking` is a Qwen3/vLLM chat
-   template kwarg. The backends that actually consume `enable_thinking` typically do
-   not publish a `supported_parameters` list at all. Advertising it there is the
-   operator hand-bridging two worlds — i.e. config-driven mapping, not detection.
-
-3. **Redundant once the rule exists.** A complete per-parameter rule (placement +
-   type + value + default) already answers "send what, where, when." A
-   list-membership check on top of it is dead weight.
-
-The advertised list and the translation rule therefore stay **separate concerns**:
-the list says what a client *may send*; the table says how the broker *rewrites it*.
-
-## Translation table (per model)
-
-Each model carries an optional reasoning translation rule. Conceptually:
+`ModelInfo.SupportedParameters` (`config/config.go`) is parsed once at startup. A
+model that needs translation advertises **both** the portable `reasoning_effort`
+and its native control, e.g.:
 
 ```yaml
-reasoningTranslation:
-  param: enable_thinking          # native parameter name
-  placement: chat_template_kwargs # top_level | chat_template_kwargs | nested
-  type: bool                      # bool | enum | int
-  defaultOn: false                # upstream default; drives whether Off must emit
+supportedParameters: [temperature, top_p, reasoning_effort, enable_thinking]
 ```
 
-Resolution per request:
+At request time the broker scans the resolved model's `supportedParameters` for a
+name it recognizes as a native thinking control (`enable_thinking`, …) and picks
+that as the translation **target**. `reasoning_effort` is never a target — it is
+the translation *input*. A model that advertises no native control (a genuine
+OpenAI-surface upstream) gets no translation: `reasoning_effort` passes through
+untouched.
+
+### 2. The `switch` (input → output)
+
+The client's `reasoning_effort` is first normalized to a binary intent:
 
 ```
-intent = normalize(inbound reasoning signals)
-
-switch intent:
-  Unset → emit nothing
-  On    → emit (param := truthy value)   unless defaultOn already true → emit nothing
-  Off   → emit (param := falsy value)    only if defaultOn true; else emit nothing
+none, minimal   → Off
+low, medium, high (any other non-empty value) → On
+absent / ""     → Unset  → emit nothing, upstream default stands
 ```
 
-The `defaultOn` short-circuits keep the outgoing body minimal: we never send a
-parameter whose value already matches the upstream default.
+Then a `switch` on the native parameter name writes the value in the wire location
+that dialect expects:
 
-Models without a `reasoningTranslation` block do not translate — an inbound
-`reasoning_effort` is passed through unchanged (relevant for genuine OpenAI-surface
-upstreams) or dropped per the existing parameter-forwarding policy.
+```go
+switch nativeParam {
+case "enable_thinking":
+    // Qwen3/vLLM: bool nested under chat_template_kwargs
+    bodyMap["chat_template_kwargs"]["enable_thinking"] = on
+// add a case per ecosystem as upstreams are onboarded
+}
+```
+
+The shape of each native control (bool here) lives inline in its `switch` arm — so
+there is no separate `type` / on-value / off-value data to store. A future
+object-shaped control (e.g. an Anthropic-style `{type: "enabled"}`) is simply
+another `case` that builds its own shape; the registry of names to recognize in
+step 1 stays in sync with the `switch` cases by construction (same vocabulary).
+
+### Why not a per-model translation table
+
+An earlier draft proposed a per-model `{param, placement, type, on, off}` config
+block. That is redundant with the `switch`: placement/type/values are properties of
+the *named* parameter, not of the model, so they belong in one shared `switch`,
+not duplicated into every model's config. The model only needs to declare *which*
+native name its upstream speaks — which it already does via `supportedParameters`.
+
+## Precedence: explicit native parameter wins
+
+Because `supportedParameters` advertises both names, a client may send
+`reasoning_effort` **and** the native parameter in one request. Rule:
+
+> If the client already set the native parameter (in its wire location), it is
+> left untouched and `reasoning_effort` is not translated. The broker only derives
+> the native value from `reasoning_effort` when the native parameter is absent.
+
+This keeps the explicit/advanced path authoritative and prevents the broker from
+writing two conflicting controls into one upstream body.
+
+When translation does occur, the broker removes `reasoning_effort` from the
+outgoing body: it has been consumed and re-expressed natively, and a Qwen/vLLM
+upstream that needs `enable_thinking` may reject the unknown OpenAI field.
 
 ## `/v1/models` advertisement
 
-`supported_parameters` advertises **both** the portable `reasoning_effort` and the
-native `enable_thinking` for models that support thinking. Clients may send either.
-This is intentional: the portable knob is the recommended path, while exposing the
-native name lets advanced clients address the upstream directly.
+`supportedParameters` advertises **both** `reasoning_effort` (the recommended
+portable knob) and the native name (e.g. `enable_thinking`) for models that
+support thinking. Clients may send either; the precedence rule above resolves the
+both-sent case.
 
-## Precedence when both are sent
+## No per-model default tracking
 
-Because both names are advertised, a client may send `reasoning_effort` AND the
-native parameter (e.g. `enable_thinking`) in one request. Rule:
-
-> **An explicitly supplied native parameter wins.** The broker computes the
-> normalized intent from `reasoning_effort` only when the native parameter is
-> absent. If the native parameter is present, it is passed through untouched and
-> the effort value is not translated (to avoid emitting a conflicting duplicate).
-
-This keeps the advanced/explicit path authoritative and prevents the broker from
-writing two contradictory controls into one upstream body.
-
-## Effort gradient (optional)
-
-For upstreams whose native control is numeric (`thinking.budget_tokens`,
-`reasoning.max_tokens`), a future extension may map effort levels to budgets:
-
-```
-low → small budget, medium → mid, high → large
-```
-
-This is out of scope for the initial bool-only translation and is noted here so the
-table schema (`type: int`, plus a `budgets` map) can accommodate it without a
-redesign.
+The broker does not record whether a model defaults thinking on or off. When the
+client expresses no intent (`Unset`) the broker emits nothing and the upstream's
+own default stands; only an explicit intent causes the broker to write an explicit
+value. This is why no `defaultOn` flag is needed.
 
 ## Open questions
 
-- Whether `none` vs `minimal` should ever differ (today both → `Off`). Some
-  upstreams distinguish "no reasoning" from "minimal reasoning"; the bool model
-  collapses them.
+- Whether `none` vs `minimal` should ever differ (today both → `Off`).
 - Whether to validate an inbound native parameter against the model's declared
-  `supported_parameters` and reject mismatches, or forward leniently.
+  `supportedParameters` and reject mismatches, or forward leniently (today:
+  lenient — an explicit native parameter is forwarded untouched).


### PR DESCRIPTION
## Summary

Implements reasoning parameter translation to convert the portable OpenAI `reasoning_effort` field into upstream-native thinking controls that different model providers understand (e.g., Qwen3/vLLM's `chat_template_kwargs.enable_thinking`, DashScope's top-level `enable_thinking`, MiniMax's `thinking` object).

## Key Changes

- **`reasoning.go`**: Core translation logic that:
  - Normalizes client `reasoning_effort` values to binary on/off intent
  - Detects which native reasoning parameter a model advertises via `supportedParameters`
  - Applies dialect-specific transformations (nested bool, top-level bool, or object shape)
  - Removes `reasoning_effort` from outgoing body after translation to avoid upstream rejection
  - Respects explicit native parameters (client-set native param wins over derived value)

- **`reasoning_test.go`**: Comprehensive test coverage including:
  - Normalization of effort values ("none"/"minimal" → off, "low"/"medium"/"high" → on)
  - Detection of native reasoning parameters across dialects
  - Translation to vLLM's nested `chat_template_kwargs.enable_thinking`
  - Translation to DashScope's top-level `enable_thinking`
  - Translation to MiniMax's `{"type": "enabled"|"disabled"}` object
  - Precedence: explicit native parameter wins over derived `reasoning_effort`
  - Preservation of existing `chat_template_kwargs` entries
  - Pass-through when no native parameter is advertised
  - Non-JSON body handling

- **`proxy.go`**: Integrated `TranslateReasoning()` call into request preparation pipeline after model resolution, ensuring multi-model requests carry the user's requested model for `supportedParameters` lookup

- **`docs/design/reasoning-translation.md`**: Design documentation covering:
  - Problem statement (different upstreams expose different thinking controls)
  - Mechanism (startup-known native parameter names + request-time switch)
  - Precedence rules (explicit native wins)
  - Why not a per-model translation table
  - `/v1/models` advertisement strategy

## Implementation Details

The translation is driven by two pieces that mirror the existing request rewriting pattern (`EnsureStreamOptions`, `EnforceConfiguredModel`):

1. **Native parameter detection** via `isNativeReasoningParam()` — recognizes `chat_template_kwargs`, `enable_thinking`, and `thinking` as valid translation targets
2. **Dialect-specific application** via `applyNativeReasoning()` switch — each native parameter name has a case that writes its value in the wire location the upstream expects

The design intentionally excludes `preserve_thinking` (a multi-turn context flag, not an on/off toggle) and `reasoning_split` (controls output format, not thinking enablement).

When translation occurs, `reasoning_effort` is removed from the outgoing body since it has been consumed and re-expressed natively; upstreams like Qwen/vLLM may reject unknown OpenAI fields.

## TODO (provider config, not code)

- [ ] 5 DashScope models (`deepseek-v4-flash`, `deepseek-v4-pro`, `qwen3.6-plus`, `qwen3.7-max`, `qwen3.7-plus`) currently advertise only `preserve_thinking`, which is **not** a thinking toggle. They need `enable_thinking` added to their `supportedParameters` for `reasoning_effort` translation to take effect. The code path already exists and is tested — this is a provider-side config change only.

## Notes / known edge cases

- If a client sends **both** an explicit native param (e.g. `enable_thinking`) and `reasoning_effort`, the explicit native param wins and the body is forwarded untouched — so `reasoning_effort` lingers in that case. Unusual for a portable OpenAI client; can be changed to strip unconditionally if desired.

https://claude.ai/code/session_01SDJc4Ztaz7kvLgSbtck44p