### PR TITLE
feat(inference): optional injectBodyFields for chatbot providers (#477)

### DIFF
--- a/api/inference/config/config.go
+++ b/api/inference/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/big"
 	"os"
@@ -270,6 +271,35 @@ type Service struct {
 	// entry, built alongside modelPricingMap. Lets the multi-model request path
 	// accept a legacy model id and resolve it to its canonical pricing entry.
 	modelAliasMap map[string]*ModelPricingEntry `yaml:"-"`
+
+	// InjectBodyFields, when set, are top-level key/value pairs merged into the
+	// JSON request body forwarded to a chatbot targetUrl. It lets an operator set
+	// upstream defaults/overrides per provider without code changes. The canonical
+	// use is OpenRouter provider routing — pin a backend while allowing fallbacks
+	// on failure — but it is generic: e.g. force reasoning off on a route, or set
+	// any other upstream-understood field:
+	//
+	//   injectBodyFields:
+	//     provider:                  # OpenRouter provider-routing object
+	//       order: ["DeepInfra"]
+	//       allow_fallbacks: true
+	//       require_parameters: true
+	//     reasoning:
+	//       enabled: false           # e.g. disable thinking on this route
+	//
+	// Server-config-wins: each injected key overwrites any client-supplied value
+	// of the same name, so users cannot steer it. Key names are NOT validated
+	// against an allowlist (the upstream is the authority on accepted keys), but:
+	//   - a denylist of broker-critical fields (model, messages, stream,
+	//     stream_options, lora_adapter_name) is REJECTED at load — overriding them
+	//     would break model enforcement / usage-based billing / LoRA rewriting
+	//     (see protectedInjectBodyFields);
+	//   - at config load the map is normalized and checked JSON-serializable so a
+	//     nested-object value (e.g. provider.max_price) cannot pass load yet fail
+	//     every request at marshal time — see normalizeInjectBodyFields.
+	// Empty or unset means the body is forwarded unchanged (backward compatible).
+	// Only applied for the chatbot service type; rejected for others at load.
+	InjectBodyFields map[string]interface{} `yaml:"injectBodyFields"`
 }
 
 // IsCentralized returns true if this service routes to a centralized API provider.
@@ -724,6 +754,86 @@ func validatePricingTiers(prefix string, tiers []PricingTier) error {
 	return nil
 }
 
+// protectedInjectBodyFields are top-level request-body keys the broker sets or
+// depends on for correctness and must never be overridden by injectBodyFields:
+//   - model: enforced per service for billing integrity (users pay for the
+//     advertised model; see EnforceConfiguredModel/ValidateModelAllowlist).
+//   - messages: the actual request content.
+//   - stream / stream_options: the broker forces stream_options.include_usage so
+//     streaming responses report usage for billing (see EnsureStreamOptions).
+//   - lora_adapter_name: the broker derives this from an ft-* model during LoRA
+//     request rewriting (see RewriteLoRARequest); injecting it would clobber the
+//     resolved adapter.
+// Injecting any of these is rejected at config load (fail loud, not silent).
+var protectedInjectBodyFields = map[string]struct{}{
+	"model":             {},
+	"messages":          {},
+	"stream":            {},
+	"stream_options":    {},
+	"lora_adapter_name": {},
+}
+
+// normalizeInjectBodyFields rejects broker-critical keys, then makes the map safe
+// to json.Marshal into the forwarded request body at runtime and verifies
+// serializability so a broken value shape fails loud at load instead of on every
+// request.
+//
+// yaml.v2 decodes nested mappings as map[interface{}]interface{}, which
+// json.Marshal rejects. So a nested-object value — e.g. OpenRouter's documented
+// provider.max_price: {prompt, completion} — would otherwise pass config load
+// (the field is map[string]interface{} at the top level) yet fail EVERY chatbot
+// request at runtime inside ctrl.InjectBodyFields. We recursively convert nested
+// maps to map[string]interface{} and re-check json.Marshal.
+//
+// This intentionally does NOT validate key names against an allowlist (beyond the
+// protected denylist): upstream-accepted keys are the gateway's vocabulary, not
+// ours, and a closed allowlist both rejects legitimate keys the moment the
+// upstream adds one and gives false confidence. We only guarantee the value is
+// forwardable and does not clobber a field the broker relies on.
+func normalizeInjectBodyFields(fields map[string]interface{}) (map[string]interface{}, error) {
+	normalized := make(map[string]interface{}, len(fields))
+	for k, v := range fields {
+		if _, protected := protectedInjectBodyFields[k]; protected {
+			return nil, fmt.Errorf("invalid config: service.injectBodyFields must not override broker-critical field %q (protected: model, messages, stream, stream_options, lora_adapter_name)", k)
+		}
+		normalized[k] = normalizeYAMLValue(v)
+	}
+	if _, err := json.Marshal(normalized); err != nil {
+		return nil, fmt.Errorf("invalid config: service.injectBodyFields is not JSON-serializable (check the value shapes): %w", err)
+	}
+	return normalized, nil
+}
+
+// normalizeYAMLValue recursively rewrites yaml.v2's map[interface{}]interface{}
+// nodes into map[string]interface{} (walking slices too) so the value can be
+// json.Marshal-ed. Map keys are stringified; OpenRouter routing keys are always
+// strings, so a non-string key indicates malformed config and simply becomes its
+// string form (harmless — the upstream ignores unknown keys).
+func normalizeYAMLValue(v interface{}) interface{} {
+	switch val := v.(type) {
+	case map[interface{}]interface{}:
+		m := make(map[string]interface{}, len(val))
+		for k, vv := range val {
+			m[fmt.Sprintf("%v", k)] = normalizeYAMLValue(vv)
+		}
+		return m
+	case map[string]interface{}:
+		m := make(map[string]interface{}, len(val))
+		for k, vv := range val {
+			m[k] = normalizeYAMLValue(vv)
+		}
+		return m
+	case []interface{}:
+		s := make([]interface{}, len(val))
+		for i, vv := range val {
+			s[i] = normalizeYAMLValue(vv)
+		}
+		return s
+	default:
+		return val
+	}
+}
+
 // validatePriceFeedConfig validates (and normalizes with defaults) the price-feed
 // configuration. Only invoked when service.priceDenomination == "USD".
 func validatePriceFeedConfig(pf *PriceFeedConfig) error {
@@ -973,6 +1083,21 @@ func loadConfig(cfg *Config) error {
 		if cfg.Service.TargetURL != "" && !strings.HasPrefix(strings.ToLower(cfg.Service.TargetURL), "https://") {
 			return fmt.Errorf("invalid config: service.targetUrl must use HTTPS for centralized providers (routing proof requires TLS), got '%s'", cfg.Service.TargetURL)
 		}
+	}
+
+	// Body-field injection is only applied for the chatbot service type (see
+	// ctrl.InjectBodyFields). Reject it elsewhere, reject broker-critical keys,
+	// and normalize, so any misconfiguration surfaces at load instead of silently
+	// doing nothing (or failing every request).
+	if len(cfg.Service.InjectBodyFields) > 0 {
+		if cfg.Service.Type != constant.ServiceTypeChatbot {
+			return fmt.Errorf("invalid config: service.injectBodyFields is only supported for service type '%s', got '%s'", constant.ServiceTypeChatbot, cfg.Service.Type)
+		}
+		normalized, err := normalizeInjectBodyFields(cfg.Service.InjectBodyFields)
+		if err != nil {
+			return err
+		}
+		cfg.Service.InjectBodyFields = normalized
 	}
 
 	// Provider display metadata (applies to any provider type). Both are optional.

--- a/api/inference/config/config_test.go
+++ b/api/inference/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -288,6 +289,108 @@ service:
 	t.Setenv("CONFIG_FILE", configPath)
 	if err := loadConfig(&Config{}); err == nil || !strings.Contains(err.Error(), "service type") {
 		t.Fatalf("expected unwired-modality rejection, got: %v", err)
+	}
+}
+
+func TestLoadConfig_InjectBodyFields_RejectsNonChatbot(t *testing.T) {
+	// injectBodyFields is only applied on the chatbot forward path, so a
+	// non-chatbot service type must be rejected at load instead of silently
+	// no-op'ing.
+	configPath := writeTestConfig(t, `
+service:
+  servingUrl: "http://example.com"
+  targetUrl: "https://backend:8000"
+  type: "text-to-image"
+  model: "dall-e-3"
+  providerType: "centralized"
+  providerIdentity: "openai"
+  verifiability: "TeeML"
+  inputPrice: "10"
+  outputPrice: "30"
+  injectBodyFields:
+    provider:
+      order: ["z-ai"]
+      allow_fallbacks: true
+`)
+	t.Setenv("CONFIG_FILE", configPath)
+	if err := loadConfig(&Config{}); err == nil || !strings.Contains(err.Error(), "injectBodyFields is only supported") {
+		t.Fatalf("expected non-chatbot rejection, got: %v", err)
+	}
+}
+
+func TestLoadConfig_InjectBodyFields_RejectsProtectedKey(t *testing.T) {
+	// Overriding a broker-critical field (here, model) would break model
+	// enforcement / billing, so it must be rejected at load.
+	configPath := writeTestConfig(t, `
+service:
+  servingUrl: "http://example.com"
+  targetUrl: "https://backend:8000"
+  type: "chatbot"
+  model: "glm-5"
+  providerType: "centralized"
+  providerIdentity: "openrouter"
+  verifiability: "TeeML"
+  inputPrice: "10"
+  outputPrice: "30"
+  injectBodyFields:
+    model: "some-cheaper-model"
+`)
+	t.Setenv("CONFIG_FILE", configPath)
+	if err := loadConfig(&Config{}); err == nil || !strings.Contains(err.Error(), "broker-critical field") {
+		t.Fatalf("expected protected-key rejection, got: %v", err)
+	}
+}
+
+func TestLoadConfig_InjectBodyFields_NormalizesNestedObject(t *testing.T) {
+	// A nested-object value (OpenRouter's provider.max_price) decodes under
+	// yaml.v2 as map[interface{}]interface{}, which json.Marshal rejects.
+	// loadConfig must normalize it to map[string]interface{} so it loads clean
+	// AND the stored map is JSON-serializable — otherwise it would fail every
+	// chatbot request at marshal time.
+	configPath := writeTestConfig(t, `
+service:
+  servingUrl: "http://example.com"
+  targetUrl: "https://backend:8000"
+  type: "chatbot"
+  model: "glm-5"
+  providerType: "centralized"
+  providerIdentity: "openrouter"
+  verifiability: "TeeML"
+  inputPrice: "10"
+  outputPrice: "30"
+  injectBodyFields:
+    provider:
+      order: ["z-ai"]
+      allow_fallbacks: true
+      max_price:
+        prompt: "0.6"
+        completion: "1.92"
+    reasoning:
+      enabled: false
+`)
+	t.Setenv("CONFIG_FILE", configPath)
+	cfg := &Config{}
+	if err := loadConfig(cfg); err != nil {
+		t.Fatalf("nested-object injection should load after normalization, got: %v", err)
+	}
+	// The whole map must be JSON-serializable (the runtime injection path marshals it).
+	if _, err := json.Marshal(cfg.Service.InjectBodyFields); err != nil {
+		t.Fatalf("normalized inject map is not JSON-serializable: %v", err)
+	}
+	prov, ok := cfg.Service.InjectBodyFields["provider"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("provider not normalized to map[string]interface{}, got %T", cfg.Service.InjectBodyFields["provider"])
+	}
+	mp, ok := prov["max_price"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("max_price not normalized to map[string]interface{}, got %T", prov["max_price"])
+	}
+	if mp["prompt"] != "0.6" || mp["completion"] != "1.92" {
+		t.Errorf("max_price values not preserved: %#v", mp)
+	}
+	reasoning, ok := cfg.Service.InjectBodyFields["reasoning"].(map[string]interface{})
+	if !ok || reasoning["enabled"] != false {
+		t.Errorf("reasoning not preserved: %#v", cfg.Service.InjectBodyFields["reasoning"])
 	}
 }
 

--- a/api/inference/internal/ctrl/proxy.go
+++ b/api/inference/internal/ctrl/proxy.go
@@ -77,6 +77,22 @@ func (c *Ctrl) PrepareHTTPRequest(ctx *gin.Context, targetURL string, reqBody []
 			// Set resolvedModel for unified billing
 			ctx.Set(CtxKeyResolvedModel, c.Service.ModelType)
 		}
+
+		// Merge operator-configured upstream body fields (e.g. OpenRouter's
+		// "provider" routing object, or a reasoning toggle). No-op unless
+		// service.injectBodyFields is configured. Runs after model rewrite so the
+		// body is the final JSON that gets forwarded.
+		modifiedBody, err = c.InjectBodyFields(reqBody)
+		if err != nil {
+			// A marshal failure here is a broker-side fault (the injected fields
+			// are server config, already verified JSON-serializable at load, and
+			// the body was valid JSON). Leave it UNFLAGGED — unlike the
+			// client-caused model-validation branches above — so the unified
+			// failure metric attributes it to source=broker and the broker alert
+			// fires (same convention as the RPC-fault path in request.go).
+			return nil, errors.Wrap(err, "inject body fields")
+		}
+		reqBody = modifiedBody
 	}
 
 	// Multi-model speech-to-text / video-generation: resolve the requested model
