### PR TITLE
feat(inference): strip operator-denylisted body fields before forwarding

### DIFF
--- a/api/inference/config/config.go
+++ b/api/inference/config/config.go
@@ -321,6 +321,18 @@ type Service struct {
 	// names, so the worst case is a missed param that keeps 404-ing (loud,
 	// discoverable) rather than a legitimate request silently mangled.
 	//
+	// The "worst case is a loud 404" guarantee holds only for params the upstream
+	// REQUIRES/rejects. Stripping a param the upstream merely accepts changes
+	// request behavior silently with no error — in particular do NOT strip
+	// cost-affecting keys (max_tokens / max_completion_tokens, etc.): removing an
+	// output cap can uncap generation and inflate the output-token bill the user
+	// pays. List only params that actually cause upstream rejection.
+	//
+	// Matching is case-sensitive and exact: an entry must equal the JSON key the
+	// client sends byte-for-byte ("logprobs", not "Logprobs"). A typo loads fine
+	// but silently never matches; confirm via the per-request "stripped … field(s)"
+	// log that the denylist is firing.
+	//
 	// Broker-critical fields (model, messages, stream, stream_options,
 	// lora_adapter_name) are REJECTED at load — stripping them would break model
 	// enforcement / usage-based billing / LoRA rewriting (same protected denylist

--- a/api/inference/config/config.go
+++ b/api/inference/config/config.go
@@ -300,6 +300,37 @@ type Service struct {
 	// Empty or unset means the body is forwarded unchanged (backward compatible).
 	// Only applied for the chatbot service type; rejected for others at load.
 	InjectBodyFields map[string]interface{} `yaml:"injectBodyFields"`
+
+	// StripBodyFields, when set, are top-level keys REMOVED from the JSON request
+	// body before it is forwarded to a chatbot targetUrl. It is the surgical
+	// counterpart of injectBodyFields: a denylist of client-supplied params the
+	// upstream does not accept. The motivating case is OpenRouter returning 404 for
+	// a request carrying a param the picked backend lacks (e.g. logprobs /
+	// top_logprobs) — the broker strips it rather than letting the upstream reject
+	// the whole request:
+	//
+	//   stripBodyFields:
+	//     - logprobs
+	//     - top_logprobs
+	//
+	// It is deliberately a denylist, NOT an allowlist derived from
+	// modelInfo.supportedParameters: that field advertises sampling capabilities
+	// for /v1/models and is not an exhaustive set of legal body keys, so using it
+	// to strip would silently drop legitimate params (max_completion_tokens, n,
+	// tools, response_format, …). A denylist can only remove keys the operator
+	// names, so the worst case is a missed param that keeps 404-ing (loud,
+	// discoverable) rather than a legitimate request silently mangled.
+	//
+	// Broker-critical fields (model, messages, stream, stream_options,
+	// lora_adapter_name) are REJECTED at load — stripping them would break model
+	// enforcement / usage-based billing / LoRA rewriting (same protected denylist
+	// as injectBodyFields; see protectedInjectBodyFields). Names are otherwise NOT
+	// validated against an allowlist (the upstream is the authority on accepted
+	// keys). Applied BEFORE injectBodyFields, so an operator may strip a client's
+	// value and then inject the server's own. Empty or unset means the body is
+	// forwarded unchanged. Only applied for the chatbot service type; rejected for
+	// others at load.
+	StripBodyFields []string `yaml:"stripBodyFields"`
 }
 
 // IsCentralized returns true if this service routes to a centralized API provider.
@@ -807,6 +838,68 @@ func normalizeInjectBodyFields(fieldPath string, fields map[string]interface{}) 
 	return normalized, nil
 }
 
