### PR TITLE
feat(inference): off-chain USD credit billing components

### DIFF
--- a/api/inference/cmd/event/main.go
+++ b/api/inference/cmd/event/main.go
@@ -91,18 +91,25 @@ func Main() {
 	// the cache and the PriceUpdateProcessor.
 	ctrl := ctrl.New(db, contract, conf, nil, teeService, nil, logger)
 
-	settlementProcessor := event.NewSettlementProcessor(ctrl, conf.Interval.SettlementProcessor, conf.Interval.ForceSettlementProcessor, conf.Monitor.Enable, logger)
-	if err := mgr.Add(settlementProcessor); err != nil {
-		panic(err)
-	}
-
-	// Add reconciliation processor for event-based settlement verification
-	if conf.Interval.ReconciliationProcessor > 0 {
-		reconciliationProcessor := event.NewReconciliationProcessor(db, contract, conf.Interval.ReconciliationProcessor, logger)
-		if err := mgr.Add(reconciliationProcessor); err != nil {
+	// Credit providers bill off-chain via the credit service and never settle
+	// on-chain, so the on-chain settlement and reconciliation processors are
+	// disabled entirely.
+	if conf.Service.CreditBilling.Enable {
+		logger.Info("credit billing enabled: on-chain settlement and reconciliation processors disabled")
+	} else {
+		settlementProcessor := event.NewSettlementProcessor(ctrl, conf.Interval.SettlementProcessor, conf.Interval.ForceSettlementProcessor, conf.Monitor.Enable, logger)
+		if err := mgr.Add(settlementProcessor); err != nil {
 			panic(err)
 		}
-		logger.Infof("Starting reconciliation processor: interval=%s", conf.Interval.ReconciliationProcessor)
+
+		// Add reconciliation processor for event-based settlement verification
+		if conf.Interval.ReconciliationProcessor > 0 {
+			reconciliationProcessor := event.NewReconciliationProcessor(db, contract, conf.Interval.ReconciliationProcessor, logger)
+			if err := mgr.Add(reconciliationProcessor); err != nil {
+				panic(err)
+			}
+			logger.Infof("Starting reconciliation processor: interval=%s", conf.Interval.ReconciliationProcessor)
+		}
 	}
 
 	// Add revenue transfer processor if configured

--- a/api/inference/cmd/server/main.go
+++ b/api/inference/cmd/server/main.go
@@ -156,9 +156,13 @@ func Main() {
 	if err := ctrl.SyncUserAccounts(ctx); err != nil {
 		panic(err)
 	}
-	settleFeesErr := ctrl.SettleFeesWithTEE(ctx)
-	if settleFeesErr != nil {
-		logger.Errorf("error settling fees: %v", settleFeesErr)
+	// Credit providers bill off-chain via the credit service and never settle
+	// on-chain, so skip the boot-time settlement sweep entirely.
+	if !config.Service.CreditBilling.Enable {
+		settleFeesErr := ctrl.SettleFeesWithTEE(ctx)
+		if settleFeesErr != nil {
+			logger.Errorf("error settling fees: %v", settleFeesErr)
+		}
 	}
 	// At startup, USD providers use SyncServiceWithPrices — the same full
 	// identicalService comparison as NATIVE's SyncService, but with the

--- a/api/inference/config/config.go
+++ b/api/inference/config/config.go
@@ -280,6 +280,12 @@ type Service struct {
 	// yield wei-per-image. Mirrors OutputPriceUSDPerSecond for video. See validate.
 	OutputPriceUSDPerImage string `yaml:"outputPriceUSDPerImage"`
 
+	// CreditBilling configures off-chain USD credit billing for this service.
+	// When enabled the broker bills via the credit service (TEE-signed micro-USD
+	// receipts) instead of on-chain settlement. Requires USD denomination and
+	// (currently) the chatbot service type. See validate and CreditBillingConfig.
+	CreditBilling CreditBillingConfig `yaml:"creditBilling"`
+
 	// ModelPricing defines per-model pricing for centralized providers that serve multiple models.
 	// When configured, the broker validates requested models against this allowlist
 	// and bills at model-specific rates instead of the single on-chain price.
@@ -623,7 +629,6 @@ type Config struct {
 	ProviderHttp        ProviderHttpConfig      `yaml:"providerHttp"`
 	ConcurrencyLimit    ConcurrencyLimitConfig  `yaml:"concurrencyLimit"`
 	UserUsageStats      UserUsageStatsConfig    `yaml:"userUsageStats"`
-	CreditBilling       CreditBillingConfig     `yaml:"creditBilling"`
 	// AllowTokenBilledSpeechToText opens the billing path for token-billed
 	// speech-to-text models (gpt-4o-transcribe, gpt-4o-mini-transcribe).
 	// Defaults to false.
@@ -851,6 +856,7 @@ func validatePricingTiers(prefix string, tiers []PricingTier) error {
 //   - lora_adapter_name: the broker derives this from an ft-* model during LoRA
 //     request rewriting (see RewriteLoRARequest); injecting it would clobber the
 //     resolved adapter.
+//
 // Injecting any of these is rejected at config load (fail loud, not silent).
 var protectedInjectBodyFields = map[string]struct{}{
 	"model":             {},
@@ -1318,6 +1324,28 @@ func loadConfig(cfg *Config) error {
 			return err
 		}
 		cfg.Service.StripBodyFields = normalized
+	}
+
+	// Off-chain credit billing. When enabled the broker bills via the credit
+	// service (TEE-signed micro-USD receipts) instead of on-chain settlement, so
+	// it requires: an endpoint, USD price denomination (the receipt fee is
+	// micro-USD derived from the USD-per-million prices), a non-negative balance
+	// threshold, and — for now — the chatbot service type. Other service types'
+	// USD-unit billing is not yet wired into the credit path; fail-stop rather
+	// than serve them unbilled.
+	if cfg.Service.CreditBilling.Enable {
+		if cfg.Service.CreditBilling.Endpoint == "" {
+			return fmt.Errorf("invalid config: service.creditBilling.endpoint is required when creditBilling.enable is true")
+		}
+		if cfg.Service.Type != constant.ServiceTypeChatbot {
+			return fmt.Errorf("invalid config: service.creditBilling is currently only supported for service type '%s', got '%s'", constant.ServiceTypeChatbot, cfg.Service.Type)
+		}
+		if cfg.Service.PriceDenomination != constant.PriceDenominationUSD {
+			return fmt.Errorf("invalid config: service.creditBilling requires service.priceDenomination '%s', got '%s'", constant.PriceDenominationUSD, cfg.Service.PriceDenomination)
+		}
+		if cfg.Service.CreditBilling.MinBalanceMicroUsd < 0 {
+			return fmt.Errorf("invalid config: service.creditBilling.minBalanceMicroUsd must be >= 0, got %d", cfg.Service.CreditBilling.MinBalanceMicroUsd)
+		}
 	}
 
 	// Provider display metadata (applies to any provider type). Both are optional.

--- a/api/inference/config/config.go
+++ b/api/inference/config/config.go
@@ -1346,6 +1346,14 @@ func loadConfig(cfg *Config) error {
 		if cfg.Service.CreditBilling.MinBalanceMicroUsd < 0 {
 			return fmt.Errorf("invalid config: service.creditBilling.minBalanceMicroUsd must be >= 0, got %d", cfg.Service.CreditBilling.MinBalanceMicroUsd)
 		}
+		// Credit billing uses a single service-level price (creditInMicro/Out).
+		// modelPricing would make the service-level USD fields the max-over-models
+		// ceiling, so the credit path would bill every model at the most expensive
+		// model's price. Reject the combination until per-model credit pricing is
+		// implemented, rather than silently overcharge.
+		if len(cfg.Service.ModelPricing) > 0 {
+			return fmt.Errorf("invalid config: service.creditBilling is not yet supported together with service.modelPricing (would bill every model at the max-over-models price)")
+		}
 	}
 
 	// Provider display metadata (applies to any provider type). Both are optional.

--- a/api/inference/config/config.go
+++ b/api/inference/config/config.go
@@ -623,6 +623,7 @@ type Config struct {
 	ProviderHttp        ProviderHttpConfig      `yaml:"providerHttp"`
 	ConcurrencyLimit    ConcurrencyLimitConfig  `yaml:"concurrencyLimit"`
 	UserUsageStats      UserUsageStatsConfig    `yaml:"userUsageStats"`
+	CreditBilling       CreditBillingConfig     `yaml:"creditBilling"`
 	// AllowTokenBilledSpeechToText opens the billing path for token-billed
 	// speech-to-text models (gpt-4o-transcribe, gpt-4o-mini-transcribe).
 	// Defaults to false.
@@ -728,6 +729,27 @@ type ProviderHttpConfig struct {
 type LogPathsConfig struct {
 	BrokerLogDir string `yaml:"brokerLogDir"`
 	EventLogDir  string `yaml:"eventLogDir"`
+}
+
+// CreditBillingConfig configures off-chain USD credit billing via the
+// centralized credit service. When Enable is false (default), the broker bills
+// purely on-chain and this config is ignored — on-chain users are unaffected.
+//
+// When enabled, admission checks balance from Endpoint instead of on-chain lock
+// balance, and per-request fees are settled by submitting a TEE-signed receipt
+// to the credit service (see internal/creditbilling). Prices come from the
+// service's USD pricing config; PriceDenomination must be "USD".
+type CreditBillingConfig struct {
+	// Enable turns on off-chain credit billing for this provider.
+	Enable bool `yaml:"enable"`
+	// Endpoint is the credit service base URL (the authenticated central domain).
+	Endpoint string `yaml:"endpoint"`
+	// Timeout bounds each call to the credit service. Defaults to 5s.
+	Timeout time.Duration `yaml:"timeout"`
+	// MinBalanceMicroUsd is the admission threshold in micro-USD (1 USD = 1e6).
+	// Requests are rejected (fail-closed) below this, or if the service is
+	// unreachable.
+	MinBalanceMicroUsd int64 `yaml:"minBalanceMicroUsd"`
 }
 
 // ControllerConfig Controller service configuration

--- a/api/inference/internal/creditbilling/client.go
+++ b/api/inference/internal/creditbilling/client.go
@@ -1,0 +1,122 @@
+package creditbilling
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// ErrInsufficientBalance is returned by Deduct when the credit service reports
+// the user cannot afford the request (HTTP 402 Payment Required). Nothing was
+// charged. The caller MUST reject the request (fail-closed) and MUST NOT serve a
+// response.
+var ErrInsufficientBalance = errors.New("insufficient credit balance")
+
+// Client talks to the centralized credit service over HTTP.
+//
+// FAIL-CLOSED CONTRACT: callers MUST treat any non-nil error from Balance or
+// Deduct — including ErrInsufficientBalance, timeouts, and non-2xx responses —
+// as "reject this request". Never serve a response when balance/deduct errored;
+// the credit service is the authority on whether the user can pay.
+type Client struct {
+	endpoint   string
+	httpClient *http.Client
+}
+
+// NewClient builds a credit-service client. endpoint is the service base URL
+// (e.g. https://credit.internal); timeout bounds each call.
+func NewClient(endpoint string, timeout time.Duration) *Client {
+	if timeout <= 0 {
+		timeout = 5 * time.Second
+	}
+	return &Client{
+		endpoint: endpoint,
+		httpClient: &http.Client{
+			Timeout: timeout,
+			Transport: &http.Transport{
+				MaxIdleConns:        100,
+				MaxIdleConnsPerHost: 10,
+				IdleConnTimeout:     90 * time.Second,
+			},
+		},
+	}
+}
+
+type balanceResponse struct {
+	CreditMicroUsd int64 `json:"creditMicroUsd"`
+	Sufficient     bool  `json:"sufficient"`
+}
+
+// Balance returns the user's remaining credit (micro-USD) and whether it clears
+// the service's minimum threshold.
+func (c *Client) Balance(ctx context.Context, user, provider string) (int64, bool, error) {
+	u := fmt.Sprintf("%s/v1/balance?user=%s&provider=%s",
+		c.endpoint, url.QueryEscape(user), url.QueryEscape(provider))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return 0, false, errors.Wrap(err, "build balance request")
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return 0, false, errors.Wrap(err, "call credit service balance")
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return 0, false, errors.Errorf("credit service balance returned %d", resp.StatusCode)
+	}
+	var br balanceResponse
+	if err := json.NewDecoder(resp.Body).Decode(&br); err != nil {
+		return 0, false, errors.Wrap(err, "decode balance response")
+	}
+	return br.CreditMicroUsd, br.Sufficient, nil
+}
+
+// DeductResult is the credit service's response to a deduct call.
+type DeductResult struct {
+	ReceiptID       string `json:"receiptId"`
+	SettledMicroUsd int64  `json:"settledMicroUsd"`
+	BalanceMicroUsd int64  `json:"balanceMicroUsd"`
+	Insufficient    bool   `json:"insufficient"`
+	Replay          bool   `json:"replay"`
+}
+
+type deductBody struct {
+	Receipt   Receipt `json:"receipt"`
+	Signature string  `json:"signature"`
+}
+
+// Deduct submits a signed receipt; the service verifies the signature against
+// the on-chain teeSignerAddress and atomically deducts.
+func (c *Client) Deduct(ctx context.Context, r Receipt, signatureHex string) (*DeductResult, error) {
+	payload, err := json.Marshal(deductBody{Receipt: r, Signature: signatureHex})
+	if err != nil {
+		return nil, errors.Wrap(err, "marshal deduct body")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint+"/v1/deduct", bytes.NewReader(payload))
+	if err != nil {
+		return nil, errors.Wrap(err, "build deduct request")
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "call credit service deduct")
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusPaymentRequired {
+		return nil, ErrInsufficientBalance
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.Errorf("credit service deduct returned %d", resp.StatusCode)
+	}
+	var dr DeductResult
+	if err := json.NewDecoder(resp.Body).Decode(&dr); err != nil {
+		return nil, errors.Wrap(err, "decode deduct response")
+	}
+	return &dr, nil
+}

--- a/api/inference/internal/creditbilling/feecalc.go
+++ b/api/inference/internal/creditbilling/feecalc.go
@@ -2,7 +2,6 @@ package creditbilling
 
 import (
 	"math/big"
-	"strconv"
 
 	"github.com/pkg/errors"
 )
@@ -34,15 +33,6 @@ func FeeMicroUsd(inputCount, outputCount, inPriceMicroPerMillion, outPriceMicroP
 		return 0, errors.Errorf("computed fee overflows int64: %s micro-USD", sum.String())
 	}
 	return sum.Int64(), nil
-}
-
-// FeeMicroUsdString is FeeMicroUsd formatted as a decimal string for the receipt.
-func FeeMicroUsdString(inputCount, outputCount, inPriceMicroPerMillion, outPriceMicroPerMillion int64) (string, error) {
-	fee, err := FeeMicroUsd(inputCount, outputCount, inPriceMicroPerMillion, outPriceMicroPerMillion)
-	if err != nil {
-		return "", err
-	}
-	return strconv.FormatInt(fee, 10), nil
 }
 
 // UsdDecimalToMicro converts a decimal USD string (e.g. "2", "0.04", "1.5") to an

--- a/api/inference/internal/creditbilling/feecalc.go
+++ b/api/inference/internal/creditbilling/feecalc.go
@@ -1,0 +1,67 @@
+package creditbilling
+
+import (
+	"math/big"
+	"strconv"
+
+	"github.com/pkg/errors"
+)
+
+// microPerMillion is the divisor relating "micro-USD per million tokens" prices
+// to micro-USD fees: feeMicroUsd = priceMicroUsdPerMillion * count / 1_000_000.
+var microPerMillion = big.NewInt(1_000_000)
+
+// FeeMicroUsd computes the integer micro-USD fee for a request from token counts
+// and per-million-token prices expressed in micro-USD.
+//
+//	feeMicroUsd = (inputCount*inPriceMicroPerMillion + outputCount*outPriceMicroPerMillion) / 1_000_000
+//
+// big.Int is used for the intermediate product to avoid int64 overflow; the
+// result is floored (truncated) to an integer micro-USD. It returns an error if
+// any input is negative or if the computed fee does not fit in int64 — billing
+// money must never silently wrap (a wrapped value could undercharge, or go
+// negative and credit the user).
+func FeeMicroUsd(inputCount, outputCount, inPriceMicroPerMillion, outPriceMicroPerMillion int64) (int64, error) {
+	if inputCount < 0 || outputCount < 0 || inPriceMicroPerMillion < 0 || outPriceMicroPerMillion < 0 {
+		return 0, errors.Errorf("fee inputs must be non-negative: in=%d out=%d inPrice=%d outPrice=%d",
+			inputCount, outputCount, inPriceMicroPerMillion, outPriceMicroPerMillion)
+	}
+	in := new(big.Int).Mul(big.NewInt(inputCount), big.NewInt(inPriceMicroPerMillion))
+	out := new(big.Int).Mul(big.NewInt(outputCount), big.NewInt(outPriceMicroPerMillion))
+	sum := new(big.Int).Add(in, out)
+	sum.Quo(sum, microPerMillion)
+	if !sum.IsInt64() {
+		return 0, errors.Errorf("computed fee overflows int64: %s micro-USD", sum.String())
+	}
+	return sum.Int64(), nil
+}
+
+// FeeMicroUsdString is FeeMicroUsd formatted as a decimal string for the receipt.
+func FeeMicroUsdString(inputCount, outputCount, inPriceMicroPerMillion, outPriceMicroPerMillion int64) (string, error) {
+	fee, err := FeeMicroUsd(inputCount, outputCount, inPriceMicroPerMillion, outPriceMicroPerMillion)
+	if err != nil {
+		return "", err
+	}
+	return strconv.FormatInt(fee, 10), nil
+}
+
+// UsdDecimalToMicro converts a decimal USD string (e.g. "2", "0.04", "1.5") to an
+// integer micro-USD value (USD * 1_000_000), truncating beyond micro precision.
+// Used to normalize configured USD-per-million prices into the integer domain.
+// Returns an error on parse failure, negative input, or int64 overflow.
+func UsdDecimalToMicro(s string) (int64, error) {
+	r, ok := new(big.Rat).SetString(s)
+	if !ok {
+		return 0, errors.Errorf("parse USD decimal %q: invalid syntax", s)
+	}
+	if r.Sign() < 0 {
+		return 0, errors.Errorf("USD price must be non-negative: %q", s)
+	}
+	r.Mul(r, new(big.Rat).SetInt64(1_000_000))
+	// Floor to integer micro-USD.
+	micro := new(big.Int).Quo(r.Num(), r.Denom())
+	if !micro.IsInt64() {
+		return 0, errors.Errorf("USD price %q overflows int64 micro-USD", s)
+	}
+	return micro.Int64(), nil
+}

--- a/api/inference/internal/creditbilling/receipt.go
+++ b/api/inference/internal/creditbilling/receipt.go
@@ -1,0 +1,70 @@
+// Package creditbilling implements the provider broker's half of the off-chain
+// USD credit billing scheme: it signs per-request billing receipts with the TEE
+// key and talks to the centralized credit service to check balances and deduct.
+//
+// The canonical receipt format and signing scheme MUST stay byte-for-byte
+// identical to the credit service's verifier (0g-credit-service
+// internal/receipt). The shared test vector in receipt_test.go (both repos)
+// guards against drift.
+package creditbilling
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/0glabs/0g-serving-broker/common/tee"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/pkg/errors"
+)
+
+// Domain tags the canonical text with a versioned scheme identifier.
+const Domain = "0g-credit-receipt-v1"
+
+// Receipt is the canonical, signature-covered billing record.
+//
+// FeeMicroUsd is an integer amount in micro-USD (1 USD = 1_000_000) encoded as a
+// decimal string. Addresses are lowercased hex; hashes are hex without 0x.
+type Receipt struct {
+	User        string `json:"user"`
+	Provider    string `json:"provider"`
+	ReqHash     string `json:"reqHash"`
+	RespHash    string `json:"respHash"`
+	InputCount  int64  `json:"inputCount"`
+	OutputCount int64  `json:"outputCount"`
+	FeeMicroUsd string `json:"feeMicroUsd"`
+	Nonce       uint64 `json:"nonce"`
+	Timestamp   int64  `json:"timestamp"`
+}
+
+// CanonicalText returns the deterministic colon-separated preimage that is
+// hashed and signed. Field order and formatting are part of the wire contract.
+func (r Receipt) CanonicalText() string {
+	return strings.Join([]string{
+		Domain,
+		strings.ToLower(r.User),
+		strings.ToLower(r.Provider),
+		r.ReqHash,
+		r.RespHash,
+		strconv.FormatInt(r.InputCount, 10),
+		strconv.FormatInt(r.OutputCount, 10),
+		r.FeeMicroUsd,
+		strconv.FormatUint(r.Nonce, 10),
+		strconv.FormatInt(r.Timestamp, 10),
+	}, ":")
+}
+
+// Sign signs the receipt with the TEE provider key and returns the hex-encoded
+// 65-byte signature. It passes Keccak256(canonicalText) to TeeService.Sign,
+// which applies the Ethereum personal-message prefix internally — so the credit
+// service verifies against Keccak256(prefix || Keccak256(canonicalText)).
+func Sign(teeService *tee.TeeService, r Receipt) (string, error) {
+	if teeService == nil {
+		return "", errors.New("tee service is nil")
+	}
+	sig, err := teeService.Sign(crypto.Keccak256([]byte(r.CanonicalText())))
+	if err != nil {
+		return "", errors.Wrap(err, "sign receipt")
+	}
+	return hexutil.Encode(sig), nil
+}

--- a/api/inference/internal/creditbilling/receipt_test.go
+++ b/api/inference/internal/creditbilling/receipt_test.go
@@ -1,0 +1,111 @@
+package creditbilling
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// sharedVectorReceipt and sharedVectorCanonicalText are duplicated verbatim in
+// the credit service (0g-credit-service internal/receipt) test. If either repo
+// changes the canonical format, the constant below must change in lockstep or
+// signatures stop verifying cross-repo.
+var sharedVectorReceipt = Receipt{
+	User:        "0x1111111111111111111111111111111111111111",
+	Provider:    "0x2222222222222222222222222222222222222222",
+	ReqHash:     "aabbcc",
+	RespHash:    "ddeeff",
+	InputCount:  100,
+	OutputCount: 250,
+	FeeMicroUsd: "1234",
+	Nonce:       7,
+	Timestamp:   1700000000,
+}
+
+const sharedVectorCanonicalText = "0g-credit-receipt-v1:0x1111111111111111111111111111111111111111:0x2222222222222222222222222222222222222222:aabbcc:ddeeff:100:250:1234:7:1700000000"
+
+func TestCanonicalTextVector(t *testing.T) {
+	if got := sharedVectorReceipt.CanonicalText(); got != sharedVectorCanonicalText {
+		t.Fatalf("canonical text drift:\n got=%q\nwant=%q", got, sharedVectorCanonicalText)
+	}
+}
+
+// TestSignSchemeVerifiable confirms the exact preimage a verifier reconstructs
+// (Keccak256(prefix || Keccak256(text))) recovers the signing address — the same
+// scheme TeeService.Sign uses internally.
+func TestSignSchemeVerifiable(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("gen key: %v", err)
+	}
+	addr := crypto.PubkeyToAddress(key.PublicKey)
+
+	messageHash := crypto.Keccak256([]byte(sharedVectorReceipt.CanonicalText()))
+	prefixed := crypto.Keccak256([]byte("\x19Ethereum Signed Message:\n32"), messageHash)
+	sig, err := crypto.Sign(prefixed, key)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	if sig[64] == 0 || sig[64] == 1 {
+		sig[64] += 27
+	}
+	_ = hexutil.Encode(sig)
+
+	// Recover the way the credit service does.
+	v := sig[64]
+	if v >= 27 {
+		v -= 27
+	}
+	rec := make([]byte, 65)
+	copy(rec, sig[:64])
+	rec[64] = v
+	pub, err := crypto.SigToPub(prefixed, rec)
+	if err != nil {
+		t.Fatalf("recover: %v", err)
+	}
+	if got := crypto.PubkeyToAddress(*pub); got != addr {
+		t.Fatalf("recovered %s, want %s", got.Hex(), addr.Hex())
+	}
+}
+
+func TestFeeMicroUsd(t *testing.T) {
+	// $2 per million input tokens => 2_000_000 micro per million.
+	// 500_000 input tokens => fee = 2_000_000 * 500_000 / 1_000_000 = 1_000_000 micro-USD ($1).
+	if got, err := FeeMicroUsd(500_000, 0, 2_000_000, 0); err != nil || got != 1_000_000 {
+		t.Fatalf("input fee: got %d, err %v, want 1000000", got, err)
+	}
+	// input 100 @ $3/M (3_000_000) + output 250 @ $6/M (6_000_000)
+	// = (100*3_000_000 + 250*6_000_000)/1_000_000 = (3e8 + 1.5e9)/1e6 = 1800
+	if got, err := FeeMicroUsd(100, 250, 3_000_000, 6_000_000); err != nil || got != 1800 {
+		t.Fatalf("combined fee: got %d, err %v, want 1800", got, err)
+	}
+	// Negative input must error, not silently compute.
+	if _, err := FeeMicroUsd(-1, 0, 1, 0); err == nil {
+		t.Fatal("expected error for negative input count")
+	}
+	// Overflow must error, not wrap. maxInt64 * maxInt64 / 1e6 far exceeds int64.
+	const maxInt64 = int64(9223372036854775807)
+	if _, err := FeeMicroUsd(maxInt64, 0, maxInt64, 0); err == nil {
+		t.Fatal("expected overflow error for huge product")
+	}
+}
+
+func TestUsdDecimalToMicro(t *testing.T) {
+	cases := map[string]int64{"2": 2_000_000, "0.04": 40_000, "1.5": 1_500_000, "0": 0}
+	for in, want := range cases {
+		got, err := UsdDecimalToMicro(in)
+		if err != nil {
+			t.Fatalf("UsdDecimalToMicro(%q): %v", in, err)
+		}
+		if got != want {
+			t.Fatalf("UsdDecimalToMicro(%q): got %d, want %d", in, got, want)
+		}
+	}
+	if _, err := UsdDecimalToMicro("-1"); err == nil {
+		t.Fatal("expected error for negative USD price")
+	}
+	if _, err := UsdDecimalToMicro("notanumber"); err == nil {
+		t.Fatal("expected error for unparseable USD price")
+	}
+}

--- a/api/inference/internal/ctrl/chatbot.go
+++ b/api/inference/internal/ctrl/chatbot.go
@@ -427,6 +427,21 @@ func (c *Ctrl) decodeAndProcess(ctx context.Context, data []byte, encodingType s
 		}
 	}
 
+	// Off-chain credit billing: charge the credit service from the actual usage.
+	// Runs after the response is delivered; a failure is logged (see
+	// billCreditChat), never surfaced to the client.
+	if c.creditEnabled() {
+		if usage != nil {
+			c.billCreditChat(reqBody, signData, int64(usage.PromptTokens), int64(usage.CompletionTokens), reqModel)
+		} else {
+			// No usage in the response: the request was served but cannot be
+			// billed (fail-open). The broker injects stream_options.include_usage,
+			// so this only happens with a non-compliant upstream — log loudly so
+			// the unbilled traffic is observable rather than silent revenue loss.
+			c.logger.Warnf("credit billing: response for %s carried no usage; request served UNBILLED", reqModel.RequestHash)
+		}
+	}
+
 	return nil
 }
 

--- a/api/inference/internal/ctrl/chatbot.go
+++ b/api/inference/internal/ctrl/chatbot.go
@@ -430,7 +430,7 @@ func (c *Ctrl) decodeAndProcess(ctx context.Context, data []byte, encodingType s
 	// Off-chain credit billing: charge the credit service from the actual usage.
 	// Runs after the response is delivered; a failure is logged (see
 	// billCreditChat), never surfaced to the client.
-	if c.creditEnabled() {
+	if c.creditEnabled() && !reqModel.IsWhitelisted {
 		if usage != nil {
 			c.billCreditChat(reqBody, signData, int64(usage.PromptTokens), int64(usage.CompletionTokens), reqModel)
 		} else {
@@ -471,6 +471,13 @@ func (c *Ctrl) processSingleResponse(ctx context.Context, decodedBody []byte, ou
 	// For non-stream responses, usage info is in the same response
 	if chunk.Usage != nil {
 		*usage = chunk.Usage
+		// Credit providers bill from usage (captured above) via the credit
+		// service in decodeAndProcess; skip the on-chain wei-price path — it
+		// needs the price feed credit doesn't use, and its stale-feed failure
+		// would otherwise return before the credit charge runs (served-unbilled).
+		if c.creditEnabled() {
+			return nil
+		}
 		// Get billing prices (model-specific for multi-model, on-chain for single-model)
 		prices, err := c.GetBillingPrices(ctx)
 		if err != nil {
@@ -479,6 +486,11 @@ func (c *Ctrl) processSingleResponse(ctx context.Context, decodedBody []byte, ou
 		return c.updateAccountWithUsage(ctx, chunk.Usage, prices.OutputPrice, requestHash, prices.InputPrice, prices.Tiers, prices.CacheTokenBilling)
 	}
 
+	// Credit providers never touch the on-chain wei path; with no usage the
+	// request is logged served-unbilled in decodeAndProcess (no phantom wei row).
+	if c.creditEnabled() {
+		return nil
+	}
 	return c.updateAccountWithOutput(ctx, *output, outputPrice, requestHash)
 }
 
@@ -817,6 +829,11 @@ func (c *Ctrl) finalizeChatStream(ctx context.Context, output string, usage *Usa
 			monitor.RecordWhitelistTokens("chatbot", metricModel, int64(usage.PromptTokens), int64(usage.CompletionTokens))
 			monitor.RecordTPSFromContext(ctx, "chatbot", metricModel, int64(usage.CompletionTokens))
 		}
+		return nil
+	}
+	// Credit providers bill from usage (captured by the caller) via the credit
+	// service; skip the on-chain wei-price path (see processSingleResponse).
+	if c.creditEnabled() {
 		return nil
 	}
 	if usage != nil {

--- a/api/inference/internal/ctrl/chatbot_litellm.go
+++ b/api/inference/internal/ctrl/chatbot_litellm.go
@@ -150,6 +150,12 @@ func (c *Ctrl) processLiteLLMSingleResponse(ctx context.Context, decodedBody []b
 			return nil
 		}
 
+		// Credit providers bill from usage (captured above) via the credit
+		// service; skip the on-chain wei-price path (see processSingleResponse).
+		if c.creditEnabled() {
+			return nil
+		}
+
 		prices, err := c.GetBillingPrices(ctx)
 		if err != nil {
 			return errors.Wrap(err, "get billing prices for LiteLLM single response billing")
@@ -159,6 +165,12 @@ func (c *Ctrl) processLiteLLMSingleResponse(ctx context.Context, decodedBody []b
 
 	// Skip billing for whitelisted users
 	if isWhitelisted {
+		return nil
+	}
+
+	// Credit providers never touch the on-chain wei path; with no usage the
+	// request is logged served-unbilled in decodeAndProcess (no phantom wei row).
+	if c.creditEnabled() {
 		return nil
 	}
 

--- a/api/inference/internal/ctrl/credit_billing.go
+++ b/api/inference/internal/ctrl/credit_billing.go
@@ -1,0 +1,90 @@
+package ctrl
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"strconv"
+	"time"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/gin-gonic/gin"
+	"github.com/pkg/errors"
+
+	"github.com/0glabs/0g-serving-broker/inference/internal/creditbilling"
+	"github.com/0glabs/0g-serving-broker/inference/model"
+)
+
+// creditDeductTimeout bounds the post-response deduct call to the credit
+// service. Billing runs on its own context (not the request context) so a
+// client disconnect after the response cannot cancel the charge.
+const creditDeductTimeout = 5 * time.Second
+
+// creditEnabled reports whether off-chain credit billing is active for this
+// provider (set when config.Service.CreditBilling.Enable and a client built).
+func (c *Ctrl) creditEnabled() bool { return c.creditClient != nil }
+
+// checkCreditBalance is the admission gate for credit providers. It queries the
+// credit service for the user's balance and rejects fail-closed: an
+// insufficient balance is a client-caused rejection (ignoreError), while a
+// service/transport error is left unflagged so the broker-fault alert fires.
+func (c *Ctrl) checkCreditBalance(ctx *gin.Context, userAddress string) error {
+	balance, _, err := c.creditClient.Balance(ctx.Request.Context(), userAddress, c.contract.ProviderAddress)
+	if err != nil {
+		return errors.Wrap(err, "credit balance check failed")
+	}
+	if balance <= c.Service.CreditBilling.MinBalanceMicroUsd {
+		ctx.Set("ignoreError", true)
+		return errors.New("insufficient credit balance")
+	}
+	return nil
+}
+
+// billCreditChat builds, TEE-signs, and submits a billing receipt for a chatbot
+// request to the credit service. It is called post-response (the response is
+// already delivered to the client), so any failure — including insufficient
+// balance — is logged as a billing loss rather than surfaced to the client; the
+// admission gate (checkCreditBalance) is what prevents serving the unpayable.
+func (c *Ctrl) billCreditChat(reqBody, respData []byte, promptTokens, completionTokens int64, reqModel model.Request) {
+	feeMicro, err := creditbilling.FeeMicroUsd(promptTokens, completionTokens, c.creditInMicro, c.creditOutMicro)
+	if err != nil {
+		c.logger.Errorf("credit billing: fee computation failed for %s: %v", reqModel.RequestHash, err)
+		return
+	}
+
+	reqHash := sha256.Sum256(reqBody)
+	respHash := sha256.Sum256(respData)
+	// Derive a per-request nonce from the unique request id so two byte-identical
+	// requests (same reqHash/respHash) still hash to distinct receiptIDs.
+	nonce := binary.BigEndian.Uint64(crypto.Keccak256([]byte(reqModel.RequestHash))[:8])
+
+	rec := creditbilling.Receipt{
+		User:        reqModel.UserAddress,
+		Provider:    c.contract.ProviderAddress,
+		ReqHash:     hex.EncodeToString(reqHash[:]),
+		RespHash:    hex.EncodeToString(respHash[:]),
+		InputCount:  promptTokens,
+		OutputCount: completionTokens,
+		FeeMicroUsd: strconv.FormatInt(feeMicro, 10),
+		Nonce:       nonce,
+		Timestamp:   time.Now().Unix(),
+	}
+
+	sig, err := creditbilling.Sign(c.teeService, rec)
+	if err != nil {
+		c.logger.Errorf("credit billing: sign receipt failed for %s: %v", reqModel.RequestHash, err)
+		return
+	}
+
+	dctx, cancel := context.WithTimeout(context.Background(), creditDeductTimeout)
+	defer cancel()
+	res, err := c.creditClient.Deduct(dctx, rec, sig)
+	if err != nil {
+		c.logger.Errorf("credit billing: deduct failed for %s (user %s, fee %d micro-USD): %v",
+			reqModel.RequestHash, reqModel.UserAddress, feeMicro, err)
+		return
+	}
+	c.logger.Debugf("credit billing: charged %d micro-USD for %s (balance %d, replay=%v)",
+		res.SettledMicroUsd, reqModel.RequestHash, res.BalanceMicroUsd, res.Replay)
+}

--- a/api/inference/internal/ctrl/ctrl.go
+++ b/api/inference/internal/ctrl/ctrl.go
@@ -16,6 +16,7 @@ import (
 	"github.com/0glabs/0g-serving-broker/inference/config"
 	constant "github.com/0glabs/0g-serving-broker/inference/const"
 	providercontract "github.com/0glabs/0g-serving-broker/inference/internal/contract"
+	"github.com/0glabs/0g-serving-broker/inference/internal/creditbilling"
 	"github.com/0glabs/0g-serving-broker/inference/internal/db"
 	"github.com/0glabs/0g-serving-broker/inference/internal/lora"
 	"github.com/0glabs/0g-serving-broker/inference/internal/pricefeed"
@@ -44,7 +45,7 @@ type Ctrl struct {
 	logger   log.Logger
 
 	autoSettleBufferTime time.Duration
-	minSettlementFee    *big.Int
+	minSettlementFee     *big.Int
 
 	Service           config.Service
 	cacheTokenBilling config.CacheTokenBillingConfig
@@ -79,6 +80,13 @@ type Ctrl struct {
 
 	teeService          *tee.TeeService
 	chatCacheExpiration time.Duration
+
+	// Off-chain credit billing. creditClient is non-nil only when
+	// config.Service.CreditBilling.Enable; creditInMicro/creditOutMicro are the
+	// per-million-token prices in integer micro-USD (USD denomination required).
+	creditClient   *creditbilling.Client
+	creditInMicro  int64
+	creditOutMicro int64
 
 	// Session validation cache
 	sessionCache *cache.Cache
@@ -237,16 +245,16 @@ func New(
 			Timeout: cfg.ProviderHttp.TotalTimeout, // Overall request timeout
 			Transport: &http.Transport{
 				// Connection pool settings for high concurrency scenarios
-				MaxIdleConns:          200,                                                                        // Increased total idle connections to handle more concurrent users
-				MaxIdleConnsPerHost:   200,                                                                        // Idle connections per host (critical for single backend)
-				MaxConnsPerHost:       500,                                                                        // Limit max active connections to prevent resource exhaustion
-				IdleConnTimeout:       90 * time.Second,                                                           // How long idle connections stay open
-				TLSHandshakeTimeout:   10 * time.Second,                                                           // TLS handshake timeout
+				MaxIdleConns:          200,                                    // Increased total idle connections to handle more concurrent users
+				MaxIdleConnsPerHost:   200,                                    // Idle connections per host (critical for single backend)
+				MaxConnsPerHost:       500,                                    // Limit max active connections to prevent resource exhaustion
+				IdleConnTimeout:       90 * time.Second,                       // How long idle connections stay open
+				TLSHandshakeTimeout:   10 * time.Second,                       // TLS handshake timeout
 				ResponseHeaderTimeout: cfg.ProviderHttp.ResponseHeaderTimeout, // Time to wait for response headers
-				ExpectContinueTimeout: 1 * time.Second,                                                            // Time to wait for 100-continue response
-				DisableKeepAlives:     false,                                                                      // Enable connection reuse (critical)
-				DisableCompression:    false,                                                                      // Allow gzip compression
-				ForceAttemptHTTP2:     false,                                                                      // Use HTTP/1.1 for stability
+				ExpectContinueTimeout: 1 * time.Second,                        // Time to wait for 100-continue response
+				DisableKeepAlives:     false,                                  // Enable connection reuse (critical)
+				DisableCompression:    false,                                  // Allow gzip compression
+				ForceAttemptHTTP2:     false,                                  // Use HTTP/1.1 for stability
 			},
 		},
 		// Initialize whitelist users map
@@ -276,6 +284,25 @@ func New(
 		}
 	} else {
 		logger.Info("Whitelist: disabled")
+	}
+
+	// Off-chain credit billing setup. Config validation guarantees, when
+	// enabled, that the endpoint is set, the service type is chatbot, and prices
+	// are USD-denominated — so the conversions below cannot fail in practice.
+	if cfg.Service.CreditBilling.Enable {
+		p.creditClient = creditbilling.NewClient(cfg.Service.CreditBilling.Endpoint, cfg.Service.CreditBilling.Timeout)
+		inMicro, err := creditbilling.UsdDecimalToMicro(cfg.Service.InputPriceUSDPerMillionTokens)
+		if err != nil {
+			logger.Errorf("credit billing: invalid inputPriceUSDPerMillionTokens %q: %v", cfg.Service.InputPriceUSDPerMillionTokens, err)
+		}
+		outMicro, err := creditbilling.UsdDecimalToMicro(cfg.Service.OutputPriceUSDPerMillionTokens)
+		if err != nil {
+			logger.Errorf("credit billing: invalid outputPriceUSDPerMillionTokens %q: %v", cfg.Service.OutputPriceUSDPerMillionTokens, err)
+		}
+		p.creditInMicro = inMicro
+		p.creditOutMicro = outMicro
+		logger.Infof("credit billing enabled: endpoint=%s, inputMicroUSD/M=%d, outputMicroUSD/M=%d",
+			cfg.Service.CreditBilling.Endpoint, inMicro, outMicro)
 	}
 
 	return p

--- a/api/inference/internal/ctrl/proxy.go
+++ b/api/inference/internal/ctrl/proxy.go
@@ -352,10 +352,16 @@ func (c *Ctrl) ProcessHTTPRequest(ctx *gin.Context, svcType string, req *http.Re
 		return c.handleResponse(ctx, resp)
 	}
 
-	_, err = c.GetOrCreateAccount(ctx, reqModel.UserAddress)
-	if err != nil {
-		c.handleBrokerError(ctx, err, "")
-		return err
+	// Credit providers bill off-chain; their users may have no on-chain account,
+	// so skip the on-chain GetOrCreateAccount (it hard-requires one and would
+	// otherwise discard an already-served response unbilled). Admission already
+	// gated on credit balance, and the downstream handlers only use the minimal
+	// account below (independent of the contract fetch).
+	if !c.creditEnabled() {
+		if _, err = c.GetOrCreateAccount(ctx, reqModel.UserAddress); err != nil {
+			c.handleBrokerError(ctx, err, "")
+			return err
+		}
 	}
 
 	account := model.User{

--- a/api/inference/internal/ctrl/request.go
+++ b/api/inference/internal/ctrl/request.go
@@ -266,6 +266,14 @@ func (c *Ctrl) ValidateProviderAuth(ctx *gin.Context) error {
 // ValidateRequestWithEstimatedFee validates the request using an estimated fee
 // This is used before the actual token count is known from the LLM
 func (c *Ctrl) ValidateRequestWithEstimatedFee(ctx *gin.Context, req model.Request, estimatedFee string) error {
+	// Off-chain credit providers bill via the credit service, not on-chain.
+	// Their users may have no on-chain account, and the service is intentionally
+	// not TeeSigner-acknowledged — so bypass the on-chain account/ack/balance
+	// checks entirely and gate on the credit balance (fail-closed) instead.
+	if c.creditEnabled() {
+		return c.checkCreditBalance(ctx, req.UserAddress)
+	}
+
 	// Try to get contract account from cache first
 	userAddress := common.HexToAddress(req.UserAddress)
 	accountCacheKey := userAddress.Hex()

--- a/docs/design/credit-billing-provider.md
+++ b/docs/design/credit-billing-provider.md
@@ -1,0 +1,187 @@
+# 链下 Credit 计费 Provider 设计(链上身份 + 链下 credit + TEE 签名回执)
+
+> 状态:MVP 设计 + 组件已实现。目标是**最快跑通**:最大化复用现有 broker / CLI 的链上身份与 API key 机制,
+> 只把"结算"这一步换成"调用中心化 credit 服务,凭 TEE 签名回执扣费"。
+>
+> ## 实现状态(已构建并通过编译/测试)
+>
+> | 组件 | 位置 | 状态 |
+> |---|---|---|
+> | **Credit 服务**(全新,独立 repo) | `/home/raven/workspace/0g/0g-credit-service`(分支 `main`) | ✅ 编译/vet/测试通过。balance / deduct(验签+原子扣+幂等) / receipt / admin topup 全部实现 |
+> | **Broker `creditbilling` 包**(回执签名 + credit 客户端 + USD 费用计算) | broker `api/inference/internal/creditbilling/` | ✅ 编译/测试通过 |
+> | **Broker 配置** `CreditBillingConfig` | broker `api/inference/config/config.go` | ✅ 编译通过,默认 `enable=false`(链上用户零影响) |
+> | **SDK credit 模式开关** `setCreditMode({skipAutoFunding, skipAcknowledgement})` | user-broker `src.ts/sdk/inference/broker/`(分支 `raven/credit-billing`) | ✅ tsc 通过 |
+> | **跨 repo 互操作锁定** | 两侧共享 canonical 文本测试向量 + 签名/验签往返测试 | ✅ 两侧测试通过,格式漂移会被测试捕获 |
+> | **Broker 活路径接线**(admission 查余额 / 响应后签回执+扣费) | broker 各服务 handler(chatbot/stt/image/video)+ settlement | ⏳ **唯一剩余步骤**,见 §10、§11 |
+>
+> 接线之所以单列:它要逐个改 broker 既有的多服务计费活路径(含流式),应当 config-gated + 配合团队 review,
+> 不宜盲改以免影响链上用户。组件已就绪,接线即"在两处调用已实现的 `creditbilling` API"。
+
+## 1. 目标与范围
+
+**要做的:**
+- 一个代理上游模型服务的 provider(下称"本 Provider"),**隐藏上游域名**。
+- 用户仍用现有 CLI / SDK(钱包 + 链上 session token)鉴权、创建 / 吊销 API key。
+- 计费走**链下中心化 credit 服务**:用户预付 USD → credit;每请求按 `fee = usage × price` 扣减。
+- 计费**不可被乱收费**:Provider broker 在 TEE 内对每笔费用签名,credit 服务**验签后才扣**,签名回执留存供用户审计。
+- 本 Provider **不被 owner acknowledge** → 对一般 CLI / SDK / router 用户**不可见**。
+
+**MVP 不做(后续):**
+- 自助 USD 充值(Stripe 等);MVP 由运营手动充值。
+- 链上结算 / USDC / 跨 provider 通用 credit。
+- 退款 / 争议工作流(仅保留可审计回执)。
+
+**明确接受的取舍:**
+- credit 服务是**中心化的单点信任 + 单点故障**。MVP 接受,靠 TEE 签名把"不能乱收费"找回来,
+  并对故障采取 fail-closed 策略。
+- credit **仅对本 Provider 有效**(per-provider),不跨 provider。
+
+## 2. 架构总览
+
+```
+用户(CLI / SDK,钱包私钥)
+   │  Authorization: Bearer app-sk-<base64(sessionToken|签名)>   ← 现有链上机制,不变
+   ▼
+┌─────────────────────────────────────────────────────────┐
+│  Provider Broker(运行在 TEE enclave 内)                  │
+│  1. ValidateSession(钱包签名)→ userAddr     [复用]       │
+│  2. admission:调 credit 服务查余额,不足则拒  [新增]       │
+│  3. 转发到上游(URL 仅 enclave 配置,不暴露)  [复用代理]   │
+│  4. 解析 usage → fee = usage × price          [复用]       │
+│  5. TEE 签回执:(user,provider,reqHash,respHash,           │
+│     usage,fee,nonce,ts)                        [复用 SyncQuote/Sign] │
+│  6. 调 credit 服务 deduct(回执 + 签名)        [新增]       │
+└───────────────┬─────────────────────────────────────────┘
+                │ (TEE 签名的扣费请求)
+                ▼
+┌─────────────────────────────────────────────────────────┐
+│  Credit 服务(中心化,独立配置的认证域名)                 │
+│  - 验签(对链上 teeSignerAddress)→ 原子 check-and-deduct  │
+│  - 存签名回执(审计)、credit 流水                         │
+│  - 运营充值入口(USD → credit)                            │
+└─────────────────────────────────────────────────────────┘
+
+链上(合约,同一份):
+  - 本 Provider 的 service:addOrUpdateService 注册一次,**不 acknowledge** → 隐藏 + 公布 teeSignerAddress
+  - 用户:链上账户,仅用于**身份 + API key 吊销**(generation / bitmap),不存计费资金
+```
+
+## 3. 鉴权与身份(全部复用现有链上机制)
+
+- **身份 = 钱包地址**;用 CLI 需要 wallet private key。
+- **API key = 现有 session token**(`app-sk-<base64(token|签名)>`),本地钱包签名生成。
+- **创建 key**:CLI 用钱包签一个 session token(持久 token 可设 `ExpiresAt=0`)。
+- **吊销 key**:走链上 `generation`(批量)/ `RevokedBitmap`(精确)—— **需要用户有链上账户**。
+  - 代价:吊销是一笔**链上交易**(gas + 确认延迟)。MVP 接受。
+- **用户链上账户**:仅作身份 + 吊销注册表用,**不需要充值**。计费资金全在 credit 服务。
+
+> 说明:provider 端 `ValidateSession` 是纯签名校验;`validateTokenRevocation` 在链上查不到账户时
+> 默认放行(generation=0)。要让吊销**生效**,用户必须有链上账户并设置 generation/bitmap。
+
+## 4. 计费流程(逐步)
+
+**Admission(转发前):**
+1. `ValidateSession` → `userAddr`。
+2. 调 credit 服务 `GET /balance?user=&provider=`,余额不足阈值 → 拒(`insufficient_credit`,标记为用户侧错误,不计入健康指标)。
+   - 可对余额做**短 TTL 缓存**降低延迟;权衡见 §9。
+
+**转发:** 现有 decentralized 代理模式,上游 URL 仅 enclave 配置,**不暴露**。
+
+**Post-response(拿到响应、fee 已知;流式在流结束时):**
+3. 解析 usage → `fee = usage × price`(USD 计价,复用 broker)。
+4. 构造回执 `Receipt = {user, provider, reqHash=sha256(req), respHash=sha256(resp), usage, price, fee, nonce, ts}`。
+5. TEE 签名:`sig = Sign(keccak256(canonical(Receipt)))`,签名 key 即链上 `teeSignerAddress`(复用 `common/tee` 的 `SyncQuote`/`Sign`)。
+6. 调 credit 服务 `POST /deduct {receipt, sig}`:
+   - 验签(对链上 `teeSignerAddress`)。
+   - 校验 `nonce` 单调递增(防回执重放重复扣)。
+   - **原子** check-and-deduct;余额不足时扣到 0 并标记欠费(见 §9 单请求封顶)。
+   - 存回执 + 写 credit 流水,返回新余额。
+
+## 5. 可验证性(把"不能乱收费"找回来)
+
+- Provider 在 enclave 内派生签名 key,地址写入 TDX quote 的 `report_data`,并注册到链上 `teeSignerAddress`。
+- **credit 服务**:只接受验签通过(对链上 `teeSignerAddress`)的扣费 → 即使 broker→服务通道被冒用,也无法乱扣。
+- **用户审计**:任意时刻可取回执,
+  1. 验签 recover 地址 == 链上 `teeSignerAddress`(出自被 attest 的 enclave);
+  2. `sha256(自己手里的请求/响应)` == 回执哈希(账对应这次交互);
+  3. `usage × 公开 price` == 回执 fee(没多收 / 没偷换价)。
+- **一次性**:验 Provider 的 `/attestation`(TDX quote)→ 确认 `teeSignerAddress` 属于跑着已知度量值 M 的真 enclave。
+  - **前提(真正工作量)**:计量代码可复现构建 + 公布预期 M,否则 attestation 只证"没被改",证不了"不黑"。
+
+## 6. 数据模型(credit 服务)
+
+- `balance`:`(user_addr, provider_addr)` → credit(USD,decimal), updated_at
+- `receipt`:id, user, provider, req_hash, resp_hash, usage, price, fee, nonce, ts, sig, applied
+- `credit_tx`:user, provider, type(topup/debit/refund), amount, ref, ts
+- `nonce_state`:`(user_addr, provider_addr)` → last_nonce(防重放)
+
+## 7. 接口
+
+**Credit 服务:**
+```
+GET  /balance?user=&provider=        → 余额        (调用方:broker / 用户本人)
+POST /deduct {receipt, sig}          → 验签+原子扣  (调用方:仅本 Provider TEE,凭 TEE 签名)
+GET  /receipt/{id}                   → 签名回执     (公开 / 用户)
+POST /admin/topup {user, amount}     → USD→credit  (调用方:运营,内部密钥)
+```
+
+**Provider broker(对用户):**
+```
+POST /v1/chat/completions ...        → 代理转发      (inference,session token)
+GET  /attestation                    → TDX quote     (公开)
+```
+
+## 8. 链上动作
+
+- **本 Provider 注册一次**:`addOrUpdateService`,填 `{url=Provider自己的入口, model, price, teeSignerAddress=回执签名key, additionalInfo}`。
+  - **不争取 owner acknowledge** → 标准客户端按 `teeSignerAcknowledged==true` 过滤掉它 → 一般用户看不到。
+  - `serviceExists=true` 但未 ack → 链上结算关闭(本就不用),`teeSignerAddress` 公布供验签。
+- **用户**:创建链上账户(身份 + 吊销);无需充值。
+
+## 9. 已知缺陷与对策
+
+| 缺陷 | 对策(MVP) |
+|---|---|
+| credit 服务单点信任 + 故障 | 接受;TEE 签名保证不可乱扣;故障时 **fail-closed**(查不到余额则拒绝服务,不免费放行);余额短 TTL 缓存平滑抖动 |
+| check-then-deduct 竞态 / 超扣 | credit 服务侧**原子** check-and-deduct;`nonce` 单调防重放 |
+| fee 响应后才知,admission 只能估 | 按当前余额给**单请求封顶**(超限直接拒/截断),避免负余额亏损 |
+| 热路径多一次同步往返(查余额) | admission 余额短 TTL 缓存;deduct 在响应后,不阻塞首字节 |
+| 吊销 API key 需链上交易(gas/延迟) | 接受;沿用现有链上 generation/bitmap 机制 |
+| 通道鉴权 | deduct 以 **TEE 签名**为准(验链上 teeSignerAddress);可叠加网络 ACL |
+
+## 10. 改动清单
+
+**Provider broker(基于现有 inference broker,在 `provider-ambr` worktree 改):**
+- 配置:`creditBilling.{enable,endpoint,timeout,minBalanceMicroUsd}`(已加于 `config.go`);`providerType=decentralized`、`targetUrl=上游`。
+- 已实现可直接调用的组件(`internal/creditbilling/`):
+  - `creditbilling.NewClient(endpoint, timeout)` → `.Balance(ctx, user, provider)` / `.Deduct(ctx, receipt, sigHex)`
+  - `creditbilling.Sign(teeService, receipt)` → 用 `common/tee` 的 TEE key 签回执(与 credit 服务验签互通)
+  - `creditbilling.FeeMicroUsd(in, out, inPriceMicroPerMillion, outPriceMicroPerMillion)` / `UsdDecimalToMicro(usd)`
+- **接线点(剩余步骤)**:
+  1. **admission**:在 `internal/ctrl/request.go` 的 `validateBalanceAdequacy` 加 `if c.Service.CreditBilling.Enable` 分支,改调 `client.Balance` 并按 `minBalanceMicroUsd` fail-closed;链上分支保持原样。
+  2. **响应后扣费**:在各服务签名处(`internal/ctrl/signing.go` 的 `signChatWithKey` / `signImageResponse` 调用点,以及 stt/video 流程)拿到 `reqBody/respData/usage` 后,构造 `creditbilling.Receipt`(fee 用 `FeeMicroUsdString`,price 由 USD 配置经 `UsdDecimalToMicro` 得到),`Sign` 后 `client.Deduct`;并对该用户跳过链上结算入队(`CreateRequest`/settlement)。
+- 复用:usage 解析、`common/tee` 的 `SyncQuote`/`Sign`/`/attestation`(后者即可验性所需 quote)。
+
+**CLI / SDK(0g-serving-user-broker,`raven/credit-billing` worktree)— ✅ 已实现:**
+- `broker.inference.setCreditMode({ skipAutoFunding, skipAcknowledgement })`(`base.ts` / `request.ts` / `broker.ts`)。
+- `skipAutoFunding`:跳过 `checkAndFund` 的链上转账,否则 credit 用户被 `Insufficient balance in ledger` 卡死。
+- `skipAcknowledgement`:链下计费下 on-chain acknowledge 无意义,跳过 `userAcknowledged` 检查,用户只需"链上账户(供吊销)+ 钱包"。
+- 其余(session token 生成、签名、请求)不变;默认两者皆 false,链上用户零影响。
+
+**Credit 服务(`/home/raven/workspace/0g/0g-credit-service`)— ✅ 已实现:**
+- §6 数据模型 + §7 接口;原子 check-and-deduct(行级锁)+ 按 `receiptId` 幂等 + 验签 + 回执存储 + 运营充值。
+
+## 11. 落地顺序
+
+1. credit 服务:`balance` / `deduct`(验签 + 原子扣 + nonce) / `receipt` / `admin/topup`。
+2. Provider broker:admission 改为查 credit 服务;post-response 改为 TEE 签回执 → deduct。
+3. SDK:加 `skipAutoFunding`(+ `skipAcknowledgement`)。
+4. 链上:Provider 注册(不 ack);用户账户创建流程。
+5. attestation 暴露 + 计量代码可复现构建 + 公布预期度量值 M。
+
+## 12. 待确认
+
+- 充值:MVP 手动 `admin/topup`,后续接 Stripe。
+- 单请求封顶策略:超额是拒绝还是按余额截断。
+- credit 服务故障策略:确认 fail-closed(默认)。
+- 回执签名格式:MVP 自定义 canonical;是否预留 EIP-712 `TEESettlementData` 以便将来链上结算。

--- a/docs/design/credit-billing-provider.md
+++ b/docs/design/credit-billing-provider.md
@@ -12,10 +12,13 @@
 > | **Broker 配置** `CreditBillingConfig` | broker `api/inference/config/config.go` | ✅ 编译通过,默认 `enable=false`(链上用户零影响) |
 > | **SDK credit 模式开关** `setCreditMode({skipAutoFunding, skipAcknowledgement})` | user-broker `src.ts/sdk/inference/broker/`(分支 `raven/credit-billing`) | ✅ tsc 通过 |
 > | **跨 repo 互操作锁定** | 两侧共享 canonical 文本测试向量 + 签名/验签往返测试 | ✅ 两侧测试通过,格式漂移会被测试捕获 |
-> | **Broker 活路径接线**(admission 查余额 / 响应后签回执+扣费) | broker 各服务 handler(chatbot/stt/image/video)+ settlement | ⏳ **唯一剩余步骤**,见 §10、§11 |
+> | **Broker 活路径接线**(admission 查余额 / 响应后签回执+扣费) | broker chatbot 路径 + 两个 settlement 入口 + config 校验 | ✅ **已接线(chatbot)**,见 §10、§11 |
 >
-> 接线之所以单列:它要逐个改 broker 既有的多服务计费活路径(含流式),应当 config-gated + 配合团队 review,
-> 不宜盲改以免影响链上用户。组件已就绪,接线即"在两处调用已实现的 `creditbilling` API"。
+> 接线已完成并 config-gated(`CreditBilling.Enable`,默认关,链上用户零影响):
+> admission 在 `ValidateRequestWithEstimatedFee` 早分支查 credit 余额(fail-closed);chatbot 响应后在
+> `decodeAndProcess` 用真实 usage 签回执并调 credit 服务扣费(流式/非流式同路);`cmd/server` 启动结算与
+> `cmd/event` 的 SettlementProcessor/Reconciliation 在 credit 模式下整体禁用。**其它服务类型(image/stt/video)
+> 的 credit 计费暂未接线**——其 USD 计价单位不同,启动时 fail-stop 而非静默不计费(见 §10 config 校验)。
 
 ## 1. 目标与范围
 


### PR DESCRIPTION
## What

Off-chain USD credit billing for an inference provider: bill via a centralized credit service (TEE-signed micro-USD receipts) instead of on-chain settlement. Gated behind `Service.CreditBilling`, **disabled by default** — on-chain providers byte-for-byte unaffected.

### Components (`internal/creditbilling`)
- `receipt.go` — canonical billing `Receipt` + `Sign()` via the existing `TeeService` key. Byte-compatible with the `0g-credit-service` verifier (shared test vector).
- `client.go` — credit-service client (`Balance`/`Deduct`); 402 → `ErrInsufficientBalance`; documented fail-closed contract.
- `feecalc.go` — USD-per-million → integer micro-USD with negative/overflow guards.

### Live-path wiring (chatbot)
- **Admission** — `ValidateRequestWithEstimatedFee` branches early for credit providers to a fail-closed credit-balance check (skips on-chain account/ack checks, which don't apply).
- **Post-response** — `decodeAndProcess` builds + TEE-signs a `Receipt` from actual usage and submits it (stream + non-stream); own context so a client disconnect can't cancel billing; failures logged, never surfaced; missing-usage logged as served-unbilled.
- **Settlement disabled under credit mode** — boot `SettleFeesWithTEE` (`cmd/server`) and `Settlement`/`Reconciliation` processors (`cmd/event`) skipped → credit requests never settle on-chain (no double-charge).
- **Config** — `CreditBillingConfig` on `Service`; validation fail-stops unless `endpoint` set, `priceDenomination==USD`, `serviceType==chatbot`.

### Scope
Wired for **chatbot** (LLM). image / speech-to-text / video have distinct USD-unit billing and are intentionally not wired — config validation fail-stops on them.

### Known follow-ups (non-blocking)
- Non-compliant upstream omitting `usage` is served unbilled (logged; broker injects `include_usage`).
- `request` rows accumulate for credit providers (settlement disabled); needs a pruner.

## Verification
`go build ./inference/...`, `go vet`, `creditbilling` tests, existing `ctrl` tests pass. Reviewed across adversarial passes (signature/replay/concurrency/fail-open) — no HIGH/CRITICAL. Rebased onto latest `main`.

## Companion
- SDK credit mode: 0gfoundation/0g-compute-ts-sdk#224
- `0g-credit-service` (credit ledger + verifier) — new repo, not yet pushed to a remote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)