### PR TITLE
feat(inference): translate max_completion_tokens <-> max_tokens per supportedParameters

### DIFF
--- a/api/inference/config/config.go
+++ b/api/inference/config/config.go
@@ -179,6 +179,28 @@ func (s *Service) ModelExpiration(model string) (time.Time, bool) {
 	return time.Time{}, false
 }
 
+// EffectiveModelInfo resolves the ModelInfo that applies to a request for the
+// given model, or nil when none is configured. Resolution mirrors ModelExpiration
+// and the /v1/models metadata: in multi-model mode a per-model pricing entry's own
+// ModelInfo wins wholesale (resolved alias-aware via ResolveRequestedModel, so a
+// legacy alias is subject to the same metadata as its canonical id), otherwise the
+// service-level ModelInfo applies; an unknown multi-model id with no wildcard entry
+// resolves to nil — it is not a model this service serves. In single-model mode the
+// service-level ModelInfo is returned regardless of the requested name.
+func (s *Service) EffectiveModelInfo(model string) *ModelInfo {
+	mi := s.ModelInfo
+	if s.HasMultiModelPricing() {
+		entry, _, ok := s.ResolveRequestedModel(model)
+		if !ok || entry == nil {
+			return nil
+		}
+		if entry.ModelInfo != nil {
+			mi = entry.ModelInfo
+		}
+	}
+	return mi
+}
+
 type Service struct {
 	ServingURL  string `yaml:"servingUrl"`
 	TargetURL   string `yaml:"targetUrl"`

--- a/api/inference/internal/ctrl/max_tokens.go
+++ b/api/inference/internal/ctrl/max_tokens.go
@@ -1,0 +1,121 @@
+package ctrl
+
+// This file implements output-token-cap translation: re-expressing a client's
+// portable OpenAI output-token limit (max_tokens / max_completion_tokens) under
+// whichever of the two field names the target model actually accepts. The
+// accepted field is picked from the model's advertised supportedParameters; the
+// motivating case is DeepSeek-on-vLLM, which accepts only max_tokens and rejects
+// the newer max_completion_tokens an OpenAI-compatible client sends.
+
+import (
+	"bytes"
+	"encoding/json"
+
+	"github.com/0glabs/0g-serving-broker/common/errors"
+)
+
+// Output-token-cap field names. Both express the same thing — a cap on generated
+// output tokens — but belong to different generations of the OpenAI
+// chat-completions schema: max_tokens is the original (now deprecated) field,
+// max_completion_tokens its replacement. Some upstreams accept only one.
+const (
+	maxTokensKey           = "max_tokens"
+	maxCompletionTokensKey = "max_completion_tokens"
+)
+
+// TranslateMaxTokens rewrites a chatbot request body so the client's output-token
+// cap is expressed under the field name the target model accepts. resolvedModel is
+// the public/canonical id the broker resolved the request to (CtxKeyResolvedModel)
+// — NOT the body's "model" field, which ValidateModelAllowlist may have already
+// rewritten to the upstream id; the accepted field is detected from THAT model's
+// advertised supportedParameters (an empty resolvedModel selects the service-level
+// ModelInfo, matching Inject/StripBodyFields):
+//
+//   - a model that advertises max_tokens but NOT max_completion_tokens has a
+//     client-sent max_completion_tokens renamed to max_tokens (the DeepSeek-on-
+//     vLLM case: the upstream rejects the unknown max_completion_tokens);
+//   - the mirror also holds — max_tokens is renamed to max_completion_tokens for a
+//     model that advertises only the newer field.
+//
+// It returns the body unchanged when:
+//   - the body is empty or not a JSON object (mirrors EnsureStreamOptions);
+//   - the resolved model has no ModelInfo (no supportedParameters to detect from);
+//   - the model advertises both fields, or neither (no single target to pick);
+//   - the source field that would be translated FROM is absent from the body.
+//
+// The two fields share identical semantics (a max-output-tokens cap), so the
+// value is moved verbatim — billing is unaffected and the cap is preserved. When
+// the destination field is ALSO present (a client that sent both), the client's
+// destination value is kept and only the source is removed (it would otherwise be
+// rejected upstream); the dropped source is logged (name only, never the value).
+//
+// Decoding uses json.Number so large integer fields elsewhere in the body (e.g. a
+// seed) survive the round-trip unmangled, matching Inject/StripBodyFields.
+func (c *Ctrl) TranslateMaxTokens(body []byte, resolvedModel string) ([]byte, error) {
+	if len(body) == 0 {
+		return body, nil
+	}
+
+	mi := c.Service.EffectiveModelInfo(resolvedModel)
+	if mi == nil {
+		return body, nil
+	}
+	supportsMax := containsParam(mi.SupportedParameters, maxTokensKey)
+	supportsCompletion := containsParam(mi.SupportedParameters, maxCompletionTokensKey)
+	if supportsMax == supportsCompletion {
+		// Advertises both (accepts either) or neither (cannot tell which the upstream
+		// wants): no single target to translate to, so skip parsing entirely and
+		// forward unchanged.
+		return body, nil
+	}
+
+	var bodyMap map[string]interface{}
+	dec := json.NewDecoder(bytes.NewReader(body))
+	dec.UseNumber()
+	// A literal JSON `null` decodes to a nil map without error; treat it the same
+	// as a non-object body and forward unchanged.
+	if err := dec.Decode(&bodyMap); err != nil || bodyMap == nil {
+		return body, nil
+	}
+
+	// Exactly one of the two is advertised (the equal case returned above), so the
+	// target is unambiguous: rename FROM the field the upstream does not accept TO
+	// the one it does.
+	from, to := maxCompletionTokensKey, maxTokensKey
+	if supportsCompletion {
+		from, to = maxTokensKey, maxCompletionTokensKey
+	}
+
+	v, ok := bodyMap[from]
+	if !ok {
+		// Client did not send the field that would need translating.
+		return body, nil
+	}
+	delete(bodyMap, from)
+	if _, exists := bodyMap[to]; exists {
+		// Client sent BOTH fields. The destination is the form the upstream accepts,
+		// so keep the client's explicit value there and drop only the source (which
+		// the upstream would reject). Log the dropped source so a surprising cap is
+		// debuggable; never log the value.
+		c.logger.Infof("translateMaxTokens: request for model %q sent both %q and %q; forwarding %q and dropping unsupported %q", resolvedModel, from, to, to, from)
+	} else {
+		bodyMap[to] = v
+	}
+
+	modified, err := json.Marshal(bodyMap)
+	if err != nil {
+		return body, errors.Wrap(err, "failed to marshal max-tokens-translated body")
+	}
+	return modified, nil
+}
+
+// containsParam reports whether params contains name. Matching is exact and
+// case-sensitive: supportedParameters entries are upstream wire field names.
+func containsParam(params []string, name string) bool {
+	for _, p := range params {
+		if p == name {
+			return true
+		}
+	}
+	return false
+}

--- a/api/inference/internal/ctrl/max_tokens_test.go
+++ b/api/inference/internal/ctrl/max_tokens_test.go
@@ -1,0 +1,262 @@
+package ctrl
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/0glabs/0g-serving-broker/inference/config"
+)
+
+// newTestCtrlForMaxTokens builds a single-model chatbot Ctrl whose model
+// advertises the given supportedParameters. A nil slice means no ModelInfo at all
+// (the "no metadata to detect from" case).
+func newTestCtrlForMaxTokens(t *testing.T, supportedParams []string) *Ctrl {
+	t.Helper()
+	var mi *config.ModelInfo
+	if supportedParams != nil {
+		mi = &config.ModelInfo{SupportedParameters: supportedParams}
+	}
+	return &Ctrl{
+		Service: config.Service{
+			Type:      "chatbot",
+			ModelType: "deepseek-op",
+			ModelInfo: mi,
+		},
+		logger:         testLogger(),
+		whitelistUsers: make(map[string]struct{}),
+	}
+}
+
+// decodeBodyMap unmarshals a translated body and fails the test on bad JSON.
+func decodeBodyMap(t *testing.T, b []byte) map[string]interface{} {
+	t.Helper()
+	var out map[string]interface{}
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("translated body is not valid JSON: %v", err)
+	}
+	return out
+}
+
+// The motivating case: the model advertises only max_tokens, the client sends
+// max_completion_tokens — it is renamed, value preserved, source removed.
+func TestTranslateMaxTokens_CompletionToMaxTokens(t *testing.T) {
+	c := newTestCtrlForMaxTokens(t, []string{"temperature", "max_tokens"})
+	body := []byte(`{"model":"deepseek-op","messages":[],"max_completion_tokens":500}`)
+
+	got, err := c.TranslateMaxTokens(body, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := decodeBodyMap(t, got)
+	if _, present := out["max_completion_tokens"]; present {
+		t.Errorf("max_completion_tokens should have been removed, got %#v", out["max_completion_tokens"])
+	}
+	if out["max_tokens"] != float64(500) {
+		t.Errorf("max_tokens = %#v, want 500", out["max_tokens"])
+	}
+}
+
+// The mirror direction: a model advertising only max_completion_tokens gets a
+// client's deprecated max_tokens renamed forward.
+func TestTranslateMaxTokens_MaxToCompletion(t *testing.T) {
+	c := newTestCtrlForMaxTokens(t, []string{"max_completion_tokens"})
+	body := []byte(`{"model":"deepseek-op","max_tokens":256}`)
+
+	got, err := c.TranslateMaxTokens(body, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := decodeBodyMap(t, got)
+	if _, present := out["max_tokens"]; present {
+		t.Errorf("max_tokens should have been removed, got %#v", out["max_tokens"])
+	}
+	if out["max_completion_tokens"] != float64(256) {
+		t.Errorf("max_completion_tokens = %#v, want 256", out["max_completion_tokens"])
+	}
+}
+
+// When the model advertises BOTH fields, the upstream accepts either, so the body
+// is forwarded byte-for-byte unchanged.
+func TestTranslateMaxTokens_NoopWhenBothAdvertised(t *testing.T) {
+	c := newTestCtrlForMaxTokens(t, []string{"max_tokens", "max_completion_tokens"})
+	body := []byte(`{"model":"deepseek-op","max_completion_tokens":500}`)
+
+	got, err := c.TranslateMaxTokens(body, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(got) != string(body) {
+		t.Errorf("body changed; got %s, want unchanged", got)
+	}
+}
+
+// When the model advertises NEITHER field, the broker cannot tell which form the
+// upstream wants, so it forwards unchanged.
+func TestTranslateMaxTokens_NoopWhenNeitherAdvertised(t *testing.T) {
+	c := newTestCtrlForMaxTokens(t, []string{"temperature", "top_p"})
+	body := []byte(`{"model":"deepseek-op","max_completion_tokens":500}`)
+
+	got, err := c.TranslateMaxTokens(body, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(got) != string(body) {
+		t.Errorf("body changed; got %s, want unchanged", got)
+	}
+}
+
+// The source field is absent: the client already sent the form the model accepts,
+// so nothing is translated.
+func TestTranslateMaxTokens_NoopWhenSourceAbsent(t *testing.T) {
+	c := newTestCtrlForMaxTokens(t, []string{"max_tokens"})
+	body := []byte(`{"model":"deepseek-op","max_tokens":128}`)
+
+	got, err := c.TranslateMaxTokens(body, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(got) != string(body) {
+		t.Errorf("body changed; got %s, want unchanged", got)
+	}
+}
+
+// Client sent BOTH the source and destination: the destination (the form the
+// upstream accepts) is kept with the client's value, and only the unsupported
+// source is dropped.
+func TestTranslateMaxTokens_BothPresentKeepsDestination(t *testing.T) {
+	c := newTestCtrlForMaxTokens(t, []string{"max_tokens"})
+	body := []byte(`{"model":"deepseek-op","max_tokens":128,"max_completion_tokens":500}`)
+
+	got, err := c.TranslateMaxTokens(body, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := decodeBodyMap(t, got)
+	if _, present := out["max_completion_tokens"]; present {
+		t.Errorf("unsupported max_completion_tokens should have been dropped, got %#v", out["max_completion_tokens"])
+	}
+	if out["max_tokens"] != float64(128) {
+		t.Errorf("max_tokens = %#v, want the client's explicit 128 kept", out["max_tokens"])
+	}
+}
+
+// A large integer field elsewhere in the body (e.g. seed) must survive the
+// decode/re-encode round-trip without float64 mangling (json.Number / UseNumber).
+func TestTranslateMaxTokens_PreservesLargeInteger(t *testing.T) {
+	c := newTestCtrlForMaxTokens(t, []string{"max_tokens"})
+	body := []byte(`{"model":"deepseek-op","seed":9007199254740993,"max_completion_tokens":500}`)
+
+	got, err := c.TranslateMaxTokens(body, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	dec := json.NewDecoder(bytes.NewReader(got))
+	dec.UseNumber()
+	var out map[string]interface{}
+	if err := dec.Decode(&out); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if n, ok := out["seed"].(json.Number); !ok || n.String() != "9007199254740993" {
+		t.Errorf("seed = %#v, want 9007199254740993 preserved exactly", out["seed"])
+	}
+}
+
+// No ModelInfo at all → nothing to detect from → forward unchanged.
+func TestTranslateMaxTokens_NoopWhenNoModelInfo(t *testing.T) {
+	c := newTestCtrlForMaxTokens(t, nil)
+	body := []byte(`{"model":"deepseek-op","max_completion_tokens":500}`)
+
+	got, err := c.TranslateMaxTokens(body, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(got) != string(body) {
+		t.Errorf("body changed; got %s, want unchanged", got)
+	}
+}
+
+// Empty and non-JSON bodies pass through untouched (mirrors the other rewriters).
+func TestTranslateMaxTokens_NoopOnEmptyOrNonJSON(t *testing.T) {
+	c := newTestCtrlForMaxTokens(t, []string{"max_tokens"})
+	for _, body := range [][]byte{nil, []byte(""), []byte("not json"), []byte("null"), []byte("[1,2,3]")} {
+		got, err := c.TranslateMaxTokens(body, "")
+		if err != nil {
+			t.Fatalf("unexpected error for %q: %v", body, err)
+		}
+		if string(got) != string(body) {
+			t.Errorf("body %q changed to %q, want unchanged", body, got)
+		}
+	}
+}
+
+// Multi-model: detection resolves per-model ModelInfo, so each model's own
+// supportedParameters governs whether its request is translated.
+func TestTranslateMaxTokens_MultiModelPerModelDetection(t *testing.T) {
+	svc := config.Service{
+		Type:         "chatbot",
+		ProviderType: "centralized",
+		ModelType:    "deepseek-op",
+		ModelPricing: []config.ModelPricingEntry{
+			{Model: "deepseek-op", ModelInfo: &config.ModelInfo{SupportedParameters: []string{"max_tokens"}}},
+			{Model: "modern-model", ModelInfo: &config.ModelInfo{SupportedParameters: []string{"max_tokens", "max_completion_tokens"}}},
+		},
+	}
+	if err := svc.BuildModelPricingMap(); err != nil {
+		t.Fatalf("BuildModelPricingMap: %v", err)
+	}
+	c := &Ctrl{Service: svc, logger: testLogger(), whitelistUsers: make(map[string]struct{})}
+
+	// deepseek-op advertises only max_tokens → translate. The lookup is keyed on
+	// the resolved public id (CtxKeyResolvedModel), not the body's model field.
+	got, err := c.TranslateMaxTokens([]byte(`{"model":"deepseek-op","max_completion_tokens":500}`), "deepseek-op")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := decodeBodyMap(t, got)
+	if out["max_tokens"] != float64(500) || out["max_completion_tokens"] != nil {
+		t.Errorf("deepseek-op: got %#v, want max_tokens=500 and no max_completion_tokens", out)
+	}
+
+	// modern-model advertises both → no-op.
+	body := []byte(`{"model":"modern-model","max_completion_tokens":500}`)
+	got, err = c.TranslateMaxTokens(body, "modern-model")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(got) != string(body) {
+		t.Errorf("modern-model: body changed; got %s, want unchanged", got)
+	}
+}
+
+// Regression for the model-id-source bug: in multi-model mode ValidateModelAllowlist
+// rewrites the body's "model" field to the entry's UPSTREAM id before this runs, so
+// the supportedParameters lookup must key on the resolved PUBLIC id (passed in), not
+// the body. Here the entry advertises only max_tokens but forwards under a distinct
+// upstream id; translation must still fire.
+func TestTranslateMaxTokens_MultiModelUpstreamModelRewrite(t *testing.T) {
+	svc := config.Service{
+		Type:         "chatbot",
+		ProviderType: "centralized",
+		ModelType:    "deepseek-op",
+		ModelPricing: []config.ModelPricingEntry{
+			{Model: "deepseek-op", UpstreamModel: "vllm-internal-id", ModelInfo: &config.ModelInfo{SupportedParameters: []string{"max_tokens"}}},
+		},
+	}
+	if err := svc.BuildModelPricingMap(); err != nil {
+		t.Fatalf("BuildModelPricingMap: %v", err)
+	}
+	c := &Ctrl{Service: svc, logger: testLogger(), whitelistUsers: make(map[string]struct{})}
+
+	// Body's model has already been rewritten to the upstream id (which is NOT a
+	// pricing-map key); resolvedModel carries the public id.
+	body := []byte(`{"model":"vllm-internal-id","max_completion_tokens":500}`)
+	got, err := c.TranslateMaxTokens(body, "deepseek-op")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := decodeBodyMap(t, got)
+	if out["max_tokens"] != float64(500) || out["max_completion_tokens"] != nil {
+		t.Errorf("got %#v, want translation to fire (max_tokens=500, no max_completion_tokens) keyed on the public id", out)
+	}
+}

--- a/api/inference/internal/ctrl/proxy.go
+++ b/api/inference/internal/ctrl/proxy.go
@@ -78,13 +78,28 @@ func (c *Ctrl) PrepareHTTPRequest(ctx *gin.Context, targetURL string, reqBody []
 			ctx.Set(CtxKeyResolvedModel, c.Service.ModelType)
 		}
 
-		// Merge operator-configured upstream body fields (e.g. OpenRouter's
-		// "provider" routing object, or a per-model max_price cap). No-op unless
-		// service- or per-model injectBodyFields is configured. Runs after model
-		// rewrite so the body is final JSON and CtxKeyResolvedModel is set (for
-		// multi-model providers; empty otherwise → service-level fields only).
+		// resolvedModel is the public/canonical id stamped by the model-handling
+		// branches above (ValidateModelAllowlist for multi-model, the single-model
+		// rewrite path otherwise). It keys per-model config lookups. Read it here so
+		// it is available to TranslateMaxTokens as well as Strip/InjectBodyFields —
+		// the body's "model" field may have been rewritten to the UPSTREAM id by
+		// ValidateModelAllowlist, so per-model lookups must use this, not the body.
+		// Empty for a single-model provider with no rewrite trigger (resolved to the
+		// default later); Effective* lookups treat "" as the service-level config.
 		resolvedModelVal, _ := ctx.Get(CtxKeyResolvedModel)
 		resolvedModelStr, _ := resolvedModelVal.(string)
+
+		// Translate the output-token cap to the field name the target model accepts
+		// (max_tokens vs max_completion_tokens), detected from its advertised
+		// supportedParameters — the DeepSeek-on-vLLM case rejects the newer
+		// max_completion_tokens an OpenAI-compatible client sends. No-op unless the
+		// model advertises exactly one of the two and the client sent the other. The
+		// two fields are semantically identical, so billing is unaffected.
+		modifiedBody, err = c.TranslateMaxTokens(reqBody, resolvedModelStr)
+		if err != nil {
+			return nil, errors.Wrap(err, "translate max tokens")
+		}
+		reqBody = modifiedBody
 
 		// Strip operator-denylisted client params (e.g. logprobs/top_logprobs the
 		// routed upstream rejects) BEFORE injecting server fields, so a stripped


### PR DESCRIPTION
## What

Adds output-token-cap translation to the inference broker's chatbot forward path: the broker re-expresses a client's output-token limit under whichever of `max_tokens` / `max_completion_tokens` the target model actually accepts, picked from the model's advertised `supportedParameters`.

## Why

DeepSeek-on-vLLM (and similar upstreams) accept only `max_tokens` and reject the newer `max_completion_tokens` that OpenAI-compatible clients now send — 4xx-ing the whole request. Rather than forcing every client to special-case the provider, the broker translates the field name before forwarding. The two fields are semantically identical output-token caps, so the value is moved verbatim and **billing is unaffected** (billing reads response `usage`, not the request body).

This mirrors the team's agreed "translation" approach (detect the accepted form from `supportedParameters`) — operators only need to list the correct field in `modelInfo.supportedParameters`; no new config knob.

## How

- **`internal/ctrl/max_tokens.go`** (new) — `TranslateMaxTokens(body, resolvedModel)`:
  - Detects which field the model accepts via `supportedParameters`.
  - If it advertises exactly one of the two, renames the client's other field to it (value moved verbatim, source removed). No-op when it advertises both (accepts either) or neither.
  - Keys the lookup on the **resolved public model id**, not the body's `model` field (which `ValidateModelAllowlist` may have rewritten to the upstream id).
  - Decodes with `json.Number` (`UseNumber`) so large integers elsewhere in the body survive; both-fields-present keeps the client's destination value and logs the dropped source by name only.
- **`config/config.go`** — `Service.EffectiveModelInfo(model)`: resolves the effective `ModelInfo` for a request (alias-aware in multi-model mode, service-level otherwise), mirroring `ModelExpiration`.
- **`internal/ctrl/proxy.go`** — wires `TranslateMaxTokens` into `PrepareHTTPRequest` after model resolution and before `Strip/InjectBodyFields`, passing the resolved id.
- **`internal/ctrl/max_tokens_test.go`** (new) — 11 tests: both translation directions, both/neither-advertised no-ops, both-present collision, large-integer preservation, empty/non-JSON, nil ModelInfo, multi-model per-model detection, and a regression test for the `upstreamModel` rewrite case.

## Testing

`go build ./...`, `go test ./inference/internal/ctrl/ ./inference/config/`, `go vet`, and `gofmt` all clean.

Reviewed via three rounds of multi-dimension deep-review (general / security-differential / silent-failure / sharp-edges); one HIGH found and fixed (lookup was keying on the rewritten body model id), then two consecutive HIGH-clean passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)