+// normalizeStripBodyFields trims and de-duplicates a stripBodyFields list and
+// rejects broker-critical keys, reusing the same protected denylist as
+// injectBodyFields — stripping model/messages/stream/stream_options/
+// lora_adapter_name would break model enforcement, usage-based billing, or LoRA
+// rewriting, so it fails loud at load instead of silently mangling every request.
+// Blank entries are dropped. fieldPath names the config location for error
+// messages (e.g. "service.stripBodyFields" or
+// "service.modelPricing[0].stripBodyFields").
+func normalizeStripBodyFields(fieldPath string, fields []string) ([]string, error) {
+	seen := make(map[string]struct{}, len(fields))
+	normalized := make([]string, 0, len(fields))
+	for _, k := range fields {
+		k = strings.TrimSpace(k)
+		if k == "" {
+			continue
+		}
+		if _, protected := protectedInjectBodyFields[k]; protected {
+			return nil, fmt.Errorf("invalid config: %s must not strip broker-critical field %q (protected: model, messages, stream, stream_options, lora_adapter_name)", fieldPath, k)
+		}
+		if _, dup := seen[k]; dup {
+			continue
+		}
+		seen[k] = struct{}{}
+		normalized = append(normalized, k)
+	}
+	return normalized, nil
+}
+
+// EffectiveStripBodyFields returns the top-level body keys to strip for a request
+// resolved to the given model: the UNION of the service-level stripBodyFields and
+// the resolved model's per-entry stripBodyFields. Unlike injectBodyFields (which
+// deep-merges so a per-model leaf overrides the service value), stripping is
+// additive — a key removed at either level should be removed — so the two lists
+// are combined rather than overridden. Returns nil when neither level is
+// configured. The result is order-stable (service entries first, then any
+// model-only entries) and de-duplicated.
+func (s *Service) EffectiveStripBodyFields(model string) []string {
+	svc := s.StripBodyFields
+	var entry []string
+	if model != "" {
+		if e := s.GetModelPricing(model); e != nil {
+			entry = e.StripBodyFields
+		}
+	}
+	if len(entry) == 0 {
+		return svc
+	}
+	if len(svc) == 0 {
+		return entry
+	}
+	seen := make(map[string]struct{}, len(svc)+len(entry))
+	out := make([]string, 0, len(svc)+len(entry))
+	for _, k := range append(append([]string{}, svc...), entry...) {
+		if _, dup := seen[k]; dup {
+			continue
+		}
+		seen[k] = struct{}{}
+		out = append(out, k)
+	}
+	return out
+}
+
 // EffectiveInjectBodyFields returns the body fields to inject for a request
 // resolved to the given model: the service-level injectBodyFields with the
 // resolved model's per-entry injectBodyFields deep-merged ON TOP (the entry wins
@@ -1155,6 +1248,20 @@ func loadConfig(cfg *Config) error {
 			return err
 		}
 		cfg.Service.InjectBodyFields = normalized
+	}
+
+	// Body-field stripping mirrors injection: only meaningful on the chatbot
+	// forward path, rejects broker-critical keys, and is normalized (trim/dedup) at
+	// load so a misconfiguration surfaces here rather than silently doing nothing.
+	if len(cfg.Service.StripBodyFields) > 0 {
+		if cfg.Service.Type != constant.ServiceTypeChatbot {
+			return fmt.Errorf("invalid config: service.stripBodyFields is only supported for service type '%s', got '%s'", constant.ServiceTypeChatbot, cfg.Service.Type)
+		}
+		normalized, err := normalizeStripBodyFields("service.stripBodyFields", cfg.Service.StripBodyFields)
+		if err != nil {
+			return err
+		}
+		cfg.Service.StripBodyFields = normalized
 	}
 
 	// Provider display metadata (applies to any provider type). Both are optional.

--- a/api/inference/config/config_test.go
+++ b/api/inference/config/config_test.go
@@ -2384,6 +2384,69 @@ service:
 	}
 }
 