@@ -634,6 +650,60 @@ func (c *Ctrl) EnsureStreamOptions(body []byte) ([]byte, error) {
 	modifiedBody, err := json.Marshal(bodyMap)
 	if err != nil {
 		return body, errors.Wrap(err, "failed to marshal modified JSON body")
+	}
+
+	return modifiedBody, nil
+}
+
+// InjectBodyFields merges c.Service.InjectBodyFields into the request body's
+// top-level object when configured, so the operator can set upstream
+// defaults/overrides per provider (e.g. OpenRouter's "provider" routing object
+// to pin a backend with fallbacks, or a reasoning toggle). It is
+// server-config-wins: each injected key replaces any client-supplied value of
+// the same name, so users cannot steer it. Broker-critical keys (model,
+// messages, stream, stream_options) are rejected at config load, so they can
+// never be injected here.
+//
+// No-op (body returned unchanged) when the fields map is empty/unset or the body
+// is empty. A body that does not parse as a JSON object is forwarded unchanged
+// rather than erroring — chatbot bodies are expected to be JSON objects, and
+// failing closed here would break the request for purely additive fields. That
+// fall-through is logged so a silently-unapplied injection is greppable.
+//
+// The configured fields map is normalized and verified JSON-serializable at
+// config load (see config.normalizeInjectBodyFields), so the marshal here cannot
+// fail in practice; the error branch is defensive.
+//
+// Decoding uses json.Number (UseNumber) so large integer fields (e.g. a seed of
+// 2^53+1, or big integers inside tool-call arguments) survive the round-trip
+// without being mangled into float64 — matching forceB64ResponseFormat.
+func (c *Ctrl) InjectBodyFields(body []byte) ([]byte, error) {
+	if len(c.Service.InjectBodyFields) == 0 || len(body) == 0 {
+		return body, nil
+	}
+
+	var bodyMap map[string]interface{}
+	dec := json.NewDecoder(bytes.NewReader(body))
+	dec.UseNumber()
+	// A literal JSON `null` decodes into a nil map WITHOUT error; assigning to it
+	// below would panic ("assignment to entry in nil map"). Treat err and nil map
+	// the same as the non-object fall-through.
+	if err := dec.Decode(&bodyMap); err != nil || bodyMap == nil {
+		// Non-JSON-object body (or null): forward unchanged (cannot inject
+		// fields). The configured injection silently does not apply to this
+		// request, so log it — otherwise "most requests injected but some aren't"
+		// is undebuggable.
+		c.logger.Warnf("injectBodyFields configured but request body is not a JSON object; forwarding without injection: %v", err)
+		return body, nil
+	}
+
+	for k, v := range c.Service.InjectBodyFields {
+		bodyMap[k] = v
+	}
+
+	modifiedBody, err := json.Marshal(bodyMap)
+	if err != nil {
+		return body, errors.Wrap(err, "failed to marshal body with injected fields")
 	}
 
 	return modifiedBody, nil

--- a/api/inference/internal/ctrl/proxy_test.go
+++ b/api/inference/internal/ctrl/proxy_test.go
@@ -168,6 +168,184 @@ func TestEnforceConfiguredModel_InjectsUpstreamWhenMissing(t *testing.T) {
 	}
 }
 
