### PR TITLE
feat(inference): per-entry upstreamModel and modelAliases for multi-model providers (#558)

### DIFF
--- a/api/inference/config/config.go
+++ b/api/inference/config/config.go
@@ -160,12 +160,16 @@ func (m *ModelInfo) Validate(serviceType string) error {
 func (s *Service) ModelExpiration(model string) (time.Time, bool) {
 	mi := s.ModelInfo
 	if s.HasMultiModelPricing() {
-		mp := s.GetModelPricing(model)
-		if mp == nil {
+		// Resolve through the same path as the request allowlist (exact id, then
+		// alias, then wildcard) so a request using a legacy alias is subject to the
+		// SAME expiration gate as the canonical id — GetModelPricing alone would
+		// miss aliases and let an alias bypass a model's 410-expiry.
+		entry, _, ok := s.ResolveRequestedModel(model)
+		if !ok || entry == nil {
 			return time.Time{}, false
 		}
-		if mp.ModelInfo != nil {
-			mi = mp.ModelInfo
+		if entry.ModelInfo != nil {
+			mi = entry.ModelInfo
 		}
 	}
 	if mi != nil && !mi.expiresAt.IsZero() {
@@ -262,6 +266,10 @@ type Service struct {
 
 	// modelPricingMap is a derived lookup map built during config validation.
 	modelPricingMap map[string]*ModelPricingEntry `yaml:"-"`
+	// modelAliasMap is a derived lookup from per-entry ModelAliases to the owning
+	// entry, built alongside modelPricingMap. Lets the multi-model request path
+	// accept a legacy model id and resolve it to its canonical pricing entry.
+	modelAliasMap map[string]*ModelPricingEntry `yaml:"-"`
 }
 
 // IsCentralized returns true if this service routes to a centralized API provider.

--- a/api/inference/config/config_test.go
+++ b/api/inference/config/config_test.go
@@ -478,8 +478,9 @@ service:
 }
 
 func TestLoadConfig_ModelPricing_RejectsModelAliases(t *testing.T) {
-	// modelAliases is a single-model rewrite knob the multi-model path never
-	// consults (it forwards the requested model verbatim). Configuring both must
+	// SERVICE-LEVEL modelAliases is never consulted by the multi-model path
+	// (which resolves per entry); per-model aliases go on the modelPricing entry
+	// instead. Configuring it at the service level alongside modelPricing must
 	// fail at load time rather than silently ignore the aliases.
 	configPath := writeTestConfig(t, `
 service:
@@ -503,9 +504,10 @@ service:
 }
 
 func TestLoadConfig_ModelPricing_RejectsUpstreamModel(t *testing.T) {
-	// upstreamModel rewrites incoming→upstream, which the multi-model path does
-	// not implement (no per-entry upstream rewrite). Configuring both must fail
-	// at load time rather than silently ignore the rewrite.
+	// SERVICE-LEVEL upstreamModel rewrites incoming→upstream for the single-model
+	// path only; the multi-model path rewrites per entry, so per-model upstream
+	// goes on the modelPricing entry instead. Configuring it at the service level
+	// alongside modelPricing must fail at load time rather than be silently ignored.
 	configPath := writeTestConfig(t, `
 service:
   servingUrl: "http://example.com"
@@ -2000,6 +2002,28 @@ func TestService_ModelExpiration(t *testing.T) {
 		}
 	})
 
+	t.Run("multi-model alias is subject to its entry's expiration", func(t *testing.T) {
+		entryMI := validModelInfo()
+		entryMI.ExpirationDate = exp
+		if err := entryMI.Validate("chatbot"); err != nil {
+			t.Fatal(err)
+		}
+		s := &Service{
+			ModelPricing: []ModelPricingEntry{
+				{Model: "expired", ModelInfo: entryMI, ModelAliases: []string{"expired-legacy"}},
+			},
+		}
+		if err := s.BuildModelPricingMap(); err != nil {
+			t.Fatal(err)
+		}
+		// A request using the alias must hit the same expiration as the canonical id,
+		// not silently bypass the 410 gate.
+		got, ok := s.ModelExpiration("expired-legacy")
+		if !ok || !got.Equal(wantTime) {
+			t.Errorf("ModelExpiration(alias) = %v, ok=%v; want %v, true", got, ok, wantTime)
+		}
+	})
+
 	t.Run("multi-model wildcard expiration applies to any served model", func(t *testing.T) {
 		wildMI := validModelInfo()
 		wildMI.ExpirationDate = exp
@@ -2017,4 +2041,320 @@ func TestService_ModelExpiration(t *testing.T) {
 			t.Errorf("ModelExpiration(any-model-name) = %v, ok=%v; want %v, true", got, ok, wantTime)
 		}
 	})
+}
+
+// TestLoadConfig_ModelPricing_PerEntryUpstreamModel exercises the issue-558
+// scenario: one centralized provider serving two models, each advertising a
+// stable public id on-chain while forwarding to a different upstream id, plus a
+// legacy alias accepted on incoming requests.
+func TestLoadConfig_ModelPricing_PerEntryUpstreamModel(t *testing.T) {
+	configPath := writeTestConfig(t, `
+service:
+  servingUrl: "http://example.com"
+  targetUrl: "https://openrouter.ai/api/v1"
+  type: "chatbot"
+  model: "zai-org/GLM-5-FP8"
+  providerType: "centralized"
+  providerIdentity: "openrouter"
+  verifiability: "TeeML"
+  modelPricing:
+    - model: "zai-org/GLM-5-FP8"
+      inputPrice: "100"
+      outputPrice: "300"
+      upstreamModel: "z-ai/glm-5"
+      modelAliases: ["glm-5-legacy"]
+    - model: "deepseek-ai/DeepSeek-V4-Flash"
+      inputPrice: "10"
+      outputPrice: "30"
+      upstreamModel: "deepseek/deepseek-v4-flash"
+`)
+	t.Setenv("CONFIG_FILE", configPath)
+
+	cfg := &Config{}
+	if err := loadConfig(cfg); err != nil {
+		t.Fatalf("loadConfig failed: %v", err)
+	}
+	svc := &cfg.Service
+
+	if got := svc.GetModelPricing("zai-org/GLM-5-FP8"); got == nil || got.UpstreamModel != "z-ai/glm-5" {
+		t.Errorf("expected GLM entry with upstream z-ai/glm-5, got %+v", got)
+	}
+
+	// Exact id, alias, and the unknown id all resolve as expected.
+	cases := []struct {
+		requested    string
+		wantResolved string
+		wantUpstream string
+		wantOK       bool
+	}{
+		{"zai-org/GLM-5-FP8", "zai-org/GLM-5-FP8", "z-ai/glm-5", true},
+		{"glm-5-legacy", "zai-org/GLM-5-FP8", "z-ai/glm-5", true}, // alias → canonical entry
+		{"deepseek-ai/DeepSeek-V4-Flash", "deepseek-ai/DeepSeek-V4-Flash", "deepseek/deepseek-v4-flash", true},
+		{"unknown-model", "unknown-model", "", false},
+		{ModelWildcard, ModelWildcard, "", false},
+	}
+	for _, tc := range cases {
+		entry, resolved, ok := svc.ResolveRequestedModel(tc.requested)
+		if ok != tc.wantOK {
+			t.Errorf("ResolveRequestedModel(%q) ok=%v, want %v", tc.requested, ok, tc.wantOK)
+			continue
+		}
+		if !ok {
+			continue
+		}
+		if resolved != tc.wantResolved {
+			t.Errorf("ResolveRequestedModel(%q) resolved=%q, want %q", tc.requested, resolved, tc.wantResolved)
+		}
+		if entry == nil || entry.UpstreamModelFor() != tc.wantUpstream {
+			t.Errorf("ResolveRequestedModel(%q) upstream=%v, want %q", tc.requested, entry, tc.wantUpstream)
+		}
+	}
+}
+
+func TestLoadConfig_ModelPricing_AliasCollidesWithModelID(t *testing.T) {
+	configPath := writeTestConfig(t, `
+service:
+  servingUrl: "http://example.com"
+  targetUrl: "https://backend:8000"
+  type: "chatbot"
+  model: "model-a"
+  providerType: "centralized"
+  providerIdentity: "openai"
+  verifiability: "TeeML"
+  modelPricing:
+    - model: "model-a"
+      inputPrice: "10"
+      outputPrice: "30"
+    - model: "model-b"
+      inputPrice: "10"
+      outputPrice: "30"
+      modelAliases: ["model-a"]
+`)
+	t.Setenv("CONFIG_FILE", configPath)
+	if err := loadConfig(&Config{}); err == nil || !strings.Contains(err.Error(), "collides with a model id") {
+		t.Fatalf("expected alias/model-id collision error, got: %v", err)
+	}
+}
+
+func TestLoadConfig_ModelPricing_DuplicateAliasAcrossEntries(t *testing.T) {
+	configPath := writeTestConfig(t, `
+service:
+  servingUrl: "http://example.com"
+  targetUrl: "https://backend:8000"
+  type: "chatbot"
+  model: "model-a"
+  providerType: "centralized"
+  providerIdentity: "openai"
+  verifiability: "TeeML"
+  modelPricing:
+    - model: "model-a"
+      inputPrice: "10"
+      outputPrice: "30"
+      modelAliases: ["legacy"]
+    - model: "model-b"
+      inputPrice: "10"
+      outputPrice: "30"
+      modelAliases: ["legacy"]
+`)
+	t.Setenv("CONFIG_FILE", configPath)
+	if err := loadConfig(&Config{}); err == nil || !strings.Contains(err.Error(), "duplicate modelPricing alias") {
+		t.Fatalf("expected duplicate-alias error, got: %v", err)
+	}
+}
+
+func TestLoadConfig_ModelPricing_WildcardAliasRejected(t *testing.T) {
+	configPath := writeTestConfig(t, `
+service:
+  servingUrl: "http://example.com"
+  targetUrl: "https://backend:8000"
+  type: "chatbot"
+  model: "model-a"
+  providerType: "centralized"
+  providerIdentity: "openai"
+  verifiability: "TeeML"
+  modelPricing:
+    - model: "model-a"
+      inputPrice: "10"
+      outputPrice: "30"
+      modelAliases: ["*"]
+`)
+	t.Setenv("CONFIG_FILE", configPath)
+	if err := loadConfig(&Config{}); err == nil || !strings.Contains(err.Error(), "wildcard") {
+		t.Fatalf("expected wildcard-alias error, got: %v", err)
+	}
+}
+
+func TestLoadConfig_ModelPricing_UpstreamCollidesWithModelID(t *testing.T) {
+	// upstreamModel pointing at another entry's PUBLIC id would forward a request
+	// for model-b under model-a's public name — reject the ambiguity at load.
+	configPath := writeTestConfig(t, `
+service:
+  servingUrl: "http://example.com"
+  targetUrl: "https://backend:8000"
+  type: "chatbot"
+  model: "model-a"
+  providerType: "centralized"
+  providerIdentity: "openai"
+  verifiability: "TeeML"
+  modelPricing:
+    - model: "model-a"
+      inputPrice: "10"
+      outputPrice: "30"
+    - model: "model-b"
+      inputPrice: "500"
+      outputPrice: "1500"
+      upstreamModel: "model-a"
+`)
+	t.Setenv("CONFIG_FILE", configPath)
+	if err := loadConfig(&Config{}); err == nil || !strings.Contains(err.Error(), "wrong public id") {
+		t.Fatalf("expected upstreamModel/public-id collision error, got: %v", err)
+	}
+}
+
+func TestLoadConfig_ModelPricing_UpstreamCollidesWithAlias(t *testing.T) {
+	configPath := writeTestConfig(t, `
+service:
+  servingUrl: "http://example.com"
+  targetUrl: "https://backend:8000"
+  type: "chatbot"
+  model: "model-a"
+  providerType: "centralized"
+  providerIdentity: "openai"
+  verifiability: "TeeML"
+  modelPricing:
+    - model: "model-a"
+      inputPrice: "10"
+      outputPrice: "30"
+      modelAliases: ["legacy-a"]
+    - model: "model-b"
+      inputPrice: "10"
+      outputPrice: "30"
+      upstreamModel: "legacy-a"
+`)
+	t.Setenv("CONFIG_FILE", configPath)
+	if err := loadConfig(&Config{}); err == nil || !strings.Contains(err.Error(), "collides with a configured model alias") {
+		t.Fatalf("expected upstreamModel/alias collision error, got: %v", err)
+	}
+}
+
+func TestLoadConfig_ModelPricing_UpstreamWildcardValueRejected(t *testing.T) {
+	configPath := writeTestConfig(t, `
+service:
+  servingUrl: "http://example.com"
+  targetUrl: "https://backend:8000"
+  type: "chatbot"
+  model: "model-a"
+  providerType: "centralized"
+  providerIdentity: "openai"
+  verifiability: "TeeML"
+  modelPricing:
+    - model: "model-a"
+      inputPrice: "10"
+      outputPrice: "30"
+      upstreamModel: "*"
+`)
+	t.Setenv("CONFIG_FILE", configPath)
+	if err := loadConfig(&Config{}); err == nil || !strings.Contains(err.Error(), "wildcard sentinel") {
+		t.Fatalf("expected upstreamModel='*' rejection, got: %v", err)
+	}
+}
+
+func TestLoadConfig_ModelPricing_UpstreamOnWildcardEntryRejected(t *testing.T) {
+	configPath := writeTestConfig(t, `
+service:
+  servingUrl: "http://example.com"
+  targetUrl: "https://backend:8000"
+  type: "chatbot"
+  model: "model-a"
+  providerType: "centralized"
+  providerIdentity: "openai"
+  verifiability: "TeeML"
+  modelPricing:
+    - model: "model-a"
+      inputPrice: "10"
+      outputPrice: "30"
+    - model: "*"
+      inputPrice: "20"
+      outputPrice: "60"
+      upstreamModel: "vendor/catchall"
+`)
+	t.Setenv("CONFIG_FILE", configPath)
+	if err := loadConfig(&Config{}); err == nil || !strings.Contains(err.Error(), "not supported on the wildcard") {
+		t.Fatalf("expected upstreamModel-on-wildcard rejection, got: %v", err)
+	}
+}
+
+func TestLoadConfig_ModelPricing_AliasWhitespaceRejected(t *testing.T) {
+	configPath := writeTestConfig(t, `
+service:
+  servingUrl: "http://example.com"
+  targetUrl: "https://backend:8000"
+  type: "chatbot"
+  model: "model-a"
+  providerType: "centralized"
+  providerIdentity: "openai"
+  verifiability: "TeeML"
+  modelPricing:
+    - model: "model-a"
+      inputPrice: "10"
+      outputPrice: "30"
+      modelAliases: [" legacy-a "]
+`)
+	t.Setenv("CONFIG_FILE", configPath)
+	if err := loadConfig(&Config{}); err == nil || !strings.Contains(err.Error(), "leading/trailing whitespace") {
+		t.Fatalf("expected alias-whitespace rejection, got: %v", err)
+	}
+}
+
+func TestLoadConfig_ModelPricing_SharedUpstreamAllowed(t *testing.T) {
+	// Two public ids deliberately mapping to one upstream model is allowed (warned,
+	// not rejected) — e.g. a price-tier rename during a cutover.
+	configPath := writeTestConfig(t, `
+service:
+  servingUrl: "http://example.com"
+  targetUrl: "https://backend:8000"
+  type: "chatbot"
+  model: "public-new"
+  providerType: "centralized"
+  providerIdentity: "openai"
+  verifiability: "TeeML"
+  modelPricing:
+    - model: "public-new"
+      inputPrice: "10"
+      outputPrice: "30"
+      upstreamModel: "vendor/x"
+    - model: "public-old"
+      inputPrice: "10"
+      outputPrice: "30"
+      upstreamModel: "vendor/x"
+`)
+	t.Setenv("CONFIG_FILE", configPath)
+	if err := loadConfig(&Config{}); err != nil {
+		t.Fatalf("shared upstreamModel should be allowed, got: %v", err)
+	}
+}
+
+func TestLoadConfig_ModelPricing_PerEntryUpstreamRejectedForSpeechToText(t *testing.T) {
+	// The per-entry upstream rewrite runs only on the chatbot JSON path; allowing
+	// it on speech-to-text (multipart, no body rewrite) would silently forward the
+	// wrong id, so it must be rejected at load.
+	configPath := writeTestConfig(t, `
+service:
+  servingUrl: "http://example.com"
+  targetUrl: "https://backend:8000"
+  type: "speech-to-text"
+  model: "whisper-1"
+  providerType: "centralized"
+  providerIdentity: "openai"
+  verifiability: "TeeML"
+  modelPricing:
+    - model: "whisper-1"
+      inputPrice: "10"
+      outputPrice: "30"
+      upstreamModel: "openai/whisper-1"
+`)
+	t.Setenv("CONFIG_FILE", configPath)
+	if err := loadConfig(&Config{}); err == nil || !strings.Contains(err.Error(), "upstreamModel is only supported") {
+		t.Fatalf("expected per-entry upstreamModel rejection for speech-to-text, got: %v", err)
+	}
 }

--- a/api/inference/config/model_pricing.go
+++ b/api/inference/config/model_pricing.go
@@ -58,6 +58,27 @@ type ModelPricingEntry struct {
 	// validation as TieredPricingConfig.Tiers.
 	Tiers []PricingTier `yaml:"tiers"`
 
+	// UpstreamModel, when set, is the model id sent to the upstream targetUrl for
+	// this entry; Model stays the id advertised on-chain and accepted on incoming
+	// requests. It is the per-model counterpart of service.UpstreamModel (which is
+	// rejected alongside modelPricing): a multi-model centralized provider can
+	// expose a stable public id (e.g. "zai-org/GLM-5-FP8") while forwarding to an
+	// upstream that uses a different id (e.g. OpenRouter's "z-ai/glm-5"). Empty
+	// means "forward Model as-is". Only supported for chatbot services (the JSON
+	// request path is the only one that rewrites the body before forwarding).
+	UpstreamModel string `yaml:"upstreamModel"`
+
+	// ModelAliases are additional legacy model ids accepted on incoming requests
+	// and resolved to this entry (billed at this entry's price, forwarded as
+	// UpstreamModel/Model). The per-model counterpart of service.ModelAliases: it
+	// lets an operator rename the advertised Model without breaking clients still
+	// sending the old id. Aliases must be globally unique across all entries' Model
+	// ids and aliases, and must not be the "*" wildcard. Only supported for chatbot
+	// services. NOTE: aliases are accepted but NOT advertised in GET /v1/models
+	// (only Model/CanonicalID are) — they exist for backward-compatible renames,
+	// not as separately discoverable model names.
+	ModelAliases []string `yaml:"modelAliases"`
+
 	// CanonicalID is the bare-lowercase canonical model id this model maps to in
 	// the router catalog (same contract as Service.CanonicalID, but per-model so
 	// a multi-model provider can map each served model to its own canonical).
@@ -355,8 +376,71 @@ func (s *Service) BuildModelPricingMap() error {
 		}
 		m[entry.Model] = entry
 	}
+	// Build the alias index after every model id is known, so an alias can be
+	// checked against the full model-id set. An alias colliding with a model id
+	// or another alias is rejected: resolution would otherwise depend on lookup
+	// order and could bill/forward the wrong model.
+	aliases := make(map[string]*ModelPricingEntry)
+	for i := range s.ModelPricing {
+		entry := &s.ModelPricing[i]
+		for _, alias := range entry.ModelAliases {
+			if alias == ModelWildcard {
+				return fmt.Errorf("modelPricing alias %q is the reserved wildcard sentinel", alias)
+			}
+			if _, ok := m[alias]; ok {
+				return fmt.Errorf("modelPricing alias %q collides with a model id", alias)
+			}
+			if _, ok := aliases[alias]; ok {
+				return fmt.Errorf("duplicate modelPricing alias %q", alias)
+			}
+			aliases[alias] = entry
+		}
+	}
 	s.modelPricingMap = m
+	s.modelAliasMap = aliases
 	return nil
+}
+
+// ResolveRequestedModel maps a client-supplied model id to its pricing entry.
+// Resolution order: exact Model id, then a configured alias, then the wildcard
+// ("*") catch-all. It returns the matched entry, the canonical model id to
+// record for billing and metrics (entry.Model for an exact/alias match; the
+// requested id for a wildcard match so wildcard attribution is preserved), and
+// whether the model is allowed.
+//
+// When multi-model pricing is not configured the service serves a single model;
+// the request id is allowed as-is and returned unchanged (entry nil).
+func (s *Service) ResolveRequestedModel(requested string) (entry *ModelPricingEntry, resolved string, ok bool) {
+	if !s.HasMultiModelPricing() {
+		return nil, requested, true
+	}
+	// "*" is a pricing sentinel, never a selectable model — a literal request for
+	// it would hit the wildcard entry and be forwarded verbatim upstream.
+	if requested == ModelWildcard {
+		return nil, requested, false
+	}
+	if e, hit := s.modelPricingMap[requested]; hit {
+		return e, e.Model, true
+	}
+	if e, hit := s.modelAliasMap[requested]; hit {
+		return e, e.Model, true
+	}
+	if e, hit := s.modelPricingMap[ModelWildcard]; hit {
+		return e, requested, true
+	}
+	return nil, requested, false
+}
+
+// UpstreamModelFor returns the model id to forward upstream for an already
+// resolved entry: the entry's UpstreamModel when set, otherwise its Model. The
+// wildcard catch-all has no concrete id, so callers must forward the requested
+// id verbatim for it (entry.Model == "*"); this returns "*" for that case and
+// the caller is expected to skip the rewrite.
+func (e *ModelPricingEntry) UpstreamModelFor() string {
+	if e.UpstreamModel != "" {
+		return e.UpstreamModel
+	}
+	return e.Model
 }
 
 // HasWildcardModel reports whether a catch-all ("*") pricing entry is configured.
@@ -567,14 +651,15 @@ func validateModelPricing(cfg *Config) error {
 	if svc.ModelType == "" {
 		return fmt.Errorf("invalid config: service.model is required when service.modelPricing is configured")
 	}
-	// The multi-model request path forwards the requested model verbatim and never
-	// consults the single-model rewrite knobs, so a config that sets either
-	// alongside modelPricing would have it silently ignored — reject at load time.
+	// The multi-model request path resolves and rewrites per ENTRY, never via the
+	// single-model service-level knobs, so a config that sets either alongside
+	// modelPricing would have it silently ignored — reject at load time and point
+	// the operator at the per-entry fields instead.
 	if len(svc.ModelAliases) > 0 {
-		return fmt.Errorf("invalid config: service.modelAliases is not supported with service.modelPricing (the multi-model path forwards the requested model verbatim; per-model aliasing is the router's canonical-mapping job)")
+		return fmt.Errorf("invalid config: service.modelAliases is not supported with service.modelPricing (set modelAliases on the individual service.modelPricing entry instead)")
 	}
 	if svc.UpstreamModel != "" {
-		return fmt.Errorf("invalid config: service.upstreamModel is not supported with service.modelPricing (the multi-model path forwards the requested model verbatim; per-model upstream rewrite is not implemented)")
+		return fmt.Errorf("invalid config: service.upstreamModel is not supported with service.modelPricing (set upstreamModel on the individual service.modelPricing entry instead)")
 	}
 
 	isUSD := svc.IsUSDDenominated()
@@ -603,6 +688,32 @@ func validateModelPricing(cfg *Config) error {
 	// MaxModelPrices* helpers rely on.
 	if err := svc.BuildModelPricingMap(); err != nil {
 		return fmt.Errorf("invalid config: %w", err)
+	}
+	// A per-entry upstreamModel must not be ambiguous with the public allowlist.
+	// If it equals ANOTHER entry's public Model id (or a configured alias), a
+	// request for that entry would be forwarded under a different entry's public
+	// name — confusing mis-routing the operator never intended. (Equaling its OWN
+	// Model id is a harmless no-op.) Two entries deliberately sharing one
+	// upstreamModel is allowed but warned: it collapses two priced public ids onto
+	// a single upstream model, so the client picks the price purely by public id.
+	upstreamOwners := make(map[string]string, len(svc.ModelPricing))
+	for i := range svc.ModelPricing {
+		entry := &svc.ModelPricing[i]
+		up := entry.UpstreamModel
+		if up == "" {
+			continue
+		}
+		if other, ok := svc.modelPricingMap[up]; ok && other != entry {
+			return fmt.Errorf("invalid config: service.modelPricing[%d].upstreamModel %q collides with the public model id of another entry; a request would be forwarded under the wrong public id", i, up)
+		}
+		if _, ok := svc.modelAliasMap[up]; ok {
+			return fmt.Errorf("invalid config: service.modelPricing[%d].upstreamModel %q collides with a configured model alias", i, up)
+		}
+		if prev, dup := upstreamOwners[up]; dup {
+			log.Printf("[CONFIG] service.modelPricing entries %q and %q share upstreamModel %q: two priced public ids map to one upstream model — ensure this is intentional (clients select the price by public id).", prev, entry.Model, up)
+		} else {
+			upstreamOwners[up] = entry.Model
+		}
 	}
 	// service.model is forwarded upstream verbatim for model-less requests, so it
 	// must be a concrete id — never the "*" pricing sentinel.
@@ -650,6 +761,46 @@ func validateModelPricingEntry(i int, entry *ModelPricingEntry, serviceType stri
 		}
 	}
 
+	// Per-entry upstream rewrite / aliasing is wired only on the chatbot JSON
+	// request path (ValidateModelAllowlist rewrites the body before forwarding).
+	// On other modalities the body is not rewritten, so an upstreamModel/alias
+	// would silently forward the wrong id — reject at load rather than mis-route.
+	if serviceType != constant.ServiceTypeChatbot {
+		if entry.UpstreamModel != "" {
+			return fmt.Errorf("invalid config: service.modelPricing[%d].upstreamModel is only supported for service type '%s' (the body rewrite runs only on the JSON chatbot path), got '%s' for model '%s'", i, constant.ServiceTypeChatbot, serviceType, entry.Model)
+		}
+		if len(entry.ModelAliases) > 0 {
+			return fmt.Errorf("invalid config: service.modelPricing[%d].modelAliases is only supported for service type '%s', got '%s' for model '%s'", i, constant.ServiceTypeChatbot, serviceType, entry.Model)
+		}
+	}
+	// The wildcard catch-all has no concrete id to rewrite to — ValidateModelAllowlist
+	// forwards a wildcard-served model verbatim — so an upstreamModel on the "*"
+	// entry would be silently dropped at runtime. Reject it rather than mislead.
+	if entry.Model == ModelWildcard && entry.UpstreamModel != "" {
+		return fmt.Errorf("invalid config: service.modelPricing[%d].upstreamModel is not supported on the wildcard ('%s') entry (the catch-all forwards the requested id verbatim)", i, ModelWildcard)
+	}
+	if entry.UpstreamModel != "" {
+		// The forwarded id must be a concrete, unpadded model id: "*" would forward
+		// the literal sentinel upstream, and surrounding whitespace would forward an
+		// id no upstream recognizes.
+		if entry.UpstreamModel == ModelWildcard {
+			return fmt.Errorf("invalid config: service.modelPricing[%d].upstreamModel must be a concrete model id, not the '%s' wildcard sentinel (model '%s')", i, ModelWildcard, entry.Model)
+		}
+		if strings.TrimSpace(entry.UpstreamModel) != entry.UpstreamModel {
+			return fmt.Errorf("invalid config: service.modelPricing[%d].upstreamModel %q must not have leading/trailing whitespace (model '%s')", i, entry.UpstreamModel, entry.Model)
+		}
+	}
+	for _, alias := range entry.ModelAliases {
+		if strings.TrimSpace(alias) == "" {
+			return fmt.Errorf("invalid config: service.modelPricing[%d].modelAliases must not contain an empty id (model '%s')", i, entry.Model)
+		}
+		// Aliases are indexed and matched verbatim, so a padded alias (" glm-5 ")
+		// would pass this check yet never match a client's "glm-5" — reject the
+		// silent-no-match trap at load.
+		if strings.TrimSpace(alias) != alias {
+			return fmt.Errorf("invalid config: service.modelPricing[%d].modelAliases entry %q must not have leading/trailing whitespace (model '%s')", i, alias, entry.Model)
+		}
+	}
 	if entry.CanonicalID != "" && !validCanonicalID.MatchString(entry.CanonicalID) {
 		return fmt.Errorf("invalid config: service.modelPricing[%d].canonicalId %q must be bare lowercase (letters, digits, '-', '.') for model '%s'", i, entry.CanonicalID, entry.Model)
 	}

--- a/api/inference/internal/ctrl/model_rewrite_test.go
+++ b/api/inference/internal/ctrl/model_rewrite_test.go
@@ -1,0 +1,119 @@
+package ctrl
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/0glabs/0g-serving-broker/inference/config"
+)
+
+// TestValidateModelAllowlist_PerEntryUpstreamRewrite covers the issue-558 path:
+// a multi-model centralized provider rewrites the request body's `model` to the
+// matched entry's upstream id before forwarding, while billing/metrics stay
+// keyed on the public id (resolvedModel). Aliases resolve to their canonical
+// entry; an entry without upstreamModel forwards its own id; unknown models are
+// rejected.
+func TestValidateModelAllowlist_PerEntryUpstreamRewrite(t *testing.T) {
+	svc := newMultiModelService(t, "NATIVE", []config.ModelPricingEntry{
+		{
+			Model:         "zai-org/GLM-5-FP8",
+			InputPrice:    "100",
+			OutputPrice:   "300",
+			UpstreamModel: "z-ai/glm-5",
+			ModelAliases:  []string{"glm-5-legacy"},
+		},
+		{
+			Model:         "deepseek-ai/DeepSeek-V4-Flash",
+			InputPrice:    "10",
+			OutputPrice:   "30",
+			UpstreamModel: "deepseek/deepseek-v4-flash",
+		},
+		{
+			Model:       "plain-model",
+			InputPrice:  "10",
+			OutputPrice: "30",
+		},
+	}, "zai-org/GLM-5-FP8")
+
+	cases := []struct {
+		name          string
+		requestModel  string // "" means omit the model field entirely
+		wantForwarded string
+		wantResolved  string
+		wantErr       bool
+	}{
+		{"public id rewritten to upstream", "zai-org/GLM-5-FP8", "z-ai/glm-5", "zai-org/GLM-5-FP8", false},
+		{"alias resolves to canonical entry", "glm-5-legacy", "z-ai/glm-5", "zai-org/GLM-5-FP8", false},
+		{"second model rewritten", "deepseek-ai/DeepSeek-V4-Flash", "deepseek/deepseek-v4-flash", "deepseek-ai/DeepSeek-V4-Flash", false},
+		{"no upstream forwards own id", "plain-model", "plain-model", "plain-model", false},
+		{"omitted model uses default and rewrites", "", "z-ai/glm-5", "zai-org/GLM-5-FP8", false},
+		{"unknown model rejected", "nope/not-served", "", "", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &Ctrl{logger: testLogger(), Service: svc}
+			ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+
+			var body []byte
+			if tc.requestModel == "" {
+				body = []byte(`{"messages":[]}`)
+			} else {
+				body = []byte(`{"model":"` + tc.requestModel + `","messages":[]}`)
+			}
+
+			out, err := c.ValidateModelAllowlist(ctx, body, "0xuser")
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected rejection for %q, got nil", tc.requestModel)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ValidateModelAllowlist(%q): %v", tc.requestModel, err)
+			}
+
+			var m map[string]interface{}
+			if err := json.Unmarshal(out, &m); err != nil {
+				t.Fatalf("unmarshal forwarded body: %v", err)
+			}
+			if got, _ := m["model"].(string); got != tc.wantForwarded {
+				t.Errorf("forwarded model = %q, want %q", got, tc.wantForwarded)
+			}
+			resolved, _ := ctx.Get(CtxKeyResolvedModel)
+			if resolved != tc.wantResolved {
+				t.Errorf("resolvedModel = %v, want %q", resolved, tc.wantResolved)
+			}
+		})
+	}
+}
+
+// TestValidateModelAllowlist_WildcardForwardsVerbatim verifies that a wildcard
+// catch-all entry (no concrete upstream id) forwards the requested model
+// unchanged and records it as the resolved model for wildcard attribution.
+func TestValidateModelAllowlist_WildcardForwardsVerbatim(t *testing.T) {
+	svc := newMultiModelService(t, "NATIVE", []config.ModelPricingEntry{
+		{Model: config.ModelWildcard, InputPrice: "200", OutputPrice: "600"},
+	}, "default-model")
+
+	c := &Ctrl{logger: testLogger(), Service: svc}
+	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+
+	out, err := c.ValidateModelAllowlist(ctx, []byte(`{"model":"some/unlisted-model","messages":[]}`), "0xuser")
+	if err != nil {
+		t.Fatalf("ValidateModelAllowlist: %v", err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got, _ := m["model"].(string); got != "some/unlisted-model" {
+		t.Errorf("wildcard forwarded model = %q, want verbatim some/unlisted-model", got)
+	}
+	if resolved, _ := ctx.Get(CtxKeyResolvedModel); resolved != "some/unlisted-model" {
+		t.Errorf("resolvedModel = %v, want some/unlisted-model", resolved)
+	}
+}

--- a/api/inference/internal/ctrl/proxy.go
+++ b/api/inference/internal/ctrl/proxy.go
@@ -949,9 +949,29 @@ func (c *Ctrl) ValidateModelAllowlist(ctx *gin.Context, body []byte, userAddr st
 
 	requestModel, _ := bodyMap["model"].(string)
 	if requestModel == "" {
-		// No model specified — use the configured ModelType as default
+		// No model specified — bill and forward the configured default model.
 		requestModel = c.Service.ModelType
-		bodyMap["model"] = requestModel
+	}
+
+	entry, resolved, ok := c.Service.ResolveRequestedModel(requestModel)
+	if !ok {
+		c.recordModelMismatch(userAddr, requestModel)
+		return nil, fmt.Errorf("model not supported: '%s' is not available for this service", requestModel)
+	}
+
+	// Forward the entry's upstream id (UpstreamModel when set, else its Model) so
+	// the request reaches the upstream under the id it expects, while billing and
+	// metrics stay keyed on the resolved public id. The wildcard catch-all has no
+	// concrete id, so a wildcard-served model is forwarded verbatim.
+	forwardModel := requestModel
+	if entry != nil && entry.Model != config.ModelWildcard {
+		forwardModel = entry.UpstreamModelFor()
+	} else if entry != nil {
+		c.logger.Debugf("Model served via wildcard catch-all pricing: requested=%s", requestModel)
+	}
+
+	if cur, _ := bodyMap["model"].(string); cur != forwardModel {
+		bodyMap["model"] = forwardModel
 		modifiedBody, err := json.Marshal(bodyMap)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to marshal modified JSON body")
@@ -959,12 +979,8 @@ func (c *Ctrl) ValidateModelAllowlist(ctx *gin.Context, body []byte, userAddr st
 		body = modifiedBody
 	}
 
-	if err := c.checkModelAllowed(ctx, requestModel, userAddr); err != nil {
-		return nil, err
-	}
-
-	ctx.Set(CtxKeyResolvedModel, requestModel)
-	c.logger.Debugf("Model allowlist passed: requested=%s", requestModel)
+	ctx.Set(CtxKeyResolvedModel, resolved)
+	c.logger.Debugf("Model allowlist passed: requested=%s resolved=%s forwarded=%s", requestModel, resolved, forwardModel)
 	return body, nil
 }
 
@@ -979,34 +995,21 @@ func (c *Ctrl) ResolveModelForBilling(ctx *gin.Context, body []byte, contentType
 	if requestModel == "" {
 		requestModel = c.Service.ModelType
 	}
-	if err := c.checkModelAllowed(ctx, requestModel, userAddr); err != nil {
-		return err
+	_, resolved, ok := c.Service.ResolveRequestedModel(requestModel)
+	if !ok {
+		c.recordModelMismatch(userAddr, requestModel)
+		return fmt.Errorf("model not supported: '%s' is not available for this service", requestModel)
 	}
-	ctx.Set(CtxKeyResolvedModel, requestModel)
-	c.logger.Debugf("Model allowlist passed (billing-only): requested=%s", requestModel)
+	ctx.Set(CtxKeyResolvedModel, resolved)
+	c.logger.Debugf("Model allowlist passed (billing-only): requested=%s resolved=%s", requestModel, resolved)
 	return nil
 }
 
-// checkModelAllowed enforces the multi-model allowlist for a resolved model id.
-// On rejection it records a model-mismatch against the user's rate limiter (to
-// throttle clients that spam invalid model names) and returns an error. A
-// wildcard ("*") entry makes every model allowed.
-func (c *Ctrl) checkModelAllowed(ctx *gin.Context, requestModel, userAddr string) error {
-	// The wildcard "*" is a config sentinel for catch-all pricing, never a
-	// selectable model. A request literally asking for "*" would otherwise be an
-	// exact map hit (IsModelAllowed true) and get forwarded verbatim upstream;
-	// reject it like any other unsupported model.
-	if requestModel != config.ModelWildcard && c.Service.IsModelAllowed(requestModel) {
-		// Audit trail: when a request is served via the catch-all wildcard rather
-		// than an explicit allowlist entry, surface the actual model so operators
-		// can see what the wildcard price is being applied to. At Debug to avoid
-		// per-request log volume on a serve-all provider (the client controls the
-		// model string); the always-on load-time warning is the operator alert.
-		if c.Service.ServedViaWildcard(requestModel) {
-			c.logger.Debugf("Model served via wildcard catch-all pricing: requested=%s (no explicit modelPricing entry)", requestModel)
-		}
-		return nil
-	}
+// recordModelMismatch records a rejected model request against the user's rate
+// limiter (to throttle clients that spam invalid model names) and logs it. Used
+// by both multi-model resolution paths (chatbot JSON and STT/video billing-only)
+// when ResolveRequestedModel reports the requested model is not allowed.
+func (c *Ctrl) recordModelMismatch(userAddr, requestModel string) {
 	c.logger.Warnf("Model allowlist rejected: user=%s, requested=%s", userAddr, requestModel)
 	if userAddr != "" {
 		rateLimiter := GetRateLimiter()
@@ -1016,5 +1019,4 @@ func (c *Ctrl) checkModelAllowed(ctx *gin.Context, requestModel, userAddr string
 				userAddr, blockedUntil.Format("2006-01-02 15:04:05"))
 		}
 	}
-	return fmt.Errorf("model not supported: '%s' is not available for this service", requestModel)
 }


### PR DESCRIPTION
## Why

Closes #558. Multi-model centralized providers forwarded the requested `model` verbatim and explicitly rejected per-model upstream rewrite — forcing the on-chain public id, client-sent id, upstream id, and billing key to all be identical. That made it impossible to add a second model to a provider whose **public id differs from the upstream id** (e.g. OpenRouter's `z-ai/glm-5` vs the advertised `zai-org/GLM-5-FP8`) without changing the chain-published id and disrupting existing clients.

This unblocks single-provider multi-model serving where each model maps a stable public id to its own upstream id.

## What

Adds `UpstreamModel` and `ModelAliases` to each `ModelPricingEntry`:

- **`ResolveRequestedModel`** resolves a requested id (exact → alias → wildcard) to its entry. Billing and metrics key on the **public id** (`entry.Model`); the outgoing request body `model` is rewritten to the entry's upstream id before forwarding. Wildcard-served models are forwarded verbatim.
- **`BuildModelPricingMap`** builds an alias index and rejects collisions (alias vs model id, duplicate alias, `"*"` alias).
- **Load-time validation** rejects, fail-closed:
  - per-entry `upstreamModel`/`modelAliases` on non-chatbot services (only the JSON chatbot path rewrites the body)
  - `upstreamModel` on the wildcard entry (would be silently dropped)
  - `upstreamModel == "*"` and whitespace-padded `upstreamModel`/aliases
  - `upstreamModel` colliding with another entry's public id or alias (two entries sharing one upstream is allowed but `[CONFIG]`-warned)
- **`ModelExpiration`** now resolves through `ResolveRequestedModel`, so an alias is subject to the same 410-expiry gate as its canonical id.

Service-level `upstreamModel`/`modelAliases` remain rejected alongside `modelPricing`, now pointing operators at the per-entry fields.

## Backward compatibility

Existing single-model and multi-model deployments are unaffected: the public `service.model` id stays the on-chain advertised id, per-model billing is unchanged, and aliases are accepted but not advertised in `/v1/models`. The on-chain price ceiling continues to auto-set to `max(model prices)`.

## Example config

```yaml
service:
  model: zai-org/GLM-5-FP8        # on-chain id; existing clients undisturbed
  priceDenomination: USD
  modelPricing:
    - model: zai-org/GLM-5-FP8
      upstreamModel: z-ai/glm-5
      inputPriceUSDPerMillionTokens: "0.60"
      outputPriceUSDPerMillionTokens: "1.92"
    - model: <deepseek public id>
      upstreamModel: deepseek/deepseek-v4-flash
      inputPriceUSDPerMillionTokens: "<...>"
      outputPriceUSDPerMillionTokens: "<...>"
```

## Testing

`go build ./...`, `go test ./inference/config/... ./inference/internal/ctrl/...`, `gofmt`, and `go vet` all pass. 13 new tests cover resolution, body rewrite, alias/upstream collisions, whitespace rejection, wildcard verbatim forwarding, and the alias-expiry gate.

## Review

Went through three rounds of deep review (general bug/CLAUDE.md, silent-failure, security-differential, sharp-edges API). The final two rounds had no HIGH-or-above findings; the surfaced HIGH (missing `upstreamModel` collision validation) and MEDIUMs (alias whitespace trap, wildcard+upstream, alias bypassing the expiry gate) are all fixed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)