+func TestLoadConfig_ModelPricing_PerEntryStripBodyFields_RejectsProtectedKey(t *testing.T) {
+	// A per-entry stripBodyFields naming a broker-critical key (messages) must be
+	// rejected at load, same as the service-level field.
+	configPath := writeTestConfig(t, `
+service:
+  servingUrl: "http://example.com"
+  targetUrl: "https://openrouter.ai/api/v1"
+  type: "chatbot"
+  model: "zai-org/GLM-5-FP8"
+  providerType: "centralized"
+  providerIdentity: "openrouter"
+  verifiability: "TeeML"
+  modelPricing:
+    - model: "zai-org/GLM-5-FP8"
+      inputPrice: "100"
+      outputPrice: "300"
+      stripBodyFields:
+        - messages
+`)
+	t.Setenv("CONFIG_FILE", configPath)
+	if err := loadConfig(&Config{}); err == nil || !strings.Contains(err.Error(), "broker-critical field") {
+		t.Fatalf("expected per-entry protected-key rejection, got: %v", err)
+	}
+}
+
+func TestLoadConfig_ModelPricing_PerEntryStripBodyFields_Loads(t *testing.T) {
+	// A valid per-entry stripBodyFields loads and is normalized (trim/dedup).
+	configPath := writeTestConfig(t, `
+service:
+  servingUrl: "http://example.com"
+  targetUrl: "https://openrouter.ai/api/v1"
+  type: "chatbot"
+  model: "zai-org/GLM-5-FP8"
+  providerType: "centralized"
+  providerIdentity: "openrouter"
+  verifiability: "TeeML"
+  stripBodyFields:
+    - logprobs
+  modelPricing:
+    - model: "zai-org/GLM-5-FP8"
+      inputPrice: "100"
+      outputPrice: "300"
+      stripBodyFields:
+        - top_logprobs
+`)
+	t.Setenv("CONFIG_FILE", configPath)
+	cfg := &Config{}
+	if err := loadConfig(cfg); err != nil {
+		t.Fatalf("valid per-entry stripBodyFields should load, got: %v", err)
+	}
+	// The effective set for the model is the union of service + per-entry lists.
+	got := cfg.Service.EffectiveStripBodyFields("zai-org/GLM-5-FP8")
+	want := map[string]bool{"logprobs": true, "top_logprobs": true}
+	if len(got) != len(want) {
+		t.Fatalf("EffectiveStripBodyFields = %#v, want union %v", got, want)
+	}
+	for _, k := range got {
+		if !want[k] {
+			t.Errorf("unexpected key %q in effective strip set %#v", k, got)
+		}
+	}
+}
+
 func TestLoadConfig_ModelPricing_AliasCollidesWithModelID(t *testing.T) {
 	configPath := writeTestConfig(t, `
 service:

--- a/api/inference/config/config_test.go
+++ b/api/inference/config/config_test.go
@@ -394,6 +394,83 @@ service:
 	}
 }
 
+func TestLoadConfig_StripBodyFields_LoadsAndNormalizes(t *testing.T) {
+	// A valid stripBodyFields list (with a blank entry and a duplicate) loads and
+	// is normalized to a trimmed, de-duplicated list.
+	configPath := writeTestConfig(t, `
+service:
+  servingUrl: "http://example.com"
+  targetUrl: "https://backend:8000"
+  type: "chatbot"
+  model: "glm-5"
+  providerType: "centralized"
+  providerIdentity: "openrouter"
+  verifiability: "TeeML"
+  inputPrice: "10"
+  outputPrice: "30"
+  stripBodyFields:
+    - logprobs
+    - top_logprobs
+    - logprobs
+    - "  "
+`)
+	t.Setenv("CONFIG_FILE", configPath)
+	cfg := &Config{}
+	if err := loadConfig(cfg); err != nil {
+		t.Fatalf("valid stripBodyFields should load, got: %v", err)
+	}
+	want := []string{"logprobs", "top_logprobs"}
+	if got := cfg.Service.StripBodyFields; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("stripBodyFields = %#v, want %#v (trimmed + de-duplicated)", got, want)
+	}
+}
+
+func TestLoadConfig_StripBodyFields_RejectsNonChatbot(t *testing.T) {
+	// stripBodyFields is only applied on the chatbot forward path, so a non-chatbot
+	// service type must be rejected at load instead of silently no-op'ing.
+	configPath := writeTestConfig(t, `
+service:
+  servingUrl: "http://example.com"
+  targetUrl: "https://backend:8000"
+  type: "text-to-image"
+  model: "dall-e-3"
+  providerType: "centralized"
+  providerIdentity: "openai"
+  verifiability: "TeeML"
+  inputPrice: "10"
+  outputPrice: "30"
+  stripBodyFields:
+    - logprobs
+`)
+	t.Setenv("CONFIG_FILE", configPath)
+	if err := loadConfig(&Config{}); err == nil || !strings.Contains(err.Error(), "stripBodyFields is only supported") {
+		t.Fatalf("expected non-chatbot rejection, got: %v", err)
+	}
+}
+
+func TestLoadConfig_StripBodyFields_RejectsProtectedKey(t *testing.T) {
+	// Stripping a broker-critical field (here, messages) would break the request /
+	// billing, so it must be rejected at load.
+	configPath := writeTestConfig(t, `
+service:
+  servingUrl: "http://example.com"
+  targetUrl: "https://backend:8000"
+  type: "chatbot"
+  model: "glm-5"
+  providerType: "centralized"
+  providerIdentity: "openrouter"
+  verifiability: "TeeML"
+  inputPrice: "10"
+  outputPrice: "30"
+  stripBodyFields:
+    - messages
+`)
+	t.Setenv("CONFIG_FILE", configPath)
+	if err := loadConfig(&Config{}); err == nil || !strings.Contains(err.Error(), "broker-critical field") {
+		t.Fatalf("expected protected-key rejection, got: %v", err)
+	}
+}
+
 func TestLoadConfig_ModelPricing_USD(t *testing.T) {
 	// USD-denominated multi-model pricing: each entry carries USD-per-1M prices,
 	// and the service-level USD price is set to the max over models so the price

--- a/api/inference/config/model_pricing.go
+++ b/api/inference/config/model_pricing.go
@@ -133,6 +133,17 @@ type ModelPricingEntry struct {
 	// the chatbot service type. Empty/unset means the service-level map applies
 	// unchanged.
 	InjectBodyFields map[string]interface{} `yaml:"injectBodyFields"`
+
+	// StripBodyFields is the per-model counterpart of service.stripBodyFields:
+	// top-level keys removed from the forwarded chat body for requests resolved to
+	// THIS model. It is UNIONed with the service-level list (not deep-merged): the
+	// effective strip set is every key named at either level (see
+	// Service.EffectiveStripBodyFields), so a multi-model service can strip a param
+	// globally while one model strips an extra param its backend rejects. Same
+	// load-time rules as the service-level field: broker-critical keys are rejected
+	// and it is only supported for the chatbot service type. Empty/unset means the
+	// service-level list applies unchanged.
+	StripBodyFields []string `yaml:"stripBodyFields"`
 }
 
 // BillingMode selects how a model's per-request fee is computed. Empty defaults
@@ -801,6 +812,19 @@ func validateModelPricingEntry(i int, entry *ModelPricingEntry, serviceType stri
 			return err
 		}
 		entry.InjectBodyFields = normalized
+	}
+	// Per-entry stripBodyFields, like injectBodyFields, only applies on the chatbot
+	// forward path; reject it elsewhere, reject broker-critical keys, and normalize
+	// (trim/dedup) so a bad list fails loud at load.
+	if len(entry.StripBodyFields) > 0 {
+		if serviceType != constant.ServiceTypeChatbot {
+			return fmt.Errorf("invalid config: service.modelPricing[%d].stripBodyFields is only supported for service type '%s', got '%s' for model '%s'", i, constant.ServiceTypeChatbot, serviceType, entry.Model)
+		}
+		normalized, err := normalizeStripBodyFields(fmt.Sprintf("service.modelPricing[%d].stripBodyFields", i), entry.StripBodyFields)
+		if err != nil {
+			return err
+		}
+		entry.StripBodyFields = normalized
 	}
 	// The wildcard catch-all has no concrete id to rewrite to — ValidateModelAllowlist
 	// forwards a wildcard-served model verbatim — so an upstreamModel on the "*"

--- a/api/inference/internal/ctrl/proxy.go
+++ b/api/inference/internal/ctrl/proxy.go
@@ -744,12 +744,13 @@ func (c *Ctrl) InjectBodyFields(body []byte, resolvedModel string) ([]byte, erro
 // missing entry merely keeps 404-ing (loud) rather than silently dropping a
 // legitimate param.
 //
-// Every field actually removed is logged (with the resolved model and key) so a
-// strip — invisible to the client, which sees a plain success — is greppable on
-// our side. No-op (body returned unchanged) when the effective set is empty or
-// the body is empty; a body that is not a JSON object is forwarded unchanged and
-// logged, matching InjectBodyFields. Decoding uses json.Number so large integer
-// fields survive the round-trip unmangled.
+// The keys actually removed are logged once per request (their names only, never
+// values) so a strip — invisible to the client, which sees a plain success — is
+// greppable on our side without emitting a line per field on the steady-state
+// workload that strips every request. No-op (body returned unchanged) when the
+// effective set is empty or the body is empty; a body that is not a JSON object
+// is forwarded unchanged and logged, matching InjectBodyFields. Decoding uses
+// json.Number so large integer fields survive the round-trip unmangled.
 func (c *Ctrl) StripBodyFields(body []byte, resolvedModel string) ([]byte, error) {
 	fields := c.Service.EffectiveStripBodyFields(resolvedModel)
 	if len(fields) == 0 || len(body) == 0 {
@@ -760,23 +761,34 @@ func (c *Ctrl) StripBodyFields(body []byte, resolvedModel string) ([]byte, error
 	dec := json.NewDecoder(bytes.NewReader(body))
 	dec.UseNumber()
 	if err := dec.Decode(&bodyMap); err != nil || bodyMap == nil {
-		c.logger.Warnf("stripBodyFields configured but request body is not a JSON object; forwarding without stripping: %v", err)
+		// A literal JSON `null` decodes to a nil map with err == nil; the generic
+		// "%v" would then print "<nil>" and read like a parse failure. Distinguish
+		// the two and carry the resolved model so the line is correlatable.
+		if err != nil {
+			c.logger.Warnf("stripBodyFields configured but request body for model %q did not parse as JSON; forwarding without stripping: %v", resolvedModel, err)
+		} else {
+			c.logger.Warnf("stripBodyFields configured but request body for model %q is JSON null, not an object; forwarding without stripping", resolvedModel)
+		}
 		return body, nil
 	}
 
-	stripped := false
+	// Collect the keys actually removed and log them ONCE per request rather than a
+	// line per field: the motivating workload strips on every request, so per-field
+	// INFO would be steady-state spam. Only the key NAMES are logged (never values),
+	// so no client content leaks; the single line stays greppable per guardrail.
+	var strippedKeys []string
 	for _, k := range fields {
 		if _, present := bodyMap[k]; present {
 			delete(bodyMap, k)
-			stripped = true
-			c.logger.Infof("stripped unsupported request body field %q for model %q before forwarding upstream", k, resolvedModel)
+			strippedKeys = append(strippedKeys, k)
 		}
 	}
-	if !stripped {
+	if len(strippedKeys) == 0 {
 		// Nothing matched — avoid a needless re-marshal (which would also reorder
 		// keys); forward the original bytes unchanged.
 		return body, nil
 	}
+	c.logger.Infof("stripped unsupported request body field(s) %v for model %q before forwarding upstream", strippedKeys, resolvedModel)
 
 	modifiedBody, err := json.Marshal(bodyMap)
 	if err != nil {

--- a/api/inference/internal/ctrl/proxy.go
+++ b/api/inference/internal/ctrl/proxy.go
@@ -85,6 +85,18 @@ func (c *Ctrl) PrepareHTTPRequest(ctx *gin.Context, targetURL string, reqBody []
 		// multi-model providers; empty otherwise → service-level fields only).
 		resolvedModelVal, _ := ctx.Get(CtxKeyResolvedModel)
 		resolvedModelStr, _ := resolvedModelVal.(string)
+
+		// Strip operator-denylisted client params (e.g. logprobs/top_logprobs the
+		// routed upstream rejects) BEFORE injecting server fields, so a stripped
+		// key can be re-set by injection. No-op unless service- or per-model
+		// stripBodyFields is configured. A marshal failure here is a broker-side
+		// fault (same reasoning as InjectBodyFields below) — leave it unflagged.
+		modifiedBody, err = c.StripBodyFields(reqBody, resolvedModelStr)
+		if err != nil {
+			return nil, errors.Wrap(err, "strip body fields")
+		}
+		reqBody = modifiedBody
+
 		modifiedBody, err = c.InjectBodyFields(reqBody, resolvedModelStr)
 		if err != nil {
 			// A marshal failure here is a broker-side fault (the injected fields
@@ -711,6 +723,64 @@ func (c *Ctrl) InjectBodyFields(body []byte, resolvedModel string) ([]byte, erro
 	modifiedBody, err := json.Marshal(bodyMap)
 	if err != nil {
 		return body, errors.Wrap(err, "failed to marshal body with injected fields")
+	}
+
+	return modifiedBody, nil
+}
+
+// StripBodyFields removes the effective stripBodyFields for resolvedModel from the
+// request body's top-level object when configured, so the operator can drop
+// client-supplied params the upstream rejects (the motivating case: OpenRouter
+// 404s a request carrying logprobs/top_logprobs that the routed backend lacks).
+// The effective set is the union of the service-level and the resolved model's
+// per-entry stripBodyFields (see Service.EffectiveStripBodyFields); resolvedModel
+// is the value stamped under CtxKeyResolvedModel. Broker-critical keys (model,
+// messages, stream, stream_options, lora_adapter_name) are rejected at config
+// load, so they can never be stripped here.
+//
+// This runs BEFORE InjectBodyFields, so an operator may strip a client's value of
+// a key and then inject the server's own. It is a denylist, not an allowlist
+// derived from supportedParameters: a denylist can only remove named keys, so a
+// missing entry merely keeps 404-ing (loud) rather than silently dropping a
+// legitimate param.
+//
+// Every field actually removed is logged (with the resolved model and key) so a
+// strip — invisible to the client, which sees a plain success — is greppable on
+// our side. No-op (body returned unchanged) when the effective set is empty or
+// the body is empty; a body that is not a JSON object is forwarded unchanged and
+// logged, matching InjectBodyFields. Decoding uses json.Number so large integer
+// fields survive the round-trip unmangled.
+func (c *Ctrl) StripBodyFields(body []byte, resolvedModel string) ([]byte, error) {
+	fields := c.Service.EffectiveStripBodyFields(resolvedModel)
+	if len(fields) == 0 || len(body) == 0 {
+		return body, nil
+	}
+
+	var bodyMap map[string]interface{}
+	dec := json.NewDecoder(bytes.NewReader(body))
+	dec.UseNumber()
+	if err := dec.Decode(&bodyMap); err != nil || bodyMap == nil {
+		c.logger.Warnf("stripBodyFields configured but request body is not a JSON object; forwarding without stripping: %v", err)
+		return body, nil
+	}
+
+	stripped := false
+	for _, k := range fields {
+		if _, present := bodyMap[k]; present {
+			delete(bodyMap, k)
+			stripped = true
+			c.logger.Infof("stripped unsupported request body field %q for model %q before forwarding upstream", k, resolvedModel)
+		}
+	}
+	if !stripped {
+		// Nothing matched — avoid a needless re-marshal (which would also reorder
+		// keys); forward the original bytes unchanged.
+		return body, nil
+	}
+
+	modifiedBody, err := json.Marshal(bodyMap)
+	if err != nil {
+		return body, errors.Wrap(err, "failed to marshal body with stripped fields")
 	}
 
 	return modifiedBody, nil

--- a/api/inference/internal/ctrl/proxy_test.go
+++ b/api/inference/internal/ctrl/proxy_test.go
@@ -588,14 +588,23 @@ func TestStripBodyFields_PerModelUnionsWithServiceLevel(t *testing.T) {
 	}
 	c := &Ctrl{Service: svc, logger: testLogger(), whitelistUsers: make(map[string]struct{})}
 
-	// Model with a per-entry strip: BOTH logprobs (service) and top_logprobs (model) gone.
+	// Model with a per-entry strip: BOTH logprobs (service) and top_logprobs (model)
+	// gone. Check keys precisely — "top_logprobs" contains the substring "logprobs",
+	// so a bytes.Contains check would conflate the two.
 	body := []byte(`{"model":"zai-org/GLM-5-FP8","logprobs":true,"top_logprobs":5,"messages":[]}`)
 	got, err := c.StripBodyFields(body, "zai-org/GLM-5-FP8")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if bytes.Contains(got, []byte(`logprobs`)) {
-		t.Errorf("union strip incomplete, logprobs/top_logprobs remain: got %s", got)
+	var out map[string]interface{}
+	if err := json.Unmarshal(got, &out); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if _, present := out["logprobs"]; present {
+		t.Errorf("service-level logprobs not stripped: %#v", out)
+	}
+	if _, present := out["top_logprobs"]; present {
+		t.Errorf("per-model top_logprobs not stripped: %#v", out)
 	}
 
 	// Model without a per-entry strip: only the service-level logprobs is removed,

--- a/api/inference/internal/ctrl/proxy_test.go
+++ b/api/inference/internal/ctrl/proxy_test.go
@@ -455,6 +455,168 @@ func TestInjectBodyFields_PerModelFallsBackToServiceLevel(t *testing.T) {
 	}
 }
 
+// newTestCtrlForStripBodyFields builds a chatbot Ctrl with the given
+// service-level stripBodyFields list.
+func newTestCtrlForStripBodyFields(t *testing.T, fields []string) *Ctrl {
+	t.Helper()
+	return &Ctrl{
+		Service: config.Service{
+			Type:            "chatbot",
+			ModelType:       "zai-org/GLM-5-FP8",
+			StripBodyFields: fields,
+		},
+		logger:         testLogger(),
+		whitelistUsers: make(map[string]struct{}),
+	}
+}
+
+// A configured field present in the body is removed before forwarding; other
+// fields (including the model) are preserved untouched.
+func TestStripBodyFields_RemovesConfiguredField(t *testing.T) {
+	c := newTestCtrlForStripBodyFields(t, []string{"logprobs", "top_logprobs"})
+	body := []byte(`{"model":"zai-org/GLM-5-FP8","messages":[{"role":"user","content":"hi"}],"logprobs":true,"top_logprobs":5,"temperature":0.7}`)
+
+	got, err := c.StripBodyFields(body, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var out map[string]interface{}
+	if err := json.Unmarshal(got, &out); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if _, present := out["logprobs"]; present {
+		t.Errorf("logprobs not stripped: %#v", out)
+	}
+	if _, present := out["top_logprobs"]; present {
+		t.Errorf("top_logprobs not stripped: %#v", out)
+	}
+	if out["model"] != "zai-org/GLM-5-FP8" {
+		t.Errorf("model = %q, want it preserved", out["model"])
+	}
+	if out["temperature"] == nil {
+		t.Errorf("unrelated field temperature dropped: %#v", out)
+	}
+}
+
+// Nothing configured → body forwarded byte-for-byte unchanged.
+func TestStripBodyFields_NoopWhenUnset(t *testing.T) {
+	c := newTestCtrlForStripBodyFields(t, nil)
+	body := []byte(`{"model":"zai-org/GLM-5-FP8","logprobs":true,"messages":[]}`)
+
+	got, err := c.StripBodyFields(body, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bytes.Equal(got, body) {
+		t.Errorf("body mutated when strip unset: got %s", got)
+	}
+}
+
+// Configured field absent from the body → body forwarded byte-for-byte unchanged
+// (no needless re-marshal/key-reorder).
+func TestStripBodyFields_NoopWhenFieldAbsent(t *testing.T) {
+	c := newTestCtrlForStripBodyFields(t, []string{"logprobs"})
+	body := []byte(`{"model":"zai-org/GLM-5-FP8","temperature":0.7,"messages":[]}`)
+
+	got, err := c.StripBodyFields(body, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bytes.Equal(got, body) {
+		t.Errorf("body mutated when no configured field present: got %s", got)
+	}
+}
+
+// Empty body is returned unchanged even when stripping is configured.
+func TestStripBodyFields_NoopOnEmptyBody(t *testing.T) {
+	c := newTestCtrlForStripBodyFields(t, []string{"logprobs"})
+	got, err := c.StripBodyFields(nil, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty body, got %s", got)
+	}
+}
+
+// A non-JSON-object body is forwarded unchanged rather than erroring.
+func TestStripBodyFields_NoopOnNonJSON(t *testing.T) {
+	c := newTestCtrlForStripBodyFields(t, []string{"logprobs"})
+	body := []byte(`not json`)
+	got, err := c.StripBodyFields(body, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bytes.Equal(got, body) {
+		t.Errorf("non-JSON body mutated: got %s", got)
+	}
+}
+
+// Large integer fields elsewhere in the body survive the decode/re-marshal
+// round-trip (UseNumber) when a strip does occur.
+func TestStripBodyFields_PreservesLargeInteger(t *testing.T) {
+	c := newTestCtrlForStripBodyFields(t, []string{"logprobs"})
+	body := []byte(`{"model":"glm-5","seed":9007199254740993,"logprobs":true,"messages":[]}`)
+
+	got, err := c.StripBodyFields(body, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bytes.Contains(got, []byte(`9007199254740993`)) {
+		t.Errorf("large integer seed not preserved verbatim: got %s", got)
+	}
+	if bytes.Contains(got, []byte(`logprobs`)) {
+		t.Errorf("logprobs not stripped: got %s", got)
+	}
+}
+
+// The effective strip set is the UNION of service-level and per-model lists: a
+// request resolved to a model gets both stripped.
+func TestStripBodyFields_PerModelUnionsWithServiceLevel(t *testing.T) {
+	svc := config.Service{
+		Type:            "chatbot",
+		ProviderType:    "centralized",
+		ModelType:       "zai-org/GLM-5-FP8",
+		StripBodyFields: []string{"logprobs"},
+		ModelPricing: []config.ModelPricingEntry{
+			{Model: "zai-org/GLM-5-FP8", StripBodyFields: []string{"top_logprobs"}},
+			{Model: "deepseek-v4-flash"}, // no per-entry strip → service-level only
+		},
+	}
+	if err := svc.BuildModelPricingMap(); err != nil {
+		t.Fatalf("BuildModelPricingMap: %v", err)
+	}
+	c := &Ctrl{Service: svc, logger: testLogger(), whitelistUsers: make(map[string]struct{})}
+
+	// Model with a per-entry strip: BOTH logprobs (service) and top_logprobs (model) gone.
+	body := []byte(`{"model":"zai-org/GLM-5-FP8","logprobs":true,"top_logprobs":5,"messages":[]}`)
+	got, err := c.StripBodyFields(body, "zai-org/GLM-5-FP8")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if bytes.Contains(got, []byte(`logprobs`)) {
+		t.Errorf("union strip incomplete, logprobs/top_logprobs remain: got %s", got)
+	}
+
+	// Model without a per-entry strip: only the service-level logprobs is removed,
+	// top_logprobs is left intact.
+	body2 := []byte(`{"model":"deepseek-v4-flash","logprobs":true,"top_logprobs":5,"messages":[]}`)
+	got2, err := c.StripBodyFields(body2, "deepseek-v4-flash")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var out2 map[string]interface{}
+	if err := json.Unmarshal(got2, &out2); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if _, present := out2["logprobs"]; present {
+		t.Errorf("service-level logprobs not stripped: %#v", out2)
+	}
+	if _, present := out2["top_logprobs"]; !present {
+		t.Errorf("top_logprobs wrongly stripped for model without per-entry strip: %#v", out2)
+	}
+}
+
 func TestDecodeErrorBody(t *testing.T) {
 	const payload = `{"error":{"message":"upstream boom"}}`
 


### PR DESCRIPTION
## Why

Real failed chatbot requests were carrying params we never advertise (e.g. `logprobs` / `top_logprobs`). When the OpenRouter-routed backend doesn't support such a param, OpenRouter **404s the whole request**. The fix: strip these client/upstream-stuffed params on the broker side instead of relying on the upstream to reject them.

## What

A new explicit `stripBodyFields` denylist — service-level and per-model — that removes named top-level keys from the chatbot request body before forwarding upstream. It's the surgical counterpart of `injectBodyFields`.

`1-glm-openrouter` lands in one block:

```yaml
service:
  stripBodyFields:
    - logprobs
    - top_logprobs
```

## Why a denylist, not an allowlist from `supportedParameters`

`modelInfo.supportedParameters` advertises **sampling capabilities** for `/v1/models` (aligned with OpenRouter's `supported_parameters`). It is *not* an exhaustive set of legal body keys. Using it to strip would silently drop legitimate params — `max_completion_tokens`, `n`, `tools`, `response_format`, `parallel_tool_calls`, `reasoning_effort`, … — i.e. the exact silent-request-mangling failure mode we've been fighting, but this time done by our own code.

A denylist is safe-by-construction: it can only remove keys the operator names. Worst case = a missed param keeps 404-ing (**loud, discoverable, one-line fix**), never a legitimate request silently broken.

## Guardrails

- **Union, not override**: service + per-model lists are UNIONed (`EffectiveStripBodyFields`) — a key removed at either level is removed. (Contrast `injectBodyFields`, which deep-merges.)
- **Protected keys rejected at load**: `model` / `messages` / `stream` / `stream_options` / `lora_adapter_name`, reusing `protectedInjectBodyFields`.
- **Observable**: every field actually removed is logged with `model` + key — a strip is silent to the client but greppable for us.
- **Order**: client body → **strip** → `injectBodyFields` → forward, so a stripped value can be re-set by injection. Decodes with `json.Number` so large integers (seed, tool args) survive the round-trip.
- **Chatbot-only**; rejected at config load on other service types.

## Tests

- `config`: load + normalize (trim/dedup), non-chatbot rejection, protected-key rejection.
- `ctrl`: removes configured field, byte-for-byte no-op when unset / field absent / empty / non-JSON, large-integer preservation, and service ∪ per-model union (incl. a model with no per-entry strip getting only the service-level removal).

`go build ./...`, `go vet`, and the `config` + `ctrl` package tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)