+// newTestCtrlForInjectBodyFields builds a chatbot Ctrl with the given
+// injectBodyFields map.
+func newTestCtrlForInjectBodyFields(t *testing.T, fields map[string]interface{}) *Ctrl {
+	t.Helper()
+	return &Ctrl{
+		Service: config.Service{
+			Type:             "chatbot",
+			ModelType:        "zai-org/GLM-5-FP8",
+			InjectBodyFields: fields,
+		},
+		logger:         testLogger(),
+		whitelistUsers: make(map[string]struct{}),
+	}
+}
+
+// When configured, each field is merged into the top-level body object — e.g. a
+// "provider" routing object AND a "reasoning" toggle in one injection.
+func TestInjectBodyFields_InjectsWhenConfigured(t *testing.T) {
+	c := newTestCtrlForInjectBodyFields(t, map[string]interface{}{
+		"provider": map[string]interface{}{
+			"order":           []interface{}{"DeepInfra"},
+			"allow_fallbacks": true,
+		},
+		"reasoning": map[string]interface{}{"enabled": false},
+	})
+	body := []byte(`{"model":"zai-org/GLM-5-FP8","messages":[{"role":"user","content":"hi"}]}`)
+
+	got, err := c.InjectBodyFields(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var out map[string]interface{}
+	if err := json.Unmarshal(got, &out); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	prov, ok := out["provider"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("provider field missing or wrong type: %#v", out["provider"])
+	}
+	if prov["allow_fallbacks"] != true {
+		t.Errorf("allow_fallbacks = %v, want true", prov["allow_fallbacks"])
+	}
+	order, ok := prov["order"].([]interface{})
+	if !ok || len(order) != 1 || order[0] != "DeepInfra" {
+		t.Errorf("order = %#v, want [DeepInfra]", prov["order"])
+	}
+	reasoning, ok := out["reasoning"].(map[string]interface{})
+	if !ok || reasoning["enabled"] != false {
+		t.Errorf("reasoning = %#v, want {enabled:false}", out["reasoning"])
+	}
+	// The original model field must be preserved.
+	if out["model"] != "zai-org/GLM-5-FP8" {
+		t.Errorf("model = %q, want it preserved", out["model"])
+	}
+}
+
+// Server-config-wins: a client-supplied value of an injected key is overwritten.
+func TestInjectBodyFields_OverwritesClientValue(t *testing.T) {
+	c := newTestCtrlForInjectBodyFields(t, map[string]interface{}{
+		"provider": map[string]interface{}{
+			"order":           []interface{}{"DeepInfra"},
+			"allow_fallbacks": true,
+		},
+	})
+	body := []byte(`{"messages":[],"provider":{"order":["SomeCheapProvider"],"allow_fallbacks":false}}`)
+
+	got, err := c.InjectBodyFields(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var out map[string]interface{}
+	if err := json.Unmarshal(got, &out); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	prov := out["provider"].(map[string]interface{})
+	if prov["allow_fallbacks"] != true {
+		t.Errorf("client value not overwritten: allow_fallbacks = %v, want true", prov["allow_fallbacks"])
+	}
+	order := prov["order"].([]interface{})
+	if order[0] != "DeepInfra" {
+		t.Errorf("client value not overwritten: order = %#v", prov["order"])
+	}
+}
+
+// Nothing configured → body forwarded byte-for-byte unchanged (backward compat).
+func TestInjectBodyFields_NoopWhenUnset(t *testing.T) {
+	c := newTestCtrlForInjectBodyFields(t, nil)
+	body := []byte(`{"model":"zai-org/GLM-5-FP8","messages":[]}`)
+
+	got, err := c.InjectBodyFields(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bytes.Equal(got, body) {
+		t.Errorf("body mutated when injection unset: got %s", got)
+	}
+}
+
+// Empty body (e.g. GET) is returned unchanged even when injection is configured.
+func TestInjectBodyFields_NoopOnEmptyBody(t *testing.T) {
+	c := newTestCtrlForInjectBodyFields(t, map[string]interface{}{"provider": map[string]interface{}{"order": []interface{}{"DeepInfra"}}})
+	got, err := c.InjectBodyFields(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty body, got %s", got)
+	}
+}
+
+// Large integer fields in the body survive the decode/re-marshal round-trip
+// (UseNumber), rather than being mangled into float64 scientific notation.
+func TestInjectBodyFields_PreservesLargeInteger(t *testing.T) {
+	c := newTestCtrlForInjectBodyFields(t, map[string]interface{}{"provider": map[string]interface{}{"order": []interface{}{"z-ai"}}})
+	// 2^53+1 cannot be represented exactly as a float64.
+	body := []byte(`{"model":"glm-5","seed":9007199254740993,"messages":[]}`)
+
+	got, err := c.InjectBodyFields(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bytes.Contains(got, []byte(`9007199254740993`)) {
+		t.Errorf("large integer seed not preserved verbatim: got %s", got)
+	}
+}
+
+// A nested-object injected value (e.g. provider.max_price) injects correctly.
+func TestInjectBodyFields_NestedObjectValue(t *testing.T) {
+	c := newTestCtrlForInjectBodyFields(t, map[string]interface{}{
+		"provider": map[string]interface{}{
+			"order":     []interface{}{"z-ai"},
+			"max_price": map[string]interface{}{"prompt": "0.6", "completion": "1.92"},
+		},
+	})
+	body := []byte(`{"model":"glm-5","messages":[]}`)
+
+	got, err := c.InjectBodyFields(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var out map[string]interface{}
+	if err := json.Unmarshal(got, &out); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	prov := out["provider"].(map[string]interface{})
+	mp, ok := prov["max_price"].(map[string]interface{})
+	if !ok || mp["prompt"] != "0.6" || mp["completion"] != "1.92" {
+		t.Errorf("nested max_price not injected: %#v", prov["max_price"])
+	}
+}
+
+// A literal JSON `null` body decodes to a nil map without error; it must NOT
+// panic on the map assignment — forward unchanged instead.
+func TestInjectBodyFields_NoopOnNullBody(t *testing.T) {
+	c := newTestCtrlForInjectBodyFields(t, map[string]interface{}{"provider": map[string]interface{}{"order": []interface{}{"z-ai"}}})
+	body := []byte(`null`)
+	got, err := c.InjectBodyFields(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bytes.Equal(got, body) {
+		t.Errorf("null body mutated: got %s", got)
+	}
+}
+
+// A non-JSON-object body is forwarded unchanged rather than erroring.
+func TestInjectBodyFields_NoopOnNonJSON(t *testing.T) {
+	c := newTestCtrlForInjectBodyFields(t, map[string]interface{}{"provider": map[string]interface{}{"order": []interface{}{"DeepInfra"}}})
+	body := []byte(`not json`)
+	got, err := c.InjectBodyFields(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bytes.Equal(got, body) {
+		t.Errorf("non-JSON body mutated: got %s", got)
+	}
+}
+
 func TestDecodeErrorBody(t *testing.T) {
 	const payload = `{"error":{"message":"upstream boom"}}`
 


### PR DESCRIPTION
## What

Adds an optional `service.injectBodyFields` config map whose top-level key/value pairs the broker **merges into the JSON request body** forwarded to a **chatbot** `targetUrl`. It lets an operator set upstream defaults/overrides per provider with no code changes.

The canonical use is **OpenRouter provider routing** — inject a `provider` object to pin a backend while allowing fallbacks on failure — which closes #477 (OpenRouter's default load-balancing could route GLM-5 to a low-context backend and truncate the answer despite the advertised `maxCompletionTokens`). But the mechanism is **generic**: e.g. also force reasoning off on a route.

> Generalized from an earlier provider-only field after review: one uniform "inject upstream body fields" knob is easier to understand and covers a real second use case (per-route `reasoning` toggle), with a denylist guarding broker-critical fields.

### Example config
```yaml
service:
  type: chatbot
  targetUrl: https://openrouter.ai/api/v1
  injectBodyFields:
    provider:                  # OpenRouter provider-routing object
      order: ["z-ai"]          # pin GLM-5 to z.ai's backend
      allow_fallbacks: true    # fail over to other providers on error
      require_parameters: true
    reasoning:
      enabled: false           # e.g. disable thinking on this route
```

## Design notes

- **Server-config-wins**: each injected key overwrites any client-supplied value of the same name — users cannot steer it.
- **Denylist (fail loud at load)**: broker-critical keys `model`, `messages`, `stream`, `stream_options`, `lora_adapter_name` are rejected — overriding them would break model enforcement, usage-based billing, or LoRA rewriting. (Billing itself is response-`usage`-driven, so no injected request field can under-bill; the denylist protects the broker's own request-shaping invariants.)
- **Backward compatible / no flag**: unset → `len()==0` short-circuit → body forwarded byte-for-byte unchanged. Feature only activates on operator opt-in.
- **Chatbot-only**: applied after model rewrite, inside the `svcType == "chatbot"` block; rejected at config load for any other service type.
- **Integer precision**: decoder uses `UseNumber()` so large ints (e.g. `seed` 2^53+1) survive the round-trip — matching `forceB64ResponseFormat`.
- **Robust input**: a literal JSON `null` body (decodes to a nil map without error) and a non-JSON-object body forward unchanged with a `Warnf`, instead of panicking or silently dropping the injection.
- **Load-time serializability**: yaml.v2 decodes nested mappings as `map[interface{}]interface{}` (which `json.Marshal` rejects); the map is normalized to `map[string]interface{}` and re-checked at load, so a nested-object value (e.g. `provider.max_price`) fails loud at boot instead of failing every request.
- **Failure attribution**: a marshal fault in injection is left unflagged (no `ignoreError`) so it attributes to `source=broker`, matching the RPC-fault convention in `request.go`.

## Deploy ≠ Release checklist
- ✅ No new route / credential / external API contract change (injected fields are outbound to the upstream gateway, not client-facing).
- ✅ No migration, no new worker, no new env/secret. Per-provider `config.yaml` field only.
- ✅ Additive + default-off (empty map = off state).

## Tests
- `ctrl`: multi-field inject (provider + reasoning), overwrite-client-value, no-op-unset, no-op-empty-body, no-op-null-body, no-op-non-JSON, large-integer preservation, nested-object value.
- `config`: reject non-chatbot service type, reject protected key, normalize + serializability of nested object.

Build clean; all new tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
