### PR TITLE
feat(inference): add "standard" providerType — non-verifiable forwarder with hidden upstream

### DIFF
--- a/api/inference/config/config.go
+++ b/api/inference/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"math/big"
 	"os"
 	"regexp"
@@ -1296,6 +1297,11 @@ func loadConfig(cfg *Config) error {
 		// A standard provider forwards to an external upstream and never signs, so it
 		// always behaves as TargetSeparated (no broker signature, no ZG-Res-Key).
 		cfg.Service.TargetSeparated = true
+		// TargetSeparated is forced on, which would otherwise publish a
+		// TargetTeeAddress on-chain (see buildAdditionalInfo). A standard provider has
+		// no upstream TEE, so force it empty rather than leak a stale/misleading TEE
+		// address for a non-verifiable service.
+		cfg.Service.TargetTeeAddress = ""
 		// The upstream must be configured explicitly — a standard provider has no
 		// co-located model and no known default base URL.
 		if cfg.Service.TargetURL == "" {
@@ -1310,6 +1316,19 @@ func loadConfig(cfg *Config) error {
 			return fmt.Errorf("invalid config: service.verifiability must be empty or '%s' when providerType is 'standard', got '%s'", constant.VerifiabilityStandard, cfg.Service.Verifiability)
 		}
 		cfg.Service.Verifiability = constant.VerifiabilityStandard
+
+		// Upstream-hiding is complete for chatbot / speech-to-text / image responses
+		// (leak headers + leak-key body fields are stripped, and image assets are
+		// broker-served). Video is the exception: the broker does not proxy video
+		// bytes, so if the upstream returns the finished asset as a DIRECT URL in the
+		// response body (e.g. {"output":{"video_url":"https://<upstream-host>/..."}}),
+		// that host reaches the client — leak-key stripping does not rewrite URL
+		// values. Upstreams that expose the asset via the OpenAI GET /videos/{id}/content
+		// pattern (which the broker proxies) do not leak. Warn so the operator makes a
+		// conscious choice. (stdlib log: the structured logger isn't up at config load.)
+		if cfg.Service.Type == constant.ServiceTypeVideoGeneration {
+			log.Printf("[CONFIG] providerType 'standard' with type 'video-generation': the upstream is fully hidden only when it returns the asset via GET /videos/{id}/content (broker-proxied). An upstream that returns a direct asset URL in the response body will expose that URL's host to clients — the broker does not proxy video bytes or rewrite URL values.")
+		}
 	}
 
 	// Body-field injection is only applied for the chatbot service type (see

--- a/api/inference/config/config.go
+++ b/api/inference/config/config.go
@@ -372,6 +372,21 @@ func (s *Service) IsCentralized() bool {
 	return s.ProviderType == constant.ProviderTypeCentralized
 }
 
+// IsStandard returns true if this service is a "standard" pure forwarder: no TEE
+// verification, no response signing, and a hidden upstream (no provider identity
+// or upstream domain published). See constant.ProviderTypeStandard.
+func (s *Service) IsStandard() bool {
+	return s.ProviderType == constant.ProviderTypeStandard
+}
+
+// IsForwarder returns true for provider types that proxy to an external upstream
+// rather than co-locating the model with the broker (centralized and standard).
+// These share forwarding behavior: TargetSeparated is forced, per-model pricing is
+// allowed, and no LLM attestation is hosted locally.
+func (s *Service) IsForwarder() bool {
+	return s.IsCentralized() || s.IsStandard()
+}
+
 // IsUSDDenominated returns true if this service's prices are configured in USD
 // and must be converted to wei by the price-feed subsystem.
 func (s *Service) IsUSDDenominated() bool {
@@ -829,6 +844,7 @@ func validatePricingTiers(prefix string, tiers []PricingTier) error {
 //   - lora_adapter_name: the broker derives this from an ft-* model during LoRA
 //     request rewriting (see RewriteLoRARequest); injecting it would clobber the
 //     resolved adapter.
+//
 // Injecting any of these is rejected at config load (fail loud, not silent).
 var protectedInjectBodyFields = map[string]struct{}{
 	"model":             {},
@@ -1249,8 +1265,10 @@ func loadConfig(cfg *Config) error {
 	if cfg.Service.ProviderType == "" {
 		cfg.Service.ProviderType = constant.ProviderTypeDecentralized
 	}
-	if cfg.Service.ProviderType != constant.ProviderTypeDecentralized && cfg.Service.ProviderType != constant.ProviderTypeCentralized {
-		return fmt.Errorf("invalid config: service.providerType must be '%s' or '%s', got '%s'", constant.ProviderTypeDecentralized, constant.ProviderTypeCentralized, cfg.Service.ProviderType)
+	if cfg.Service.ProviderType != constant.ProviderTypeDecentralized &&
+		cfg.Service.ProviderType != constant.ProviderTypeCentralized &&
+		cfg.Service.ProviderType != constant.ProviderTypeStandard {
+		return fmt.Errorf("invalid config: service.providerType must be '%s', '%s', or '%s', got '%s'", constant.ProviderTypeDecentralized, constant.ProviderTypeCentralized, constant.ProviderTypeStandard, cfg.Service.ProviderType)
 	}
 	if cfg.Service.ProviderType == constant.ProviderTypeCentralized {
 		if cfg.Service.ProviderIdentity == "" {
@@ -1267,6 +1285,31 @@ func loadConfig(cfg *Config) error {
 		if cfg.Service.TargetURL != "" && !strings.HasPrefix(strings.ToLower(cfg.Service.TargetURL), "https://") {
 			return fmt.Errorf("invalid config: service.targetUrl must use HTTPS for centralized providers (routing proof requires TLS), got '%s'", cfg.Service.TargetURL)
 		}
+	}
+	if cfg.Service.ProviderType == constant.ProviderTypeStandard {
+		// A standard provider deliberately hides its upstream: it never publishes a
+		// provider identity, so reject one rather than silently ignoring it (which
+		// would mislead an operator into thinking it is advertised).
+		if cfg.Service.ProviderIdentity != "" {
+			return fmt.Errorf("invalid config: service.providerIdentity must not be set when providerType is 'standard' (a standard provider hides its upstream identity)")
+		}
+		// A standard provider forwards to an external upstream and never signs, so it
+		// always behaves as TargetSeparated (no broker signature, no ZG-Res-Key).
+		cfg.Service.TargetSeparated = true
+		// The upstream must be configured explicitly — a standard provider has no
+		// co-located model and no known default base URL.
+		if cfg.Service.TargetURL == "" {
+			return fmt.Errorf("invalid config: service.targetUrl is required when providerType is 'standard'")
+		}
+		// Standard is non-verifiable by construction. Force the "standard" marker so
+		// the on-chain verifiability can never claim a TEE mode (which would make
+		// clients attempt a verification the broker never backs). Reject any
+		// operator-supplied value other than the standard marker rather than
+		// silently overwriting it.
+		if cfg.Service.Verifiability != "" && cfg.Service.Verifiability != constant.VerifiabilityStandard {
+			return fmt.Errorf("invalid config: service.verifiability must be empty or '%s' when providerType is 'standard', got '%s'", constant.VerifiabilityStandard, cfg.Service.Verifiability)
+		}
+		cfg.Service.Verifiability = constant.VerifiabilityStandard
 	}
 
 	// Body-field injection is only applied for the chatbot service type (see

--- a/api/inference/config/config_test.go
+++ b/api/inference/config/config_test.go
@@ -182,6 +182,31 @@ service:
 	}
 }
 
+func TestLoadConfig_ProviderTypeStandard_ForcesEmptyTargetTeeAddress(t *testing.T) {
+	// standard forces TargetSeparated=true, which would otherwise publish a
+	// TargetTeeAddress on-chain. A stale/copied targetTeeAddress must be zeroed so a
+	// non-verifiable, upstream-hidden service never advertises a TEE address.
+	configPath := writeTestConfig(t, `
+service:
+  servingUrl: "http://example.com"
+  targetUrl: "https://backend:8000"
+  inputPrice: "1000"
+  outputPrice: "2000"
+  type: "chatbot"
+  model: "gpt-4"
+  providerType: "standard"
+  targetTeeAddress: "0x1234567890123456789012345678901234567890"
+`)
+	t.Setenv("CONFIG_FILE", configPath)
+	cfg := &Config{}
+	if err := loadConfig(cfg); err != nil {
+		t.Fatalf("loadConfig failed: %v", err)
+	}
+	if cfg.Service.TargetTeeAddress != "" {
+		t.Errorf("expected TargetTeeAddress forced empty for standard, got %q", cfg.Service.TargetTeeAddress)
+	}
+}
+
 func TestLoadConfig_ProviderTypeStandard_RejectsProviderIdentity(t *testing.T) {
 	// A standard provider hides its upstream, so a providerIdentity is rejected
 	// rather than silently ignored.

--- a/api/inference/config/config_test.go
+++ b/api/inference/config/config_test.go
@@ -148,6 +148,120 @@ service:
 	}
 }
 
+func TestLoadConfig_ProviderTypeStandard(t *testing.T) {
+	// A standard provider is a pure forwarder: it must load without a
+	// providerIdentity, force TargetSeparated, and force the "standard"
+	// verifiability marker so it can never claim a TEE mode.
+	configPath := writeTestConfig(t, `
+service:
+  servingUrl: "http://example.com"
+  targetUrl: "https://backend:8000"
+  inputPrice: "1000"
+  outputPrice: "2000"
+  type: "chatbot"
+  model: "gpt-4"
+  providerType: "standard"
+`)
+	t.Setenv("CONFIG_FILE", configPath)
+
+	cfg := &Config{}
+	if err := loadConfig(cfg); err != nil {
+		t.Fatalf("loadConfig failed: %v", err)
+	}
+	if !cfg.Service.IsStandard() || !cfg.Service.IsForwarder() {
+		t.Errorf("expected IsStandard && IsForwarder, got providerType %q", cfg.Service.ProviderType)
+	}
+	if cfg.Service.IsCentralized() {
+		t.Error("standard provider must not report IsCentralized")
+	}
+	if !cfg.Service.TargetSeparated {
+		t.Error("standard provider must force TargetSeparated")
+	}
+	if cfg.Service.Verifiability != "standard" {
+		t.Errorf("expected verifiability 'standard', got %q", cfg.Service.Verifiability)
+	}
+}
+
+func TestLoadConfig_ProviderTypeStandard_RejectsProviderIdentity(t *testing.T) {
+	// A standard provider hides its upstream, so a providerIdentity is rejected
+	// rather than silently ignored.
+	configPath := writeTestConfig(t, `
+service:
+  servingUrl: "http://example.com"
+  targetUrl: "https://backend:8000"
+  inputPrice: "1000"
+  outputPrice: "2000"
+  type: "chatbot"
+  model: "gpt-4"
+  providerType: "standard"
+  providerIdentity: "openai"
+`)
+	t.Setenv("CONFIG_FILE", configPath)
+	if err := loadConfig(&Config{}); err == nil || !strings.Contains(err.Error(), "providerIdentity must not be set") {
+		t.Fatalf("expected providerIdentity rejection, got: %v", err)
+	}
+}
+
+func TestLoadConfig_ProviderTypeStandard_RejectsTeeMLVerifiability(t *testing.T) {
+	// A standard provider is non-verifiable; it must not advertise a TEE mode that
+	// would make clients attempt a verification the broker never backs.
+	configPath := writeTestConfig(t, `
+service:
+  servingUrl: "http://example.com"
+  targetUrl: "https://backend:8000"
+  inputPrice: "1000"
+  outputPrice: "2000"
+  type: "chatbot"
+  model: "gpt-4"
+  providerType: "standard"
+  verifiability: "TeeML"
+`)
+	t.Setenv("CONFIG_FILE", configPath)
+	if err := loadConfig(&Config{}); err == nil || !strings.Contains(err.Error(), "verifiability must be empty or 'standard'") {
+		t.Fatalf("expected verifiability rejection, got: %v", err)
+	}
+}
+
+func TestLoadConfig_ProviderTypeStandard_RequiresTargetURL(t *testing.T) {
+	configPath := writeTestConfig(t, `
+service:
+  servingUrl: "http://example.com"
+  inputPrice: "1000"
+  outputPrice: "2000"
+  type: "chatbot"
+  model: "gpt-4"
+  providerType: "standard"
+`)
+	t.Setenv("CONFIG_FILE", configPath)
+	if err := loadConfig(&Config{}); err == nil || !strings.Contains(err.Error(), "targetUrl is required") {
+		t.Fatalf("expected targetUrl-required rejection, got: %v", err)
+	}
+}
+
+func TestLoadConfig_ProviderTypeStandard_AllowsModelPricing(t *testing.T) {
+	// Multi-model pricing is supported for standard forwarders, same as centralized.
+	configPath := writeTestConfig(t, `
+service:
+  servingUrl: "http://example.com"
+  targetUrl: "https://backend:8000"
+  type: "chatbot"
+  model: "gpt-4o"
+  providerType: "standard"
+  modelPricing:
+    - model: "gpt-4o"
+      inputPrice: "10"
+      outputPrice: "30"
+`)
+	t.Setenv("CONFIG_FILE", configPath)
+	cfg := &Config{}
+	if err := loadConfig(cfg); err != nil {
+		t.Fatalf("standard multi-model should be allowed, got: %v", err)
+	}
+	if !cfg.Service.HasMultiModelPricing() {
+		t.Fatal("expected multi-model pricing to be configured")
+	}
+}
+
 func TestLoadConfig_CanonicalID_Valid(t *testing.T) {
 	configPath := writeTestConfig(t, `
 service:
@@ -1025,7 +1139,7 @@ service:
 	if err == nil {
 		t.Fatal("expected error for invalid providerType")
 	}
-	if !strings.Contains(err.Error(), "must be 'decentralized' or 'centralized'") {
+	if !strings.Contains(err.Error(), "must be 'decentralized', 'centralized', or 'standard'") {
 		t.Errorf("unexpected error message: %v", err)
 	}
 }

--- a/api/inference/config/model_pricing.go
+++ b/api/inference/config/model_pricing.go
@@ -658,8 +658,8 @@ func validateModelPricing(cfg *Config) error {
 		return nil
 	}
 	svc := &cfg.Service
-	if svc.ProviderType != constant.ProviderTypeCentralized {
-		return fmt.Errorf("invalid config: service.modelPricing is only supported when providerType is 'centralized'")
+	if !svc.IsForwarder() {
+		return fmt.Errorf("invalid config: service.modelPricing is only supported when providerType is 'centralized' or 'standard'")
 	}
 	// Per-model billing is wired only for the modalities whose request path
 	// resolves the request model before billing: chatbot + speech-to-text (token

--- a/api/inference/const/const.go
+++ b/api/inference/const/const.go
@@ -17,10 +17,24 @@ const (
 
 // Provider type constants for distinguishing between decentralized GPU providers
 // and centralized API providers (e.g., OpenAI, Anthropic).
+//
+// ProviderTypeStandard is a pure forwarder that performs NO TEE verification and
+// deliberately hides its upstream: it never signs responses (no routing proof, no
+// broker signature), never publishes a provider identity or upstream domain, and
+// advertises verifiability "standard" so clients skip verification instead of
+// attempting it. It is the non-verifiable sibling of the TEE ("TeeML") mode.
 const (
 	ProviderTypeDecentralized = "decentralized"
 	ProviderTypeCentralized   = "centralized"
+	ProviderTypeStandard      = "standard"
 )
+
+// VerifiabilityStandard is the verifiability marker written on-chain for a
+// standard (pure-forwarder, non-verifiable) service. It is intentionally NOT one
+// of the client-recognized verifiability values (OpML/TeeML/ZKML), so the
+// user-broker treats the service as non-verifiable and never requests a
+// signature.
+const VerifiabilityStandard = "standard"
 
 // Known centralized provider identities.
 const (
@@ -30,9 +44,12 @@ const (
 
 // Price denomination modes for provider-configured service prices.
 // NATIVE: inputPrice/outputPrice are configured directly in wei (0G) and written
-//         to chain as-is; existing behavior.
+//
+//	to chain as-is; existing behavior.
+//
 // USD:    inputPriceUSDPerMillionTokens/outputPriceUSDPerMillionTokens are configured in USD and converted to
-//         wei by the PriceUpdateProcessor using a live 0G/USDT rate.
+//
+//	wei by the PriceUpdateProcessor using a live 0G/USDT rate.
 const (
 	PriceDenominationNative = "NATIVE"
 	PriceDenominationUSD    = "USD"

--- a/api/inference/internal/contract/service.go
+++ b/api/inference/internal/contract/service.go
@@ -42,18 +42,29 @@ var DefaultProviderStake = new(big.Int).Mul(big.NewInt(100), new(big.Int).Exp(bi
 
 // buildAdditionalInfo creates the additionalInfo JSON string for a service
 func buildAdditionalInfo(service config.Service, imageName, imageDigest string, tieredPricing config.TieredPricingConfig, cacheTokenBilling config.CacheTokenBillingConfig) (string, error) {
-	// Determine TEE verifier based on NETWORK environment variable
+	// Determine TEE verifier based on NETWORK environment variable. A standard
+	// provider performs no TEE verification, so it publishes no verifier: leaving
+	// TEEVerifier/VerifierURL empty means a client has nothing to call even if it
+	// somehow reached the verification path (it does not — verifiability "standard"
+	// is already skipped client-side).
 	var teeVerifier string
-	switch os.Getenv("NETWORK") {
-	case "phala":
-		teeVerifier = tee.VerifierDStack
-	default:
-		teeVerifier = tee.VerifierCryptoPilot
+	if !service.IsStandard() {
+		switch os.Getenv("NETWORK") {
+		case "phala":
+			teeVerifier = tee.VerifierDStack
+		default:
+			teeVerifier = tee.VerifierCryptoPilot
+		}
+	}
+
+	verifierURL := service.VerifierURL
+	if service.IsStandard() {
+		verifierURL = ""
 	}
 
 	// Create AdditionalInfo JSON string
 	additionalInfo := map[string]interface{}{
-		"VerifierURL":      service.VerifierURL,
+		"VerifierURL":      verifierURL,
 		"TEEVerifier":      teeVerifier,
 		"TargetSeparated":  service.TargetSeparated,
 		"TargetTeeAddress": "",

--- a/api/inference/internal/ctrl/async.go
+++ b/api/inference/internal/ctrl/async.go
@@ -378,7 +378,17 @@ func (c *Ctrl) processAsyncJob(params asyncJobParams) {
 
 	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(resp.Body)
-		c.markAsyncJobFailed(jobID, "provider returned status "+resp.Status+": "+string(respBody))
+		detail := string(respBody)
+		// Forwarder providers hide their upstream, but an upstream error body can
+		// name it (e.g. {"provider":"openai"}). Strip #184 leak fields before this
+		// body becomes the client-visible job ErrorMessage — mirrors the sync path's
+		// handleServiceError sanitization.
+		if c.Service.IsForwarder() {
+			if sanitized, changed := c.sanitizeResponseBody(respBody, ""); changed {
+				detail = string(sanitized)
+			}
+		}
+		c.markAsyncJobFailed(jobID, "provider returned status "+resp.Status+": "+detail)
 		return
 	}
 
@@ -387,6 +397,16 @@ func (c *Ctrl) processAsyncJob(params asyncJobParams) {
 	if err != nil {
 		c.markAsyncJobFailed(jobID, "failed to read provider response: "+err.Error())
 		return
+	}
+	// For forwarder providers, strip #184 upstream identity/cost leak fields before
+	// the body is stored/returned or signed. Done here (before b64 extraction, URL
+	// rewrite, and signing) so every downstream consumer — including the TEE
+	// signature, which must bind the bytes the client actually receives — sees the
+	// sanitized bytes. sanitizeResponseBody preserves data[] (image payloads).
+	if c.Service.IsForwarder() {
+		if sanitized, changed := c.sanitizeResponseBody(providerRespBody, ""); changed {
+			providerRespBody = sanitized
+		}
 	}
 	respBody := providerRespBody
 

--- a/api/inference/internal/ctrl/chatbot_test.go
+++ b/api/inference/internal/ctrl/chatbot_test.go
@@ -367,6 +367,15 @@ func TestZGResKeyCondition(t *testing.T) {
 			targetSeparated: true,
 			wantResKey:      true,
 		},
+		{
+			// A standard provider never signs, so it must never advertise ZG-Res-Key
+			// (it is TargetSeparated + !centralized). This is the gate used by the
+			// chatbot, speech-to-text, text-to-image, image-editing, and video paths.
+			name:            "standard never sets key",
+			providerType:    "standard",
+			targetSeparated: true,
+			wantResKey:      false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/api/inference/internal/ctrl/handle_service_error_test.go
+++ b/api/inference/internal/ctrl/handle_service_error_test.go
@@ -1,0 +1,107 @@
+package ctrl
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/0glabs/0g-serving-broker/inference/config"
+)
+
+// newErrorResp builds a minimal upstream *http.Response carrying an error status
+// and a JSON body that names the upstream via a #184 leak key ("provider").
+func newErrorResp(body string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusBadRequest,
+		Header:     http.Header{},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+func runHandleServiceError(t *testing.T, svc config.Service, body string) string {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	c := newChatbotTestCtrl(t, svc)
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Request = httptest.NewRequest("POST", "/v1/proxy/chat/completions", nil)
+	c.handleServiceError(ctx, newErrorResp(body))
+	return w.Body.String()
+}
+
+func TestHandleServiceError_ForwarderSanitizesUpstreamErrorBody(t *testing.T) {
+	// A standard forwarder must not leak its upstream via an error body. The
+	// "provider" leak key is stripped before the body is re-emitted to the client.
+	body := `{"error":{"message":"bad request"},"provider":"openai"}`
+	out := runHandleServiceError(t, config.Service{
+		ProviderType:    "standard",
+		TargetSeparated: true,
+		TargetURL:       "https://secret-upstream:8000",
+	}, body)
+	if strings.Contains(out, "openai") || strings.Contains(out, "\"provider\"") {
+		t.Errorf("upstream identity leaked in forwarder error body: %s", out)
+	}
+	if !strings.Contains(out, "bad request") {
+		t.Errorf("error message should be preserved, got: %s", out)
+	}
+}
+
+func TestSanitizeSTTStreamLine(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c := newChatbotTestCtrl(t, config.Service{ProviderType: "standard", TargetSeparated: true})
+	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ctx.Request = httptest.NewRequest("POST", "/v1/proxy/audio/transcriptions", nil)
+
+	t.Run("bare ND-JSON line strips leak key, preserves usage", func(t *testing.T) {
+		out := c.sanitizeSTTStreamLine(ctx, []byte(`{"type":"transcript.text.done","provider":"openai","usage":{"type":"duration","seconds":3}}`))
+		if out == nil {
+			t.Fatal("expected line forwarded, got dropped")
+		}
+		if bytes.Contains(out, []byte("openai")) || bytes.Contains(out, []byte("\"provider\"")) {
+			t.Errorf("provider leaked in STT stream line: %s", out)
+		}
+		if !bytes.Contains(out, []byte("transcript.text.done")) || !bytes.Contains(out, []byte("duration")) {
+			t.Errorf("type/usage must survive: %s", out)
+		}
+	})
+
+	t.Run("SSE data: line strips leak key", func(t *testing.T) {
+		out := c.sanitizeSTTStreamLine(ctx, []byte("data: {\"provider\":\"openai\",\"delta\":\"hi\"}\n"))
+		if out == nil || bytes.Contains(out, []byte("openai")) {
+			t.Errorf("SSE data line not sanitized: %s", out)
+		}
+		if !bytes.Contains(out, []byte("hi")) {
+			t.Errorf("delta content must survive: %s", out)
+		}
+	})
+
+	t.Run("upstream comment banner is dropped", func(t *testing.T) {
+		if out := c.sanitizeSTTStreamLine(ctx, []byte(": OPENROUTER PROCESSING\n")); out != nil {
+			t.Errorf("comment banner should be dropped, got: %s", out)
+		}
+	})
+
+	t.Run("plain non-JSON line passes through", func(t *testing.T) {
+		out := c.sanitizeSTTStreamLine(ctx, []byte("plain text\n"))
+		if out == nil || !bytes.Contains(out, []byte("plain text")) {
+			t.Errorf("plain line should pass through, got: %q", out)
+		}
+	})
+}
+
+func TestHandleServiceError_DecentralizedForwardsErrorBodyUnchanged(t *testing.T) {
+	// For a decentralized provider the "upstream" is the provider's own service, so
+	// the error body is forwarded verbatim (no forwarder sanitization applied).
+	body := `{"error":{"message":"bad request"},"provider":"self"}`
+	out := runHandleServiceError(t, config.Service{
+		ProviderType: "decentralized",
+	}, body)
+	if !strings.Contains(out, "\"provider\":\"self\"") {
+		t.Errorf("decentralized error body should be forwarded unchanged, got: %s", out)
+	}
+}

--- a/api/inference/internal/ctrl/image_editing.go
+++ b/api/inference/internal/ctrl/image_editing.go
@@ -141,13 +141,29 @@ func findSubstring(s, substr string) int {
 func (c *Ctrl) handleImageEditingResponse(ctx *gin.Context, resp *http.Response, account model.User, outputPrice string, reqBody []byte, reqModel model.Request) error {
 	defer resp.Body.Close()
 
+	// chatKey always backs the image store / broker-served URLs; ZG-Res-Key (the
+	// signature-lookup handle) is only advertised when the response is signed. A
+	// standard/TargetSeparated provider produces no signature, so advertising it
+	// would point clients at a signature endpoint that only 404s.
 	chatKey := uuid.NewString()
-	ctx.Writer.Header().Set("ZG-Res-Key", chatKey)
+	if !c.Service.TargetSeparated || c.Service.IsCentralized() {
+		ctx.Writer.Header().Set("ZG-Res-Key", chatKey)
+	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		c.handleBrokerError(ctx, err, "read image editing response body")
 		return err
+	}
+
+	// For forwarder providers, strip #184 upstream identity/cost leak fields before
+	// the envelope is used for extraction, URL rewrite, signing, or forwarding
+	// (sanitize-before-sign keeps the signature bound to what the client receives).
+	// sanitizeResponseBody preserves data[] (image payloads).
+	if c.Service.IsForwarder() {
+		if sanitized, changed := c.sanitizeResponseBody(body, ""); changed {
+			body = sanitized
+		}
 	}
 
 	responseSizeMB := float64(len(body)) / (1024 * 1024)

--- a/api/inference/internal/ctrl/proxy.go
+++ b/api/inference/internal/ctrl/proxy.go
@@ -408,12 +408,25 @@ func isUpstreamLeakHeader(key string) bool {
 	switch k {
 	case "provider", "server", "via", "x-powered-by":
 		return true
+	case "location":
+		// An upstream redirect Location would name the upstream host. Go's http
+		// client auto-follows redirects so this rarely reaches the response today,
+		// but strip it defensively so a future CheckRedirect change can't leak it.
+		return true
 	}
 	return strings.HasPrefix(k, "x-openrouter") ||
 		strings.HasPrefix(k, "openrouter") ||
 		strings.HasPrefix(k, "x-or-") ||
 		strings.HasPrefix(k, "x-ratelimit") ||
-		strings.HasPrefix(k, "x-clerk")
+		strings.HasPrefix(k, "x-clerk") ||
+		// Upstream-vendor identity headers real providers emit and name themselves
+		// with: OpenAI (openai-organization/openai-version/openai-processing-ms),
+		// Anthropic (anthropic-ratelimit-*/anthropic-organization-id), and the
+		// Cloudflare front all three sit behind (cf-ray/cf-cache-status). Forwarding
+		// any of these would reveal the upstream a "standard" provider must hide.
+		strings.HasPrefix(k, "openai-") ||
+		strings.HasPrefix(k, "anthropic-") ||
+		strings.HasPrefix(k, "cf-")
 }
 
 func (c *Ctrl) handleResponse(ctx *gin.Context, resp *http.Response) error {
@@ -562,16 +575,32 @@ func (c *Ctrl) handleServiceError(ctx *gin.Context, resp *http.Response) {
 		c.logger.Errorf("Service returned error response: %s, Incoming request: method=%s, URI=%s, path=%s, RemoteAddr=%s,", decodedBody, ctx.Request.Method, ctx.Request.RequestURI, ctx.Request.URL.Path, ctx.Request.RemoteAddr)
 	}
 
+	// Forwarder providers (centralized/standard) hide their upstream, but an
+	// upstream ERROR body can still name it (e.g. {"error":{...,"provider":"openai"}}
+	// or an upstream model id). The success path sanitizes (#184, see handleResponse);
+	// the error path did not. Strip leak fields from the decoded error body before
+	// re-emitting for forwarders. Emit the decoded body (dropping the now-stale
+	// Content-Encoding) when sanitization changed it; otherwise forward the original
+	// bytes unchanged (leak headers are already stripped upstream in ProcessHTTPRequest).
+	outBody := respBody
+	if c.Service.IsForwarder() {
+		if sanitized, changed := c.sanitizeResponseBody([]byte(decodedBody), ""); changed {
+			outBody = sanitized
+			ctx.Writer.Header().Del("Content-Encoding")
+		}
+	}
+
 	ctx.Writer.WriteHeader(statusCode)
 
-	if _, err := ctx.Writer.Write(respBody); err != nil {
+	if _, err := ctx.Writer.Write(outBody); err != nil {
 		c.logger.Errorf("Failed to write service error response: %v", err)
 	}
 }
 
 // decodeErrorBody returns a human-readable form of an upstream error body, decompressing
-// it according to the upstream Content-Encoding. On any failure, it returns the raw string —
-// callers use this only for logging and substring matching, never for re-emission.
+// it according to the upstream Content-Encoding. On any failure, it returns the raw string.
+// Used for logging and substring matching, and — for forwarder providers — as the input to
+// leak-field sanitization whose decoded output is then re-emitted (Content-Encoding dropped).
 func decodeErrorBody(body []byte, contentEncoding string) string {
 	switch strings.ToLower(strings.TrimSpace(contentEncoding)) {
 	case "", "identity":

--- a/api/inference/internal/ctrl/sanitize_test.go
+++ b/api/inference/internal/ctrl/sanitize_test.go
@@ -315,6 +315,15 @@ func TestIsUpstreamLeakHeader(t *testing.T) {
 		{"X-Powered-By", true},
 		{"X-Ratelimit-Remaining", true},
 		{"X-Clerk-Auth", true},
+		// Upstream-vendor identity headers (OpenAI / Anthropic / Cloudflare front).
+		{"Openai-Organization", true},
+		{"Openai-Version", true},
+		{"Openai-Processing-Ms", true},
+		{"Anthropic-Ratelimit-Requests-Remaining", true},
+		{"Anthropic-Organization-Id", true},
+		{"Cf-Ray", true},
+		{"Cf-Cache-Status", true},
+		{"Location", true},
 		{"Content-Type", false},
 		{"Content-Encoding", false},
 		{"ZG-Res-Key", false},
@@ -329,6 +338,47 @@ func TestIsUpstreamLeakHeader(t *testing.T) {
 
 // router #373: the synthesized openrouter.reasoning redacted_thinking block must
 // not reach the client on the Anthropic surface.
+// TestSanitizeResponseBody_ImageEnvelopePreservesData pins the property the
+// forwarder image/video/async paths rely on: leak keys (provider/cost) are
+// stripped from an image envelope while the data[] payload (b64/url images) is
+// left intact, so sanitizing before extraction/URL-rewrite/signing is safe.
+func TestSanitizeResponseBody_ImageEnvelopePreservesData(t *testing.T) {
+	c := &Ctrl{logger: testLogger()}
+
+	in := []byte(`{"created":1700000000,"provider":"openai","cost":0.04,` +
+		`"data":[{"b64_json":"aGVsbG8="},{"b64_json":"d29ybGQ="}]}`)
+	out, changed := c.sanitizeResponseBody(in, "")
+	if !changed {
+		t.Fatal("expected changed=true (provider/cost present)")
+	}
+	obj := decode(t, out)
+	if _, ok := obj["provider"]; ok {
+		t.Error("provider leak key not stripped from image envelope")
+	}
+	if _, ok := obj["cost"]; ok {
+		t.Error("cost leak key not stripped from image envelope")
+	}
+	data, ok := obj["data"].([]interface{})
+	if !ok || len(data) != 2 {
+		t.Fatalf("data[] must be preserved intact, got %v", obj["data"])
+	}
+	if d0 := data[0].(map[string]interface{}); d0["b64_json"] != "aGVsbG8=" {
+		t.Errorf("image payload corrupted, got %v", d0["b64_json"])
+	}
+}
+
+// TestSanitizeResponseBody_CleanImageEnvelopeUnchanged verifies a clean upstream
+// image envelope (no leak keys) is a no-op, so forwarder sanitization never
+// rewrites or corrupts a well-behaved response.
+func TestSanitizeResponseBody_CleanImageEnvelopeUnchanged(t *testing.T) {
+	c := &Ctrl{logger: testLogger()}
+	in := []byte(`{"created":1700000000,"data":[{"b64_json":"aGVsbG8="}]}`)
+	out, changed := c.sanitizeResponseBody(in, "")
+	if changed {
+		t.Errorf("clean envelope should be unchanged, got %s", out)
+	}
+}
+
 func TestSanitizeResponseBody_StripsUpstreamReasoningLeak(t *testing.T) {
 	c := &Ctrl{logger: testLogger()}
 

--- a/api/inference/internal/ctrl/speech_to_text.go
+++ b/api/inference/internal/ctrl/speech_to_text.go
@@ -266,6 +266,19 @@ func (c *Ctrl) handleNonStreamingSpeechToText(ctx *gin.Context, resp *http.Respo
 		return err
 	}
 
+	// For forwarder providers, strip #184 upstream identity/cost leak fields from a
+	// JSON transcription body before forwarding (and, for in-network signing,
+	// before signing — sanitize-before-sign keeps the signature bound to what the
+	// client receives). STT also returns non-JSON formats (text/srt/vtt) that carry
+	// no such fields; skip them (and sanitizeResponseBody's fail-open warning) by
+	// only sanitizing a JSON object body. Usage fields are not leak keys, so
+	// downstream billing extraction is unaffected.
+	if c.Service.IsForwarder() && bytes.HasPrefix(bytes.TrimSpace(body), []byte("{")) {
+		if sanitized, changed := c.sanitizeResponseBody(body, ""); changed {
+			body = sanitized
+		}
+	}
+
 	// Attempt to write raw response to client. If client disconnected, continue to billing.
 	if _, writeErr := ctx.Writer.Write(body); writeErr != nil {
 		if c.isClientDisconnectError(writeErr) {
@@ -355,6 +368,25 @@ func (c *Ctrl) handleNonStreamingSpeechToText(ctx *gin.Context, resp *http.Respo
 	return c.updateSpeechToTextFallback(ctx, reqModel, string(decompressedBody))
 }
 
+// sanitizeSTTStreamLine strips #184 upstream identity/cost leak fields from a
+// single speech-to-text stream line for forwarder providers. It returns the bytes
+// to forward, or nil to drop the line entirely (an upstream comment/keepalive
+// banner such as OpenRouter's ": OPENROUTER PROCESSING"). It handles both SSE
+// "data: {json}" chunks (via sanitizeStreamLine) and bare ND-JSON object lines
+// (via sanitizeResponseBody); non-JSON lines pass through unchanged.
+func (c *Ctrl) sanitizeSTTStreamLine(ctx *gin.Context, line []byte) []byte {
+	s, forward := c.sanitizeStreamLine(ctx, string(line), "")
+	if !forward {
+		return nil
+	}
+	if trimmed := bytes.TrimSpace([]byte(s)); bytes.HasPrefix(trimmed, []byte("{")) {
+		if sanitized, changed := c.sanitizeResponseBody(trimmed, ""); changed {
+			return append(sanitized, '\n')
+		}
+	}
+	return []byte(s)
+}
+
 // handleStreamingSpeechToText handles streaming speech-to-text response
 func (c *Ctrl) handleStreamingSpeechToText(ctx *gin.Context, resp *http.Response, reqBody []byte, reqModel model.Request) error {
 	defer resp.Body.Close()
@@ -399,20 +431,30 @@ func (c *Ctrl) handleStreamingSpeechToText(ctx *gin.Context, resp *http.Response
 				}
 			}
 
-			// Only write to client if still connected
+			// Only write to client if still connected. For forwarder providers,
+			// strip #184 upstream leak fields from the client-facing bytes first
+			// (billing still uses the original `line` / captured rawBody). A nil
+			// result means the line was an upstream comment/keepalive banner and is
+			// dropped.
 			if !clientDisconnected {
-				_, streamErr = w.Write(line)
-				if streamErr != nil {
-					if c.isClientDisconnectError(streamErr) {
-						ctx.Set("ignoreError", true)
-						clientDisconnected = true
-						c.logger.Warnf("Client disconnected during speech-to-text stream, continuing to read for billing")
+				writeLine := line
+				if c.Service.IsForwarder() {
+					writeLine = c.sanitizeSTTStreamLine(ctx, line)
+				}
+				if writeLine != nil {
+					_, streamErr = w.Write(writeLine)
+					if streamErr != nil {
+						if c.isClientDisconnectError(streamErr) {
+							ctx.Set("ignoreError", true)
+							clientDisconnected = true
+							c.logger.Warnf("Client disconnected during speech-to-text stream, continuing to read for billing")
+						} else {
+							c.handleBrokerError(ctx, streamErr, "write to stream")
+							return false
+						}
 					} else {
-						c.handleBrokerError(ctx, streamErr, "write to stream")
-						return false
+						ctx.Writer.Flush()
 					}
-				} else {
-					ctx.Writer.Flush()
 				}
 			}
 

--- a/api/inference/internal/ctrl/text_to_image.go
+++ b/api/inference/internal/ctrl/text_to_image.go
@@ -101,13 +101,31 @@ func (c *Ctrl) GetTextToImageInputFeeAndImageNum(reqBody []byte) (string, int64,
 func (c *Ctrl) handleTextToImageResponse(ctx *gin.Context, resp *http.Response, account model.User, outputPrice string, reqBody []byte, reqModel model.Request) error {
 	defer resp.Body.Close()
 
+	// chatKey is always generated: it keys the image store and the broker-served
+	// image URLs (buildURLResponse) regardless of signing. But ZG-Res-Key — the
+	// signature-lookup handle — is only advertised when the response is actually
+	// signed (broker-in-network or centralized routing proof). A standard/
+	// TargetSeparated provider produces no signature, so emitting ZG-Res-Key would
+	// point clients at a signature endpoint that only 404s.
 	chatKey := uuid.NewString()
-	ctx.Writer.Header().Set("ZG-Res-Key", chatKey)
+	if !c.Service.TargetSeparated || c.Service.IsCentralized() {
+		ctx.Writer.Header().Set("ZG-Res-Key", chatKey)
+	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		c.handleBrokerError(ctx, err, "read image response body")
 		return err
+	}
+
+	// For forwarder providers, strip #184 upstream identity/cost leak fields before
+	// the envelope is used for extraction, URL rewrite, signing, or forwarding —
+	// sanitizing first keeps the (later) signature bound to the bytes the client
+	// receives. sanitizeResponseBody preserves data[] (image payloads).
+	if c.Service.IsForwarder() {
+		if sanitized, changed := c.sanitizeResponseBody(body, ""); changed {
+			body = sanitized
+		}
 	}
 
 	// Resolve the original client request body (pre-b64 rewrite) for signing.

--- a/api/inference/internal/ctrl/video.go
+++ b/api/inference/internal/ctrl/video.go
@@ -239,13 +239,28 @@ func (c *Ctrl) videoOutputUnits(ctx context.Context, seconds int64, size string)
 func (c *Ctrl) handleVideoGenerationResponse(ctx *gin.Context, resp *http.Response, account model.User, outputPrice string, reqBody []byte, reqModel model.Request) error {
 	defer resp.Body.Close()
 
+	// ZG-Res-Key (the signature-lookup handle) is only advertised when the
+	// response is actually signed (broker-in-network). A standard/TargetSeparated
+	// provider produces no signature, so advertising it would point clients at a
+	// signature endpoint that only 404s.
 	chatKey := uuid.NewString()
-	ctx.Writer.Header().Set("ZG-Res-Key", chatKey)
+	if !c.Service.TargetSeparated || c.Service.IsCentralized() {
+		ctx.Writer.Header().Set("ZG-Res-Key", chatKey)
+	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		c.handleBrokerError(ctx, err, "read video generation response body")
 		return err
+	}
+
+	// For forwarder providers, strip #184 upstream identity/cost leak fields before
+	// the body is forwarded, signed, or billed (sanitize-before-sign keeps any
+	// signature bound to what the client receives). Non-JSON bodies fail open.
+	if c.Service.IsForwarder() {
+		if sanitized, changed := c.sanitizeResponseBody(body, ""); changed {
+			body = sanitized
+		}
 	}
 
 	if _, err := ctx.Writer.Write(body); err != nil {

--- a/api/inference/internal/handler/models.go
+++ b/api/inference/internal/handler/models.go
@@ -159,6 +159,18 @@ func (h *Handler) GetModels(ctx *gin.Context) {
 		if cfg.IsCentralized() {
 			servingDomain = parseServingDomain(cfg.TargetURL)
 		}
+		// Provider class/identity are surfaced only for centralized providers (same
+		// gate as the single-model path). A standard provider hides its upstream, so
+		// it must not publish providerType/providerIdentity here either.
+		var providerType, providerIdentity string
+		if cfg.IsCentralized() {
+			providerType = cfg.ProviderType
+			providerIdentity = cfg.ProviderIdentity
+		}
+		// A standard provider performs no response attestation; its settlement TEE
+		// signer being acknowledged must not surface as tee_attested (that marker
+		// reflects response verifiability, which standard deliberately omits).
+		teeAttested := svc.TeeSignerAcknowledged && !cfg.IsStandard()
 		var created int64
 		if svc.CreatedAt != nil {
 			created = svc.CreatedAt.Unix()
@@ -230,11 +242,11 @@ func (h *Handler) GetModels(ctx *gin.Context) {
 				OwnedBy:          cfg.OwnedBy,
 				Type:             svc.Type,
 				Verifiability:    svc.Verifiability,
-				TeeAttested:      svc.TeeSignerAcknowledged,
+				TeeAttested:      teeAttested,
 				TeeVerifier:      teeVerifier,
 				Pricing:          &ModelPricing{CacheTokenBilling: modelCacheBilling},
-				ProviderType:     cfg.ProviderType,
-				ProviderIdentity: cfg.ProviderIdentity,
+				ProviderType:     providerType,
+				ProviderIdentity: providerIdentity,
 				ProviderName:     cfg.ProviderName,
 				ProviderCountry:  cfg.ProviderCountry,
 				ServingDomain:    servingDomain,
@@ -357,8 +369,10 @@ func (h *Handler) GetModels(ctx *gin.Context) {
 		OwnedBy:       cfg.OwnedBy,
 		Type:          svc.Type,
 		Verifiability: svc.Verifiability,
-		TeeAttested:   svc.TeeSignerAcknowledged,
-		Pricing:       &ModelPricing{},
+		// A standard provider does no response attestation; don't surface its
+		// settlement-signer acknowledgement as tee_attested (mirrors multi-model).
+		TeeAttested: svc.TeeSignerAcknowledged && !cfg.IsStandard(),
+		Pricing:     &ModelPricing{},
 	}
 
 	if svc.CreatedAt != nil {

--- a/api/inference/internal/handler/models_test.go
+++ b/api/inference/internal/handler/models_test.go
@@ -558,6 +558,109 @@ func TestGetModels_ProviderNameCountryDecentralized(t *testing.T) {
 	}
 }
 
+func TestGetModels_StandardHidesUpstreamAndTeeMarker(t *testing.T) {
+	// A standard provider hides its upstream and is non-verifiable: even with an
+	// acknowledged settlement TEE signer it must report tee_attested=false and
+	// expose no provider_type / provider_identity / serving_domain.
+	mock := &mockModelsCtrl{
+		service: model.Service{
+			ModelType:             "gpt-4o",
+			Type:                  "chatbot",
+			InputPrice:            "100",
+			OutputPrice:           "200",
+			Verifiability:         "standard",
+			TeeSignerAcknowledged: true, // acknowledged for settlement, but not response-attested
+			AdditionalInfo:        `{"TargetSeparated":true}`,
+		},
+		serviceConfig: config.Service{
+			ProviderType: "standard",
+			// Upstream URL must never leak as serving_domain.
+			TargetURL: "https://secret-upstream:8000",
+		},
+	}
+
+	h := newModelsTestHandler(mock)
+	w := performRequest(h.GetModels, "GET", "/v1/models", "", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	var resp ModelListResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	m := resp.Data[0]
+	if m.Verifiability != "standard" {
+		t.Errorf("expected verifiability=standard, got %q", m.Verifiability)
+	}
+	if m.TeeAttested {
+		t.Error("expected tee_attested=false for standard even with acknowledged signer")
+	}
+	if m.ProviderType != "" {
+		t.Errorf("expected empty provider_type for standard, got %q", m.ProviderType)
+	}
+	if m.ProviderIdentity != "" {
+		t.Errorf("expected empty provider_identity for standard, got %q", m.ProviderIdentity)
+	}
+	if m.ServingDomain != "" {
+		t.Errorf("expected empty serving_domain for standard, got %q", m.ServingDomain)
+	}
+}
+
+func TestGetModels_MultiModelStandardHidesProviderFields(t *testing.T) {
+	// The multi-model path builds ModelObject inline; verify standard hides
+	// provider_type/identity/serving_domain and reports tee_attested=false there
+	// too (parity with the single-model path).
+	svcCfg := config.Service{
+		ProviderType: "standard",
+		TargetURL:    "https://secret-upstream:8000",
+		ModelType:    "gpt-4o",
+		Type:         "chatbot",
+		ModelPricing: []config.ModelPricingEntry{
+			{Model: "gpt-4o", InputPrice: "10", OutputPrice: "30"},
+			{Model: "gpt-4o-mini", InputPrice: "1", OutputPrice: "3"},
+		},
+	}
+	if err := svcCfg.BuildModelPricingMap(); err != nil {
+		t.Fatalf("BuildModelPricingMap: %v", err)
+	}
+	mock := &mockModelsCtrl{
+		service: model.Service{
+			ModelType:             "gpt-4o",
+			Type:                  "chatbot",
+			Verifiability:         "standard",
+			TeeSignerAcknowledged: true,
+		},
+		serviceConfig: svcCfg,
+	}
+	h := newModelsTestHandler(mock)
+	w := performRequest(h.GetModels, "GET", "/v1/models", "", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp ModelListResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if len(resp.Data) != 2 {
+		t.Fatalf("expected 2 models, got %d", len(resp.Data))
+	}
+	for _, m := range resp.Data {
+		if m.ProviderType != "" {
+			t.Errorf("model %s: expected empty provider_type, got %q", m.ID, m.ProviderType)
+		}
+		if m.ProviderIdentity != "" {
+			t.Errorf("model %s: expected empty provider_identity, got %q", m.ID, m.ProviderIdentity)
+		}
+		if m.ServingDomain != "" {
+			t.Errorf("model %s: expected empty serving_domain, got %q", m.ID, m.ServingDomain)
+		}
+		if m.TeeAttested {
+			t.Errorf("model %s: expected tee_attested=false for standard", m.ID)
+		}
+	}
+}
+
 func TestGetModels_DecentralizedOmitsProviderFields(t *testing.T) {
 	mock := &mockModelsCtrl{
 		service: model.Service{

--- a/api/inference/internal/proxy/proxy.go
+++ b/api/inference/internal/proxy/proxy.go
@@ -436,20 +436,20 @@ func (p *Proxy) proxyHTTPRequest(ctx *gin.Context) {
 		}
 
 		if isFree {
-			// Centralized providers don't host an LLM TEE, so attestation
-			// report requests would be proxied to e.g. OpenAI which has no
-			// such endpoint.  Intercept early and return a clear error.
+			// Forwarder providers (centralized/standard) don't host an LLM TEE, so
+			// attestation report requests would be proxied to e.g. OpenAI which has no
+			// such endpoint.  Intercept early and return a clear error so the request
+			// never reaches — and never reveals — the upstream.
 			// Old SDK versions set TargetSeparated=true → call
 			// /attestation/report?model=… and cannot parse the body, but
 			// the 501 status is still more informative than a 404 from OpenAI.
-			if p.ctrl.Service.IsCentralized() && strings.HasPrefix(strings.ToLower(targetPath), "/attestation") {
-				p.logger.Warnf("Blocked LLM attestation request on centralized provider: path=%s, remote=%s",
-					targetPath, ctx.Request.RemoteAddr)
+			if p.ctrl.Service.IsForwarder() && strings.HasPrefix(strings.ToLower(targetPath), "/attestation") {
+				p.logger.Warnf("Blocked LLM attestation request on forwarder provider: path=%s, providerType=%s, remote=%s",
+					targetPath, p.ctrl.Service.ProviderType, ctx.Request.RemoteAddr)
 				ctx.Set("ignoreError", true)
 				ctx.JSON(http.StatusNotImplemented, gin.H{
-					"error": "LLM attestation report is not available for centralized providers. " +
-						"This service routes to a centralized API (e.g., OpenAI). " +
-						"Please upgrade your SDK to a version that supports centralized provider verification.",
+					"error": "LLM attestation report is not available for this provider. " +
+						"This service forwards to an upstream API without local TEE attestation.",
 				})
 				return
 			}
@@ -914,7 +914,11 @@ func (p *Proxy) handleSignatureRoute(ctx *gin.Context, targetRoute string) bool 
 	relativePath := strings.ToLower(ctx.Param("any"))
 	chatID := strings.TrimPrefix(relativePath, "/signature/")
 
-	if !p.ctrl.Service.TargetSeparated || p.ctrl.Service.IsCentralized() {
+	// Standard providers never sign responses, so no signature is ever cached.
+	// Serve the lookup from the broker cache (which always misses → a 404
+	// chat_id_not_found) rather than forwarding /signature/ to the upstream, which
+	// would both leak the upstream and hit an endpoint it does not implement.
+	if !p.ctrl.Service.TargetSeparated || p.ctrl.Service.IsCentralized() || p.ctrl.Service.IsStandard() {
 		sig, err := p.ctrl.GetChatSignature(chatID)
 		if err != nil {
 			if errors.Is(err, ctrl.ErrChatIDNotFound) {

--- a/api/inference/internal/proxy/proxy_test.go
+++ b/api/inference/internal/proxy/proxy_test.go
@@ -209,15 +209,48 @@ func TestProxyHTTPRequest_CentralizedBlocksAttestation(t *testing.T) {
 				t.Fatalf("failed to parse response body: %v", err)
 			}
 			errMsg, _ := body["error"].(string)
-			if !strings.Contains(errMsg, "centralized") {
-				t.Errorf("expected error mentioning 'centralized', got: %s", errMsg)
+			if !strings.Contains(errMsg, "attestation report is not available") {
+				t.Errorf("expected error mentioning attestation unavailability, got: %s", errMsg)
 			}
 		})
 	}
 }
 
+func TestProxyHTTPRequest_StandardBlocksAttestation(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	// A standard forwarder hides its upstream and hosts no local TEE, so an
+	// attestation request must be blocked at the broker (501) rather than proxied
+	// to — and thereby revealing — the upstream.
+	c := &ctrl.Ctrl{
+		Service: config.Service{
+			ProviderType: "standard",
+		},
+	}
+	p := &Proxy{
+		ctrl:          c,
+		logger:        noopLogger{},
+		serviceTarget: "https://backend:8000",
+		serviceType:   "chatbot",
+	}
+
+	w := httptest.NewRecorder()
+	ctx, engine := gin.CreateTestContext(w)
+	ctx.Request = httptest.NewRequest("GET", constant.ServicePrefix+"/attestation/report", nil)
+	engine.GET(constant.ServicePrefix+"/*any", func(c *gin.Context) {
+		p.proxyHTTPRequest(c)
+	})
+	engine.ServeHTTP(w, ctx.Request)
+
+	if w.Code != http.StatusNotImplemented {
+		t.Errorf("expected status %d, got %d; body: %s", http.StatusNotImplemented, w.Code, w.Body.String())
+	}
+}
+
 func TestCentralizedAttestationGuard_Logic(t *testing.T) {
-	// Verify the guard condition: only centralized + attestation path triggers blocking.
+	// Verify the guard condition: any forwarder (centralized/standard) +
+	// attestation path triggers blocking; decentralized and non-attestation paths
+	// do not.
 	tests := []struct {
 		name         string
 		providerType string
@@ -226,8 +259,11 @@ func TestCentralizedAttestationGuard_Logic(t *testing.T) {
 	}{
 		{"centralized + attestation", "centralized", "/attestation/report", true},
 		{"centralized + attestation with query", "centralized", "/attestation/report?model=gpt-4o", true},
+		{"standard + attestation", "standard", "/attestation/report", true},
+		{"standard + attestation with query", "standard", "/attestation/report?model=gpt-4o", true},
 		{"decentralized + attestation", "decentralized", "/attestation/report", false},
 		{"centralized + signature", "centralized", "/signature/abc123", false},
+		{"standard + signature", "standard", "/signature/abc123", false},
 		{"decentralized + signature", "decentralized", "/signature/abc123", false},
 	}
 
@@ -241,7 +277,7 @@ func TestCentralizedAttestationGuard_Logic(t *testing.T) {
 				targetPath = targetPath[:idx]
 			}
 
-			blocked := svc.IsCentralized() && strings.HasPrefix(strings.ToLower(targetPath), "/attestation")
+			blocked := svc.IsForwarder() && strings.HasPrefix(strings.ToLower(targetPath), "/attestation")
 			if blocked != tt.shouldBlock {
 				t.Errorf("expected shouldBlock=%v, got %v", tt.shouldBlock, blocked)
 			}


### PR DESCRIPTION
## What

Adds a third `providerType` value **`standard`** (alongside `decentralized` and `centralized`): a **pure forwarder** that performs **no TEE verification** and deliberately **hides its upstream**. It is the non-verifiable sibling of the TEE (`TeeML`) mode.

## Why

An operator wants to onboard a provider that (1) never exposes the upstream, (2) never shows a TEE/`teetls` marker, (3) doesn't break existing clients, and (4) rejects client TEE signature-verification requests.

## How

**config (`config.go`, `model_pricing.go`, `const.go`)**
- New `constant.ProviderTypeStandard` / `VerifiabilityStandard`.
- `standard` forces `TargetSeparated=true`, forces `verifiability="standard"` (not a client-recognized `OpML/TeeML/ZKML` value → user-broker skips verification), **rejects `providerIdentity`** (hides upstream identity), and **requires `targetUrl`**.
- New helpers `IsStandard()` / `IsForwarder()` (`centralized || standard`); multi-model pricing is allowed for any forwarder.

**no signing (controllers)**
- `standard` is `TargetSeparated=true` + `!IsCentralized()`, so every signing branch falls through — no routing proof, no content signature, and no `ZG-Res-Key` on chatbot/STT.

**additionalInfo (`contract/service.go`)**
- `standard` publishes no `TEEVerifier`/`VerifierURL` and no `ProviderType`/`ProviderIdentity`; `/v1/models` exposes no upstream domain (`IsCentralized()`-gated).

**proxy (`proxy.go`)**
- `/signature/` for a forwarder is served from the (always-missing) broker cache → **404**, never forwarded upstream.
- `/attestation` for a forwarder returns **501**, never forwarded upstream.

## Client (`0g-serving-user-broker`) impact: none

- `verifiability="standard"` is not in `VerifiabilityEnum`, so `processResponse()` logs "not verifiable" and returns `false` **without** fetching a signature — fee calculation runs first, so billing/auto-funding is unaffected.
- The **funding → acknowledge → request** flow is unchanged: `acknowledgeProviderSigner` does no attestation verification; it only creates the account (`transferFund`) and calls on-chain `acknowledgeTEESigner`.
- **Settlement is unaffected**: it is signed by the broker's own TEE signer (registered for every provider type), independent of the upstream.

## Operational note

A `standard` provider's broker TEE signer still must be **owner-acknowledged** on-chain (same as any provider), otherwise `listService` filters it out and user acknowledge fails. The broker still runs in TEE for settlement signing — `standard` only removes upstream response verification and upstream exposure.

## Tests

- `config`: valid standard load; rejects `providerIdentity`; rejects `TeeML` verifiability; requires `targetUrl`; allows multi-model pricing.
- `proxy`: standard blocks `/attestation` (501); forwarder guard logic covers standard.
- `go build ./...`, `go vet`, and `go test ./inference/...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)